### PR TITLE
Fix Together API + dynamic /v1/models catalog (unlocks gpt-oss + 200 OSS models)

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -221,9 +221,12 @@ function resolveModel(modelString: string, apiKey?: string, retryRules?: RetryRu
   // Perplexity, Together, Fireworks) all speak the same `/v1/chat/completions`
   // shape, so one branch covers them — only the baseURL + apiKey differ.
   if (OPENAI_COMPAT_BASE_URLS[provider]) {
+    // AI SDK v6: `createOpenAI(...)(model)` defaults to the OpenAI Responses
+    // API (/v1/responses), which these third-party providers don't implement.
+    // Use `.chat(model)` to pin chat/completions.
     return apiKey
-      ? createOpenAI({ baseURL: OPENAI_COMPAT_BASE_URLS[provider], apiKey, fetch: retryFetch })(model)
-      : createOpenAI({ baseURL: OPENAI_COMPAT_BASE_URLS[provider], fetch: retryFetch })(model);
+      ? createOpenAI({ baseURL: OPENAI_COMPAT_BASE_URLS[provider], apiKey, fetch: retryFetch }).chat(model)
+      : createOpenAI({ baseURL: OPENAI_COMPAT_BASE_URLS[provider], fetch: retryFetch }).chat(model);
   }
 
   switch (provider) {

--- a/apps/agent/src/providers/manifests/index.ts
+++ b/apps/agent/src/providers/manifests/index.ts
@@ -2,12 +2,19 @@
  * Provider manifests.
  *
  * Each manifest declares:
- *  - id           — stable identifier used by the UI, DB, and model strings
- *  - displayName  — human-readable label
- *  - requiredEnv  — env var names that must be present for the provider to work
- *  - optionalEnv  — env var names that refine behavior but are not required
- *  - models       — models exposed in the model picker when enabled
- *  - healthCheck  — minimal API call descriptor used by ProviderHealthService
+ *  - id              — stable identifier used by the UI, DB, and model strings
+ *  - displayName     — human-readable label
+ *  - requiredEnv     — env var names that must be present for the provider to work
+ *  - optionalEnv     — env var names that refine behavior but are not required
+ *  - models          — curated/fallback models shown in the picker when dynamic
+ *                      discovery is unavailable. Always present as the "blessed"
+ *                      defaults; dynamic discovery unions on top.
+ *  - healthCheck     — minimal API call descriptor used by ProviderHealthService
+ *  - modelsEndpoint  — (optional) live model-list endpoint. When set, the
+ *                      ModelCatalogService fetches it with the scoped API key
+ *                      and unions the result with `models`. Providers without
+ *                      this field stay on the static list (Perplexity has no
+ *                      endpoint; Azure is per-deployment; Vertex needs OAuth).
  *
  * Per Theme B + PLATOS_SPEC §4.4: provider API keys live **only** in the
  * trigger.dev Environment Variables table. We never store them in a
@@ -15,6 +22,37 @@
  * "link-env" checklist — the webapp reads the env var presence for the
  * current scope and shows each provider as `Set | Not set`.
  */
+
+export type ModelsEndpointShape =
+  /** OpenAI-canonical `{ object: "list", data: [{ id, ... }] }`. */
+  | "openai"
+  /** Together returns a bare JSON array `[ { id, type, ... } ]`. */
+  | "together"
+  /** Anthropic `{ data: [{ id, display_name, ... }], has_more, ... }`. */
+  | "anthropic"
+  /** Google AI `{ models: [{ name: "models/<id>", supportedGenerationMethods }] }`. */
+  | "google"
+  /** Fireworks `{ data: [{ id, supports_chat, kind }] }`. */
+  | "fireworks"
+  /** Mistral `{ data: [{ id, capabilities: { completion_chat } }] }`. */
+  | "mistral"
+  /** Groq `{ data: [{ id, active, ... }] }`. */
+  | "groq";
+
+export type ModelsEndpointAuth =
+  /** `Authorization: Bearer <key>` — used by OpenAI/Together/Groq/xAI/DeepSeek/Cerebras/Fireworks/Mistral. */
+  | "bearer"
+  /** `x-api-key: <key>` + `anthropic-version: 2023-06-01` — used by Anthropic. */
+  | "anthropic"
+  /** `?key=<key>` query string — used by Google AI Studio. */
+  | "google-query";
+
+export interface ModelsEndpoint {
+  /** Full URL of the GET-models endpoint. */
+  url: string;
+  auth: ModelsEndpointAuth;
+  shape: ModelsEndpointShape;
+}
 
 export interface ProviderManifest {
   id: string;
@@ -24,7 +62,11 @@ export interface ProviderManifest {
   requiredEnv: string[];
   /** Env vars that refine behavior (e.g. region, baseURL). */
   optionalEnv: string[];
-  /** Models exposed when the provider is enabled. */
+  /**
+   * Curated / fallback models. When `modelsEndpoint` is set the live response
+   * is unioned on top of this list (curated entries appear first and stay
+   * even if the upstream call fails).
+   */
   models: string[];
   /** Minimal probe for the health endpoint (fetches against the live API). */
   healthCheck: {
@@ -40,6 +82,8 @@ export interface ProviderManifest {
      */
     baseURL?: string;
   };
+  /** Optional live model-list endpoint for the dynamic catalog. */
+  modelsEndpoint?: ModelsEndpoint;
 }
 
 export const PROVIDER_MANIFESTS: ProviderManifest[] = [
@@ -55,20 +99,30 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       "anthropic:claude-haiku-4-5-20251001",
     ],
     healthCheck: { kind: "anthropic", probeModel: "claude-haiku-4-5-20251001" },
+    modelsEndpoint: {
+      url: "https://api.anthropic.com/v1/models?limit=1000",
+      auth: "anthropic",
+      shape: "anthropic",
+    },
   },
   {
     id: "openai",
     displayName: "OpenAI",
-    description: "GPT-4.1, GPT-4o and GPT-OSS models via OpenAI's API.",
+    description: "GPT-4.1, GPT-4o and OpenAI's hosted models via OpenAI's API.",
     requiredEnv: ["OPENAI_API_KEY"],
     optionalEnv: ["OPENAI_BASE_URL"],
     models: [
       "openai:gpt-4.1",
       "openai:gpt-4.1-mini",
       "openai:gpt-4o",
-      "openai:gpt-oss-120b",
+      "openai:gpt-4o-mini",
     ],
     healthCheck: { kind: "openai", probeModel: "gpt-4.1-mini" },
+    modelsEndpoint: {
+      url: "https://api.openai.com/v1/models",
+      auth: "bearer",
+      shape: "openai",
+    },
   },
   {
     id: "google",
@@ -81,6 +135,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       "google:gemini-2.5-flash",
     ],
     healthCheck: { kind: "google", probeModel: "gemini-2.0-flash" },
+    modelsEndpoint: {
+      url: "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000",
+      auth: "google-query",
+      shape: "google",
+    },
   },
   {
     id: "google-vertex",
@@ -97,6 +156,10 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       "google-vertex:zai-org/glm-5-maas",
     ],
     healthCheck: { kind: "vertex-file", probeModel: "gemini-2.5-flash" },
+    // Vertex uses GCP OAuth + per-publisher endpoints (publishers/google,
+    // publishers/anthropic, publishers/meta, publishers/mistralai). The
+    // single-key catalog pattern doesn't fit — fall back to the curated list
+    // until we add a Vertex-aware OAuth path. Tracked in follow-up.
   },
   {
     id: "groq",
@@ -115,6 +178,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       kind: "openai-compat",
       probeModel: "llama-3.1-8b-instant",
       baseURL: "https://api.groq.com/openai/v1",
+    },
+    modelsEndpoint: {
+      url: "https://api.groq.com/openai/v1/models",
+      auth: "bearer",
+      shape: "groq",
     },
   },
   {
@@ -135,6 +203,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       probeModel: "ministral-8b-latest",
       baseURL: "https://api.mistral.ai/v1",
     },
+    modelsEndpoint: {
+      url: "https://api.mistral.ai/v1/models",
+      auth: "bearer",
+      shape: "mistral",
+    },
   },
   {
     id: "xai",
@@ -152,6 +225,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       probeModel: "grok-2-latest",
       baseURL: "https://api.x.ai/v1",
     },
+    modelsEndpoint: {
+      url: "https://api.x.ai/v1/models",
+      auth: "bearer",
+      shape: "openai",
+    },
   },
   {
     id: "deepseek",
@@ -167,6 +245,13 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       kind: "openai-compat",
       probeModel: "deepseek-chat",
       baseURL: "https://api.deepseek.com/v1",
+    },
+    modelsEndpoint: {
+      // DeepSeek serves /models off the API root (no /v1 prefix on this
+      // particular endpoint; /v1/chat/completions for inference is unaffected).
+      url: "https://api.deepseek.com/models",
+      auth: "bearer",
+      shape: "openai",
     },
   },
   {
@@ -185,6 +270,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       probeModel: "llama-3.1-8b",
       baseURL: "https://api.cerebras.ai/v1",
     },
+    modelsEndpoint: {
+      url: "https://api.cerebras.ai/v1/models",
+      auth: "bearer",
+      shape: "openai",
+    },
   },
   {
     id: "perplexity",
@@ -197,17 +287,20 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       "perplexity:sonar-pro",
       "perplexity:sonar-reasoning",
       "perplexity:sonar-reasoning-pro",
+      "perplexity:sonar-deep-research",
     ],
     healthCheck: {
       kind: "openai-compat",
       probeModel: "sonar",
       baseURL: "https://api.perplexity.ai",
     },
+    // Perplexity does not expose a public /models endpoint. Catalog stays
+    // curated; update this list when their docs add a model.
   },
   {
     id: "together",
     displayName: "Together AI",
-    description: "Llama 3.x, Qwen 2.5, Mixtral, DeepSeek-R1 + 200 OSS models. OpenAI-compatible.",
+    description: "Llama, Qwen, Mixtral, DeepSeek-R1, gpt-oss + 200 OSS models. OpenAI-compatible.",
     requiredEnv: ["TOGETHER_API_KEY"],
     optionalEnv: [],
     models: [
@@ -215,11 +308,18 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       "together:meta-llama/Llama-3.1-8B-Instruct-Turbo",
       "together:Qwen/Qwen2.5-72B-Instruct-Turbo",
       "together:deepseek-ai/DeepSeek-R1",
+      "together:openai/gpt-oss-120b",
+      "together:openai/gpt-oss-20b",
     ],
     healthCheck: {
       kind: "openai-compat",
       probeModel: "meta-llama/Llama-3.1-8B-Instruct-Turbo",
       baseURL: "https://api.together.xyz/v1",
+    },
+    modelsEndpoint: {
+      url: "https://api.together.xyz/v1/models",
+      auth: "bearer",
+      shape: "together",
     },
   },
   {
@@ -238,6 +338,11 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       kind: "openai-compat",
       probeModel: "accounts/fireworks/models/llama-v3p1-8b-instruct",
       baseURL: "https://api.fireworks.ai/inference/v1",
+    },
+    modelsEndpoint: {
+      url: "https://api.fireworks.ai/inference/v1/models",
+      auth: "bearer",
+      shape: "fireworks",
     },
   },
   {
@@ -259,6 +364,8 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
       probeModel: "gpt-4o-mini",
       // baseURL filled in at probe time from AZURE_OPENAI_BASE_URL
     },
+    // Azure's /openai/deployments is per-resource (URL needs the resource
+    // subdomain) and lists deployments, not models. Catalog stays curated.
   },
 ];
 

--- a/apps/agent/src/providers/model-catalog.service.ts
+++ b/apps/agent/src/providers/model-catalog.service.ts
@@ -1,0 +1,254 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { createHash } from "crypto";
+import type { ProviderManifest, ModelsEndpoint } from "./manifests";
+import { ScopedEnvService, type ScopeTuple } from "./scoped-env.service";
+
+/**
+ * Per-provider live model discovery.
+ *
+ * For every provider whose manifest declares `modelsEndpoint`, this service
+ * calls the upstream `/v1/models` (or equivalent) endpoint with the scoped
+ * API key, parses the response to a flat array of `<providerId>:<modelId>`
+ * strings, and caches in memory for `CATALOG_TTL_MS`.
+ *
+ * The caller (`ProviderRegistryService`) unions the result with the
+ * manifest's curated list so:
+ *   - Curated models always show up (even if upstream is down)
+ *   - Live additions (e.g. Together adding `openai/gpt-oss-120b`) surface
+ *     automatically the next time the cache TTL elapses
+ *   - Providers WITHOUT a `modelsEndpoint` (Perplexity, Azure, Vertex)
+ *     fall through to the static list with no extra HTTP calls
+ *
+ * Failure mode: any fetch / parse error logs a warning and returns the empty
+ * array, so the caller falls back cleanly to the static manifest. Auth-style
+ * errors (401/403) are particularly common during key rotation — we don't
+ * want them to break the picker.
+ *
+ * Cache key: `<providerId>:<sha256(apiKey)>`. We never put the plaintext key
+ * in the cache key. Two scopes that share an API key share the cache hit.
+ */
+@Injectable()
+export class ModelCatalogService {
+  private readonly logger = new Logger(ModelCatalogService.name);
+  /** 10-minute TTL. Live model lists change rarely; this is a sane trade-off
+   * between freshness and not hammering the upstream on every UI tick. */
+  private static readonly CATALOG_TTL_MS = 10 * 60 * 1000;
+  /** 5s per-provider fetch budget — picker is on the loader's critical path. */
+  private static readonly FETCH_TIMEOUT_MS = 5000;
+
+  private cache = new Map<string, { models: string[]; expiresAt: number }>();
+  /** In-flight de-dup so concurrent loaders don't fan out duplicate fetches. */
+  private inflight = new Map<string, Promise<string[]>>();
+
+  constructor(private readonly scopedEnv: ScopedEnvService) {}
+
+  /**
+   * Returns the live model list for a provider in this scope, prefixed with
+   * the provider id (`<id>:<model>`). Returns `[]` when:
+   *   - the manifest has no `modelsEndpoint`
+   *   - no API key is configured for the scope
+   *   - the upstream fetch / parse failed
+   *
+   * Caller is expected to union this with `manifest.models` and de-dup.
+   */
+  async listFor(scope: ScopeTuple, manifest: ProviderManifest): Promise<string[]> {
+    if (!manifest.modelsEndpoint) return [];
+
+    const legacyEnv = manifest.requiredEnv[0];
+    const apiKey = await this.scopedEnv.getProviderApiKey(scope, manifest.id, legacyEnv);
+    if (!apiKey) return [];
+
+    const cacheKey = `${manifest.id}:${sha256(apiKey)}`;
+    const now = Date.now();
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expiresAt > now) return cached.models;
+
+    const existing = this.inflight.get(cacheKey);
+    if (existing) return existing;
+
+    const promise = this.fetchAndCache(manifest, apiKey, cacheKey);
+    this.inflight.set(cacheKey, promise);
+    try {
+      return await promise;
+    } finally {
+      this.inflight.delete(cacheKey);
+    }
+  }
+
+  /**
+   * Drop every cached entry for a provider. Called when a user adds / rotates
+   * a provider key so the picker reflects the new credential's reach
+   * immediately, not after the next 10-minute tick.
+   */
+  invalidate(providerId: string): void {
+    const prefix = `${providerId}:`;
+    for (const k of this.cache.keys()) {
+      if (k.startsWith(prefix)) this.cache.delete(k);
+    }
+  }
+
+  private async fetchAndCache(
+    manifest: ProviderManifest,
+    apiKey: string,
+    cacheKey: string,
+  ): Promise<string[]> {
+    try {
+      const ids = await this.fetchUpstream(manifest.modelsEndpoint!, apiKey);
+      const prefixed = ids.map((id) => `${manifest.id}:${id}`);
+      this.cache.set(cacheKey, {
+        models: prefixed,
+        expiresAt: Date.now() + ModelCatalogService.CATALOG_TTL_MS,
+      });
+      return prefixed;
+    } catch (err: any) {
+      this.logger.warn(
+        `model-catalog fetch failed for ${manifest.id}: ${err?.message ?? String(err)}`,
+      );
+      // Cache the negative result briefly so we don't hammer a broken
+      // upstream on every loader call. 30s is short enough that a fixed
+      // upstream recovers quickly.
+      this.cache.set(cacheKey, {
+        models: [],
+        expiresAt: Date.now() + 30_000,
+      });
+      return [];
+    }
+  }
+
+  private async fetchUpstream(endpoint: ModelsEndpoint, apiKey: string): Promise<string[]> {
+    const url = endpoint.auth === "google-query"
+      ? `${endpoint.url}${endpoint.url.includes("?") ? "&" : "?"}key=${encodeURIComponent(apiKey)}`
+      : endpoint.url;
+
+    const headers: Record<string, string> = { Accept: "application/json" };
+    if (endpoint.auth === "bearer") {
+      headers.Authorization = `Bearer ${apiKey}`;
+    } else if (endpoint.auth === "anthropic") {
+      headers["x-api-key"] = apiKey;
+      headers["anthropic-version"] = "2023-06-01";
+    }
+
+    const res = await fetch(url, {
+      method: "GET",
+      headers,
+      signal: AbortSignal.timeout(ModelCatalogService.FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`${res.status} ${res.statusText}: ${body.slice(0, 120)}`);
+    }
+    const json = await res.json();
+    return parseModelsResponse(endpoint.shape, json);
+  }
+}
+
+function parseModelsResponse(shape: ModelsEndpoint["shape"], json: any): string[] {
+  switch (shape) {
+    case "openai": {
+      // { object: "list", data: [{ id, object, owned_by }] }
+      const data = Array.isArray(json?.data) ? json.data : [];
+      return data
+        .map((m: any) => (typeof m?.id === "string" ? m.id : null))
+        .filter((id: string | null): id is string => !!id && !isNonChatOpenAIModel(id));
+    }
+
+    case "together": {
+      // Bare JSON array. Each entry has { id, type, ... }.
+      const arr = Array.isArray(json) ? json : Array.isArray(json?.data) ? json.data : [];
+      return arr
+        .filter((m: any) => {
+          if (typeof m?.id !== "string") return false;
+          // Together's `type` is one of: chat | language | code | embedding |
+          // image | moderation | rerank. Keep chat + language + code; gpt-oss
+          // ships as "chat" today but Together has historically tagged some
+          // OSS models as "language" — accept both so we don't accidentally
+          // filter out a hosted model.
+          const t = m.type;
+          if (!t) return true; // be permissive when type is missing
+          return t === "chat" || t === "language" || t === "code";
+        })
+        .map((m: any) => m.id as string);
+    }
+
+    case "anthropic": {
+      // { data: [{ id, display_name, type: "model" }], has_more, first_id, last_id }
+      const data = Array.isArray(json?.data) ? json.data : [];
+      return data
+        .map((m: any) => (typeof m?.id === "string" ? m.id : null))
+        .filter((id: string | null): id is string => !!id);
+    }
+
+    case "google": {
+      // { models: [{ name: "models/gemini-2.5-pro", supportedGenerationMethods: [...] }] }
+      const models = Array.isArray(json?.models) ? json.models : [];
+      return models
+        .filter((m: any) => {
+          const methods = Array.isArray(m?.supportedGenerationMethods) ? m.supportedGenerationMethods : [];
+          // Keep anything that supports `generateContent` (chat-style).
+          return methods.includes("generateContent");
+        })
+        .map((m: any) => {
+          const name = typeof m?.name === "string" ? m.name : "";
+          return name.startsWith("models/") ? name.slice("models/".length) : name;
+        })
+        .filter((id: string) => !!id);
+    }
+
+    case "fireworks": {
+      // { data: [{ id, supports_chat, kind }] }
+      const data = Array.isArray(json?.data) ? json.data : [];
+      return data
+        .filter((m: any) => typeof m?.id === "string" && m.supports_chat !== false)
+        .map((m: any) => m.id as string);
+    }
+
+    case "mistral": {
+      // { data: [{ id, capabilities: { completion_chat }, deprecation: string | null }] }
+      const data = Array.isArray(json?.data) ? json.data : [];
+      return data
+        .filter((m: any) => {
+          if (typeof m?.id !== "string") return false;
+          if (m.deprecation) return false;
+          const caps = m.capabilities;
+          // Default to true when the field is missing (older accounts).
+          return caps ? caps.completion_chat !== false : true;
+        })
+        .map((m: any) => m.id as string);
+    }
+
+    case "groq": {
+      // { object: "list", data: [{ id, active, ... }] }
+      const data = Array.isArray(json?.data) ? json.data : [];
+      return data
+        .filter((m: any) => typeof m?.id === "string" && m.active !== false)
+        .map((m: any) => m.id as string);
+    }
+
+    default:
+      return [];
+  }
+}
+
+/**
+ * Filter OpenAI's flat /v1/models response down to chat-capable models.
+ * OpenAI doesn't expose a type field — we filter by id prefix, dropping the
+ * non-chat families (embeddings, TTS, transcription, image, moderation).
+ */
+function isNonChatOpenAIModel(id: string): boolean {
+  return (
+    id.startsWith("text-embedding-") ||
+    id.startsWith("text-similarity-") ||
+    id.startsWith("text-search-") ||
+    id.startsWith("dall-e") ||
+    id.startsWith("whisper") ||
+    id.startsWith("tts-") ||
+    id.startsWith("babbage") ||
+    id.startsWith("davinci") ||
+    id.startsWith("omni-moderation") ||
+    id.startsWith("text-moderation")
+  );
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/apps/agent/src/providers/provider-registry.service.ts
+++ b/apps/agent/src/providers/provider-registry.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from "@nestjs/common";
 import { PRISMA_TOKEN } from "../shared/database.provider";
 import { PROVIDER_MANIFESTS, getManifest, type ProviderManifest } from "./manifests";
 import { ScopedEnvService } from "./scoped-env.service";
+import { ModelCatalogService } from "./model-catalog.service";
 import type { RequestScope } from "../auth/scope.guard";
 
 export type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
@@ -46,6 +47,7 @@ export class ProviderRegistryService {
   constructor(
     @Inject(PRISMA_TOKEN) prisma: any,
     private readonly scopedEnv: ScopedEnvService,
+    private readonly modelCatalog: ModelCatalogService,
   ) {
     this.prisma = prisma;
   }
@@ -208,6 +210,33 @@ export class ProviderRegistryService {
     // intentionally disable a provider.
     const linked = !!row || envReady;
     const enabled = row ? row.enabled : envReady;
+
+    // Dynamic model discovery — for providers that publish a /v1/models
+    // endpoint, union the live list with the curated manifest defaults.
+    // Curated entries appear first so the picker preserves a stable order
+    // even when the upstream catalog reorders. De-dup by exact id match.
+    let models = manifest.models;
+    if (envReady && manifest.modelsEndpoint) {
+      try {
+        const live = await this.modelCatalog.listFor(scope, manifest);
+        if (live.length > 0) {
+          const seen = new Set(manifest.models);
+          const additions: string[] = [];
+          for (const id of live) {
+            if (!seen.has(id)) {
+              seen.add(id);
+              additions.push(id);
+            }
+          }
+          models = [...manifest.models, ...additions];
+        }
+      } catch {
+        // ModelCatalogService swallows fetch errors internally; this catch
+        // is defense in depth for unexpected runtime errors. Keep the
+        // curated list on failure.
+      }
+    }
+
     return {
       id: manifest.id,
       displayName: manifest.displayName,
@@ -218,7 +247,7 @@ export class ProviderRegistryService {
       enabled,
       linked,
       linkedAt: row ? row.linkedAt.toISOString() : null,
-      models: manifest.models,
+      models,
     };
   }
 }

--- a/apps/agent/src/providers/providers.controller.ts
+++ b/apps/agent/src/providers/providers.controller.ts
@@ -15,6 +15,7 @@ import { type Request } from "express";
 import { PRISMA_TOKEN } from "../shared/database.provider";
 import { ProviderRegistryService } from "./provider-registry.service";
 import { ScopedEnvService } from "./scoped-env.service";
+import { ModelCatalogService } from "./model-catalog.service";
 import type { RequestScope } from "../auth/scope.guard";
 
 /**
@@ -32,6 +33,7 @@ export class ProvidersController {
     @Inject(PRISMA_TOKEN) private readonly prisma: any,
     private readonly registry: ProviderRegistryService,
     private readonly scopedEnv: ScopedEnvService,
+    private readonly modelCatalog: ModelCatalogService,
   ) {}
 
   private getScope(req: Request): RequestScope {
@@ -133,6 +135,10 @@ export class ProvidersController {
         createdAt: true,
       },
     });
+    // New key may unlock a different upstream catalog (e.g. a Together
+    // enterprise account vs. trial). Drop the in-memory cache so the next
+    // picker load fetches /v1/models with the new credential.
+    this.modelCatalog.invalidate(body.provider);
     return { key };
   }
 
@@ -198,6 +204,7 @@ export class ProvidersController {
     }
 
     await this.prisma.platosProviderKey.delete({ where: { id } });
+    this.modelCatalog.invalidate(existing.provider);
     return { deleted: true };
   }
 }

--- a/apps/agent/src/providers/providers.module.ts
+++ b/apps/agent/src/providers/providers.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
 import { ProviderRegistryService } from "./provider-registry.service";
 import { ScopedEnvService } from "./scoped-env.service";
+import { ModelCatalogService } from "./model-catalog.service";
 import { ProvidersController } from "./providers.controller";
 
 @Module({
   controllers: [ProvidersController],
-  providers: [ProviderRegistryService, ScopedEnvService],
-  exports: [ProviderRegistryService, ScopedEnvService],
+  providers: [ProviderRegistryService, ScopedEnvService, ModelCatalogService],
+  exports: [ProviderRegistryService, ScopedEnvService, ModelCatalogService],
 })
 export class ProvidersModule {}


### PR DESCRIPTION
## Summary

Two related fixes for the agent's LLM provider layer. Both reproduce on play.platos right now.

**1. Together / Groq / xAI / DeepSeek / Cerebras / Perplexity / Together / Fireworks all 404 with \`AI_APICallError: Not Found\`.**
AI SDK v6's \`@ai-sdk/openai@3.0.55\` changed the default callable from chat/completions to the OpenAI Responses API. \`createOpenAI({ baseURL })(model)\` now hits \`/v1/responses\`, which third-party OpenAI-compatible providers don't implement. Pin them to \`.chat(model)\`.

**2. Picker only shows the 4 hard-coded Together models; \`openai/gpt-oss-120b\` and friends never surface.**
\`ProviderRegistryService.availableModels()\` returned \`manifest.models\` (static curated list). The agent runtime gate at \`agent.service.ts:4669\` also reads from it and rejects any model not in the list with \`provider_unavailable\` before any API call happens. New \`ModelCatalogService\` calls each provider's live \`/v1/models\` with the scoped API key and unions the result on top of the manifest.

## Plumbing per provider (verified against current docs)

| provider | endpoint | auth | shape | notes |
|---|---|---|---|---|
| openai | \`/v1/models\` | Bearer | openai | filter embedding/tts/whisper/dall-e/moderation by id prefix |
| anthropic | \`/v1/models?limit=1000\` | x-api-key + anthropic-version | anthropic | all entries are chat models |
| together | \`/v1/models\` | Bearer | bare JSON array | filter type ∈ {chat,language,code,or missing} — gpt-oss confirmed live |
| groq | \`/openai/v1/models\` | Bearer | openai-like | filter \`active !== false\` |
| mistral | \`/v1/models\` | Bearer | openai-like | filter \`capabilities.completion_chat !== false\`, skip deprecated |
| xai | \`/v1/models\` | Bearer | openai | — |
| deepseek | \`/models\` (no \`/v1\`!) | Bearer | openai | — |
| cerebras | \`/v1/models\` | Bearer | openai | gpt-oss surfaces here too |
| fireworks | \`/inference/v1/models\` | Bearer | openai-like | filter \`supports_chat !== false\` |
| google-ai | \`/v1beta/models?key=&pageSize=1000\` | query-key | google | filter \`supportedGenerationMethods.includes("generateContent")\`, strip \`models/\` prefix |
| perplexity | none | — | — | static fallback only (no public endpoint) |
| azure | per-deployment | — | — | static fallback only |
| google-vertex | per-publisher (needs OAuth) | — | — | static fallback only — follow-up |

## Cache + failure behavior

- 10-min TTL, in-memory \`Map\`, keyed by \`<providerId>:<sha256(apiKey)>\` (no plaintext in cache keys)
- Negative results cached for 30s so a broken upstream doesn't slow every picker load
- POST/DELETE on \`/api/v1/agent/providers/keys\` invalidates the provider's cache entries
- 5s \`AbortSignal\` timeout, no retry — picker is on the critical path
- Any fetch/parse failure → log + fall back to manifest list (no UI breakage during key rotation 401s)

## Curated additions

Together's manifest now includes \`openai/gpt-oss-120b\` and \`openai/gpt-oss-20b\` directly so they're visible before the first cache fill.

## Test plan

- [ ] Container restart on play.platos picks up the merged image (or rebuild)
- [ ] /agents picker shows >4 Together models when a Together key is linked
- [ ] Chat turn with \`together:openai/gpt-oss-120b\` lands in \`/v1/chat/completions\`, returns successfully
- [ ] Chat turn with \`together:meta-llama/Llama-3.3-70B-Instruct-Turbo\` (existing manifest) still works
- [ ] Anthropic flow unchanged (regression check — user reported it was the only working path before this)
- [ ] Provider key add invalidates that provider's catalog cache (verify next /agents load refetches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)