### PR TITLE
fix(transport, infra): WS URL bug + welcome decode + ClickHouse hardening + client.tools API

### DIFF
--- a/.changeset/platools-js-query-string-and-welcome.md
+++ b/.changeset/platools-js-query-string-and-welcome.md
@@ -1,0 +1,21 @@
+---
+"@platosdev/platools-sdk": patch
+---
+
+Fix two transport-layer bugs in the TS SDK that have shipped since 0.2.0:
+
+- `PlatoolsClient.websocketUrl()` raw-concatenated `/ws/sdk` to the URL,
+  corrupting query strings: `wss://play.platos.dev/tools/sync?env=prod`
+  became `…?env=prod/ws/sdk`, which the server parsed as `env="prod/ws/sdk"`
+  and rejected with `could not resolve env for entity`. The suffix is now
+  inserted before the query string (mirrors the fix already carried in
+  fandesk's vendored Python SDK).
+
+- `decodePlatformMessage` only accepted the legacy `welcome.org_id`
+  field; the agent emits `welcome.organization_id` (plus `entity_id`,
+  `environment_id`, `project_id`). The decoder now accepts either shape,
+  exposes the canonical `organization_id`, keeps `org_id` as a
+  back-compat alias, and surfaces the additional ids. Eliminates the
+  `platools received malformed message` warn on every connect.
+
+Regression tests added in `tests/transport.test.ts`.

--- a/.changeset/platos-client-tools-api.md
+++ b/.changeset/platos-client-tools-api.md
@@ -1,0 +1,15 @@
+---
+"@platosdev/client": minor
+---
+
+Add `client.tools` namespace (issue #2) — typed wrappers for the tool-catalog REST surface exposed by the agent service. Previously consumers had to hand-roll fetch calls with the right scope + auth plumbing.
+
+New methods:
+- `client.tools.list({ category? })` — GET /api/v1/agent/tools
+- `client.tools.search(q, { limit?, entity? })` — GET /api/v1/agent/tools/search
+- `client.tools.stats()` — GET /api/v1/agent/tools/stats
+- `client.tools.matrix()` — GET /api/v1/agent/tools/matrix (per-entity grid with health data)
+- `client.tools.setEnabled(entityId, toolName, enabled)` — PATCH …/:entityId/:toolName/enabled
+- `client.tools.test(toolId, params)` — POST …/:toolId/test
+
+Exports: `PlatosTool`, `PlatosToolHealth`, `PlatosToolMatrixRow`, `PlatosToolStats`, `PlatosToolListOptions`, `PlatosToolSearchOptions`, `PlatosToolTestResult`.

--- a/.platos/clickhouse/system-tables-ttl.xml
+++ b/.platos/clickhouse/system-tables-ttl.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+  Cap retention on ClickHouse's *own* observability tables so they
+  cannot accumulate unbounded and OOM the server during background
+  merges.
+
+  Backstory (2026-05-19 outage post-mortem): a week of write churn
+  from a misbehaving entity drove `system.metric_log` to 1.2 M rows /
+  ~300 MiB across 108 unmerged parts. Once a single merge needed more
+  than the container's mem_limit (default `1200m` at the time, now
+  bumped to `4g`), every restart lost progress and the next merge was
+  bigger — the classic OOM-loop. The server was killed 523 times in
+  12 days.
+
+  Cause = unbounded retention on tables that exist purely for
+  ClickHouse self-introspection. None of these tables drive product
+  features; they're useful for live debugging only. 7 days is plenty.
+
+  This file is mounted into the container at
+  `/etc/clickhouse-server/config.d/system-tables-ttl.xml` by
+  docker-compose.platos.yml.
+-->
+<clickhouse>
+  <!-- High-cardinality engine telemetry. Was 1.2 M rows after a week. -->
+  <metric_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </metric_log>
+
+  <!-- Async metric snapshots. 91 M rows after a week — biggest by row count. -->
+  <asynchronous_metric_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </asynchronous_metric_log>
+
+  <!-- Per-query telemetry. Useful for debug, not for long-term retention. -->
+  <query_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </query_log>
+
+  <query_metric_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </query_metric_log>
+
+  <!-- Network/disk latency observations from the engine. -->
+  <latency_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </latency_log>
+
+  <!-- Server error counters (rolled up in `system.errors` already). -->
+  <error_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </error_log>
+
+  <!-- Profile-event samples from query execution. -->
+  <processors_profile_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </processors_profile_log>
+
+  <!-- Part-merge history. 7 days is enough to spot regressions. -->
+  <part_log>
+    <ttl>event_date + INTERVAL 7 DAY DELETE</ttl>
+  </part_log>
+
+  <!-- Sparingly-used OTLP span sink. -->
+  <opentelemetry_span_log>
+    <ttl>finish_date + INTERVAL 7 DAY DELETE</ttl>
+  </opentelemetry_span_log>
+</clickhouse>

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -58,7 +58,9 @@ services:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
     logging: *default-logging
-    mem_limit: ${POSTGRES_MEM_LIMIT:-512m}
+    # 2026-05-19 incident: 512m default OOMed under storm-driven UPSERT load + autovacuum.
+    # Production realistic minimum is ~1 GiB; override via POSTGRES_MEM_LIMIT for bigger hosts.
+    mem_limit: ${POSTGRES_MEM_LIMIT:-1g}
     ports:
       # EOBD.51 — bind to localhost by default. Override via
       # POSTGRES_PUBLIC_BIND=0.0.0.0 for external access.
@@ -99,7 +101,10 @@ services:
     image: clickhouse/clickhouse-server:25.3-alpine
     restart: unless-stopped
     logging: *default-logging
-    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-1200m}
+    # 2026-05-19 incident: 1200m default caused 523 OOM-restarts in 12 days
+    # because ClickHouse's *own* `system.metric_log` grew past what a 1.17 GiB
+    # cgroup could merge. New default is 4 GiB; pair with the TTL config below.
+    mem_limit: ${CLICKHOUSE_MEM_LIMIT:-4g}
     ports:
       # EOBD.51 — bind to localhost by default.
       - "${CLICKHOUSE_PUBLIC_BIND:-127.0.0.1}:8123:8123"
@@ -108,8 +113,11 @@ services:
       - platos-clickhouse:/var/lib/clickhouse
       # Host has IPv6 disabled; override listen_host to 0.0.0.0 (IPv4-only)
       - ./.platos/clickhouse/listen.xml:/etc/clickhouse-server/config.d/listen.xml:ro
-      # Disable trace_log/text_log (grew to 7+ GiB), cap memory to ~1.2 GB
+      # Disable trace_log/text_log (grew to 7+ GiB)
       - ./.platos/clickhouse/logging.xml:/etc/clickhouse-server/config.d/logging.xml:ro
+      # 7-day TTL on every system.*_log table to prevent the OOM-loop
+      # documented in the 2026-05-19 post-mortem.
+      - ./.platos/clickhouse/system-tables-ttl.xml:/etc/clickhouse-server/config.d/system-tables-ttl.xml:ro
     environment:
       CLICKHOUSE_USER: "${CLICKHOUSE_USER:-default}"
       # Override CLICKHOUSE_PASSWORD in .env before exposing externally.

--- a/packages/platools-js/src/transport/client.ts
+++ b/packages/platools-js/src/transport/client.ts
@@ -202,14 +202,20 @@ export class PlatoolsClient {
 
   /**
    * Compute the normalized WebSocket URL. Mirrors the Python
-   * SDK's `_ws_url` — strips trailing slashes, swaps `http://` →
-   * `ws://` / `https://` → `wss://`, and appends `/ws/sdk`.
+   * SDK's `_ws_url` — swaps `http://` → `ws://` / `https://` →
+   * `wss://`, strips trailing slashes from the *path*, and inserts
+   * `/ws/sdk` before any query string. Concatenating the suffix
+   * after the query corrupts the last query value
+   * (`?env=prod` → `?env=prod/ws/sdk`).
    */
   public websocketUrl(): string {
-    let base = this.url.replace(/\/+$/, "");
+    let base = this.url;
     if (base.startsWith("http://")) base = `ws://${base.slice("http://".length)}`;
     else if (base.startsWith("https://")) base = `wss://${base.slice("https://".length)}`;
-    return `${base}/ws/sdk`;
+    const qIdx = base.indexOf("?");
+    const path = qIdx >= 0 ? base.slice(0, qIdx) : base;
+    const query = qIdx >= 0 ? base.slice(qIdx) : "";
+    return `${path.replace(/\/+$/, "")}/ws/sdk${query}`;
   }
 
   /**

--- a/packages/platools-js/src/transport/protocol.ts
+++ b/packages/platools-js/src/transport/protocol.ts
@@ -78,7 +78,18 @@ export interface HeartbeatAckMessage {
 export interface WelcomeMessage {
   readonly type: "welcome";
   readonly sdk_connection_id: string;
+  /**
+   * Canonical organization id. The server emits `organization_id`;
+   * older SDKs (< 0.2.1) only decoded `org_id`. The decoder accepts
+   * either shape, exposes the canonical name here, and back-fills
+   * `org_id` for any consumer that still reads the legacy field.
+   */
+  readonly organization_id: string;
+  /** @deprecated alias for `organization_id` — preserved for v0.2.x consumers. */
   readonly org_id: string;
+  readonly entity_id?: string;
+  readonly environment_id?: string;
+  readonly project_id?: string;
 }
 
 export type PlatformToSdk = ToolCallMessage | HeartbeatAckMessage | WelcomeMessage;
@@ -119,18 +130,33 @@ export function decodePlatformMessage(raw: string): PlatformToSdk | null {
       };
     case "heartbeat_ack":
       return { type: "heartbeat_ack" };
-    case "welcome":
-      if (
-        typeof record.sdk_connection_id !== "string" ||
-        typeof record.org_id !== "string"
-      ) {
+    case "welcome": {
+      const orgId =
+        typeof record.organization_id === "string"
+          ? record.organization_id
+          : typeof record.org_id === "string"
+            ? record.org_id
+            : null;
+      if (typeof record.sdk_connection_id !== "string" || orgId === null) {
         return null;
       }
-      return {
+      const welcome: WelcomeMessage = {
         type: "welcome",
         sdk_connection_id: record.sdk_connection_id,
-        org_id: record.org_id,
+        organization_id: orgId,
+        org_id: orgId,
+        ...(typeof record.entity_id === "string"
+          ? { entity_id: record.entity_id }
+          : {}),
+        ...(typeof record.environment_id === "string"
+          ? { environment_id: record.environment_id }
+          : {}),
+        ...(typeof record.project_id === "string"
+          ? { project_id: record.project_id }
+          : {}),
       };
+      return welcome;
+    }
     default:
       return null;
   }

--- a/packages/platools-js/tests/transport.test.ts
+++ b/packages/platools-js/tests/transport.test.ts
@@ -162,6 +162,78 @@ describe("PlatoolsClient.websocketUrl", () => {
     });
     expect(client.websocketUrl()).toBe("ws://host:9000/ws/sdk");
   });
+
+  // Regression: raw string concat used to produce
+  // `wss://x.example/y?z=1/ws/sdk`, which the server parsed as
+  // `?z=1/ws/sdk` and failed env resolution.
+  it("inserts /ws/sdk before query strings, not after", () => {
+    const client = new PlatoolsClient({
+      url: "wss://x.example/y?z=1",
+      secret: "s",
+      registry: new ToolRegistry(),
+    });
+    expect(client.websocketUrl()).toBe("wss://x.example/y/ws/sdk?z=1");
+  });
+
+  it("handles multiple query params (source + env)", () => {
+    const client = new PlatoolsClient({
+      url: "wss://play.platos.dev/tools/sync?source=winsen-brain-demo-app&env=prod",
+      secret: "s",
+      registry: new ToolRegistry(),
+    });
+    expect(client.websocketUrl()).toBe(
+      "wss://play.platos.dev/tools/sync/ws/sdk?source=winsen-brain-demo-app&env=prod",
+    );
+  });
+});
+
+describe("decodePlatformMessage — welcome", () => {
+  // Server emits `organization_id`; legacy SDKs only read `org_id`.
+  // The decoder accepts either and exposes both.
+  it("decodes the canonical organization_id shape", () => {
+    const decoded = decodePlatformMessage(
+      JSON.stringify({
+        type: "welcome",
+        sdk_connection_id: "conn-1",
+        organization_id: "org-abc",
+        project_id: "prj-def",
+        environment_id: "env-ghi",
+        entity_id: "winsen-brain-demo-app",
+      }),
+    );
+    expect(decoded).toEqual({
+      type: "welcome",
+      sdk_connection_id: "conn-1",
+      organization_id: "org-abc",
+      org_id: "org-abc",
+      project_id: "prj-def",
+      environment_id: "env-ghi",
+      entity_id: "winsen-brain-demo-app",
+    });
+  });
+
+  it("falls back to the legacy org_id shape", () => {
+    const decoded = decodePlatformMessage(
+      JSON.stringify({
+        type: "welcome",
+        sdk_connection_id: "conn-2",
+        org_id: "org-xyz",
+      }),
+    );
+    expect(decoded).toEqual({
+      type: "welcome",
+      sdk_connection_id: "conn-2",
+      organization_id: "org-xyz",
+      org_id: "org-xyz",
+    });
+  });
+
+  it("rejects a welcome frame with neither field", () => {
+    const decoded = decodePlatformMessage(
+      JSON.stringify({ type: "welcome", sdk_connection_id: "c" }),
+    );
+    expect(decoded).toBeNull();
+  });
 });
 
 describe("PlatoolsClient session dispatch", () => {

--- a/packages/platools-py/CHANGELOG.md
+++ b/packages/platools-py/CHANGELOG.md
@@ -1,5 +1,17 @@
 # platools (Python)
 
+## 0.2.1 — 2026-05-20
+
+### Fixed
+
+- **`PlatoolsClient._ws_url` corrupted query strings** (parity with the JS SDK fix in `@platosdev/platools-sdk` 0.2.1; mirrors winsenlabs/platos#3). The old implementation did `f"{base.rstrip('/')}/ws/sdk"`, concatenating the suffix *after* any query string. A bridge configured with `PLATOS_URL=wss://play.platos.dev/tools/sync?env=prod` ended up shipping the handshake to `…?env=prod/ws/sdk`; the server then parsed `env="prod/ws/sdk"` and rejected with `could not resolve env for entity`. Fix splits the URL at `?`, appends `/ws/sdk` to the path, and re-attaches the query.
+- **`WelcomeMessage` accepts the canonical `organization_id` field** the server actually emits, with `org_id` kept as a backwards-compatible read alias. The model also surfaces optional `entity_id`, `environment_id`, and `project_id` when present. Silences the `platools received malformed message` warn that older SDKs emitted on every connect.
+
+### Tests
+
+- New regression cases in `tests/test_ws_url.py` for the URL-construction bug.
+- Welcome decoder dual-shape cases added to `tests/test_protocol.py`.
+
 ## 0.2.0 — 2026-05-06
 
 ### What changed

--- a/packages/platools-py/platools/transport/client.py
+++ b/packages/platools-py/platools/transport/client.py
@@ -120,12 +120,23 @@ class PlatoolsClient:
                 self._ws = None
 
     def _ws_url(self) -> str:
-        base = self._url.rstrip("/")
+        # Mirror the JS SDK's fix: swap protocol, strip trailing slashes
+        # from the *path*, and insert `/ws/sdk` *before* any query
+        # string. Naive `f"{base}/ws/sdk"` concatenation corrupts the
+        # last query value (`?env=prod` becomes `?env=prod/ws/sdk`),
+        # which the server then fails to parse — see
+        # winsenlabs/platos#3.
+        base = self._url
         if base.startswith("http://"):
             base = "ws://" + base[len("http://") :]
         elif base.startswith("https://"):
             base = "wss://" + base[len("https://") :]
-        return f"{base}/ws/sdk"
+        q_idx = base.find("?")
+        if q_idx >= 0:
+            path, query = base[:q_idx], base[q_idx:]
+        else:
+            path, query = base, ""
+        return f"{path.rstrip('/')}/ws/sdk{query}"
 
     async def _send_registration(self, ws: ClientConnection) -> None:
         payloads: list[ToolSchemaPayload] = []

--- a/packages/platools-py/platools/transport/protocol.py
+++ b/packages/platools-py/platools/transport/protocol.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 
 class ToolSchemaPayload(BaseModel):
@@ -74,11 +74,28 @@ class HeartbeatAckMessage(BaseModel):
 class WelcomeMessage(BaseModel):
     """Sent by the platform on successful handshake so the SDK knows the
     connection is authenticated and its tools are queued for registration.
+
+    The server emits ``organization_id`` as the canonical field; older
+    SDKs only decoded ``org_id``. We accept either shape (validation
+    alias) and back-fill the legacy ``org_id`` attribute so any v0.2.x
+    consumer still reads through. The extra scope fields (``entity_id``,
+    ``environment_id``, ``project_id``) are populated when the server
+    sends them and remain ``None`` otherwise — they're additive only.
     """
+
+    model_config = ConfigDict(populate_by_name=True)
 
     type: Literal["welcome"] = "welcome"
     sdk_connection_id: str
-    org_id: str
+    organization_id: str = Field(validation_alias=AliasChoices("organization_id", "org_id"))
+    entity_id: str | None = None
+    environment_id: str | None = None
+    project_id: str | None = None
+
+    @property
+    def org_id(self) -> str:
+        """Deprecated alias for :attr:`organization_id` — kept for v0.2.x consumers."""
+        return self.organization_id
 
 
 SdkToPlatform = ToolRegisterMessage | ToolResultMessage | ToolErrorMessage | HeartbeatMessage

--- a/packages/platools-py/pyproject.toml
+++ b/packages/platools-py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "platools"
-version = "0.2.0"
+version = "0.2.1"
 description = "Platools — Your AI Arsenal. Turn any backend function into a managed, authenticated, monitored MCP tool with one decorator."
 readme = "README.md"
 # The SDK ships to PyPI independently and must support older Pythons that

--- a/packages/platools-py/tests/test_protocol.py
+++ b/packages/platools-py/tests/test_protocol.py
@@ -81,3 +81,38 @@ def test_welcome_and_heartbeat_ack_discriminated() -> None:
 
     ack = adapter.validate_python({"type": "heartbeat_ack"})
     assert isinstance(ack, HeartbeatAckMessage)
+
+
+def test_welcome_accepts_canonical_organization_id() -> None:
+    # Server emits `organization_id`; older SDK only decoded `org_id`.
+    # The decoder now accepts either shape and exposes both names.
+    adapter: TypeAdapter[PlatformToSdk] = TypeAdapter(PlatformToSdk)
+    welcome = adapter.validate_python(
+        {
+            "type": "welcome",
+            "sdk_connection_id": "conn-1",
+            "organization_id": "org-abc",
+            "entity_id": "winsen-brain-demo-app",
+            "environment_id": "env-prod",
+            "project_id": "prj-1",
+        }
+    )
+    assert isinstance(welcome, WelcomeMessage)
+    assert welcome.organization_id == "org-abc"
+    assert welcome.org_id == "org-abc"
+    assert welcome.entity_id == "winsen-brain-demo-app"
+    assert welcome.environment_id == "env-prod"
+    assert welcome.project_id == "prj-1"
+
+
+def test_welcome_back_compat_org_id_only() -> None:
+    adapter: TypeAdapter[PlatformToSdk] = TypeAdapter(PlatformToSdk)
+    welcome = adapter.validate_python(
+        {"type": "welcome", "sdk_connection_id": "conn-2", "org_id": "org-xyz"}
+    )
+    assert isinstance(welcome, WelcomeMessage)
+    assert welcome.organization_id == "org-xyz"
+    assert welcome.org_id == "org-xyz"
+    assert welcome.entity_id is None
+    assert welcome.environment_id is None
+    assert welcome.project_id is None

--- a/packages/platools-py/tests/test_ws_url.py
+++ b/packages/platools-py/tests/test_ws_url.py
@@ -1,0 +1,53 @@
+"""Regression tests for `PlatoolsClient._ws_url`.
+
+The old implementation did `f"{base.rstrip('/')}/ws/sdk"`, which
+corrupted the last query value when the URL had a query string
+(`?env=prod` → `?env=prod/ws/sdk`). The server then failed env
+resolution. See winsenlabs/platos#3.
+"""
+
+from __future__ import annotations
+
+from platools import Platools
+from platools.transport.client import PlatoolsClient
+
+
+def _make_client(url: str) -> PlatoolsClient:
+    p = Platools()
+    return PlatoolsClient(url=url, secret="s", registry=p.registry)
+
+
+def test_ws_url_no_query() -> None:
+    client = _make_client("wss://host.example/y")
+    assert client._ws_url() == "wss://host.example/y/ws/sdk"
+
+
+def test_ws_url_strips_trailing_slash_from_path() -> None:
+    client = _make_client("wss://host.example/y/")
+    assert client._ws_url() == "wss://host.example/y/ws/sdk"
+
+
+def test_ws_url_swaps_http_to_ws() -> None:
+    client = _make_client("http://host:9000")
+    assert client._ws_url() == "ws://host:9000/ws/sdk"
+
+
+def test_ws_url_swaps_https_to_wss() -> None:
+    client = _make_client("https://host.example/y")
+    assert client._ws_url() == "wss://host.example/y/ws/sdk"
+
+
+def test_ws_url_inserts_before_query_single_param() -> None:
+    # Regression for the concat bug. Server saw `env=prod/ws/sdk`.
+    client = _make_client("wss://x.example/y?z=1")
+    assert client._ws_url() == "wss://x.example/y/ws/sdk?z=1"
+
+
+def test_ws_url_inserts_before_query_multiple_params() -> None:
+    client = _make_client(
+        "wss://play.platos.dev/tools/sync?source=winsen-brain-demo-app&env=prod",
+    )
+    assert (
+        client._ws_url()
+        == "wss://play.platos.dev/tools/sync/ws/sdk?source=winsen-brain-demo-app&env=prod"
+    )

--- a/packages/platos-client/src/__tests__/tools.test.ts
+++ b/packages/platos-client/src/__tests__/tools.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for `client.tools` (issue #2).
+ *
+ * We mock `globalThis.fetch` rather than instantiating a live agent —
+ * the goal is to lock down the URL paths, query-string encoding, and
+ * request bodies the SDK ships, not to exercise the server.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlatosClient } from "../client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("client.tools", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: PlatosClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new PlatosClient({
+      baseUrl: "https://play.platos.dev",
+      sessionToken: "test-token",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("list() — no filter", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tools: [{ toolId: "t1", toolName: "echo" }] }));
+    const tools = await client.tools.list();
+    expect(tools).toHaveLength(1);
+    expect(tools[0].toolName).toBe("echo");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://play.platos.dev/api/v1/agent/tools");
+    expect(init.method).toBe("GET");
+  });
+
+  it("list({ category }) — passes category in query string", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tools: [] }));
+    await client.tools.list({ category: "communication" });
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toBe(
+      "https://play.platos.dev/api/v1/agent/tools?category=communication",
+    );
+  });
+
+  it("search() — builds query string with q, limit, entity", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ tools: [] }));
+    await client.tools.search("refund", { limit: 5, entity: "fandesk" });
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("/api/v1/agent/tools/search");
+    expect(url).toContain("q=refund");
+    expect(url).toContain("limit=5");
+    expect(url).toContain("entity=fandesk");
+  });
+
+  it("matrix() — returns rows array", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({
+        tools: [
+          {
+            toolId: "t1",
+            toolName: "echo",
+            description: "",
+            category: "debug",
+            paramSchema: {},
+            entityId: "e1",
+            health: { totalCalls: 5, failCount: 0, p95LatencyMs: 42, lastCalledAt: "2026-05-19T00:00:00Z" },
+          },
+        ],
+      }),
+    );
+    const rows = await client.tools.matrix();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].health?.totalCalls).toBe(5);
+  });
+
+  it("setEnabled() — PATCH with correct path + body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ enabled: false }));
+    const out = await client.tools.setEnabled("fandesk", "process_refund", false);
+    expect(out.enabled).toBe(false);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(
+      "https://play.platos.dev/api/v1/agent/tools/fandesk/process_refund/enabled",
+    );
+    expect(init.method).toBe("PATCH");
+    expect(JSON.parse(init.body as string)).toEqual({ enabled: false });
+  });
+
+  it("setEnabled() — URL-encodes entity + tool", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ enabled: true }));
+    await client.tools.setEnabled("ent/with slash", "tool name", true);
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toContain("/ent%2Fwith%20slash/tool%20name/enabled");
+  });
+
+  it("test() — POST with params body", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ status: "ok", elapsedMs: 12 }));
+    const result = await client.tools.test("t1", { message: "hi" });
+    expect(result.status).toBe("ok");
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://play.platos.dev/api/v1/agent/tools/t1/test");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ params: { message: "hi" } });
+  });
+});

--- a/packages/platos-client/src/apis/tools.ts
+++ b/packages/platos-client/src/apis/tools.ts
@@ -1,0 +1,177 @@
+/**
+ * @platosdev/client — tools API surface (issue #2).
+ *
+ * Wraps the tool-catalog REST endpoints exposed by the agent service
+ * (`apps/agent/src/agent-runtime/agent.controller.ts`). These power the
+ * dashboard's Tools tab and the per-entity tool matrix UI; before this
+ * namespace landed, SDK consumers had to hand-roll fetch calls with the
+ * right auth + scope headers.
+ */
+
+import type { PlatosClient } from "../client.js";
+import { PlatosNotFoundError } from "../errors.js";
+import type { PlatosScope } from "../types.js";
+
+export interface PlatosTool {
+  readonly toolId: string;
+  readonly toolName: string;
+  readonly description: string;
+  readonly category: string | null;
+  readonly paramSchema: unknown;
+  readonly entityId: string;
+  readonly entityPk?: string;
+  readonly callbackUrl?: string;
+  readonly enabled?: boolean;
+}
+
+export interface PlatosToolHealth {
+  readonly totalCalls: number;
+  readonly failCount: number;
+  readonly p95LatencyMs: number | null;
+  readonly lastCalledAt: string | null;
+}
+
+export interface PlatosToolMatrixRow extends PlatosTool {
+  readonly health?: PlatosToolHealth;
+}
+
+export interface PlatosToolStats {
+  readonly toolCount: number;
+  readonly entityCount: number;
+  readonly bm25IndexSize?: number;
+  readonly lastIndexedAt?: string;
+}
+
+export interface PlatosToolListOptions {
+  /** Optional category filter (matches `PlatosToolDefinition.category`). */
+  category?: string;
+}
+
+export interface PlatosToolSearchOptions {
+  /** Max results to return (default 25 server-side). */
+  limit?: number;
+  /** Narrow the search to a single connected-entity slug. */
+  entity?: string;
+}
+
+export interface PlatosToolTestResult {
+  readonly status: "ok" | "error";
+  readonly elapsedMs: number;
+  readonly result?: unknown;
+  readonly error?: string;
+}
+
+export class ToolsApi {
+  constructor(private readonly client: PlatosClient) {}
+
+  /**
+   * List tools visible in scope, optionally filtered by category.
+   * Backs the agent dashboard's Tools tab.
+   */
+  async list(opts: PlatosToolListOptions = {}, scope?: PlatosScope): Promise<PlatosTool[]> {
+    const qs = opts.category
+      ? `?category=${encodeURIComponent(opts.category)}`
+      : "";
+    const res = await this.client._fetch<{ tools: PlatosTool[] }>(
+      `/api/v1/agent/tools${qs}`,
+      { method: "GET" },
+      scope,
+    );
+    return res?.tools ?? [];
+  }
+
+  /**
+   * Keyword search the tool registry (BM25 server-side). Use for
+   * tool-discovery UIs.
+   */
+  async search(
+    q: string,
+    opts: PlatosToolSearchOptions = {},
+    scope?: PlatosScope,
+  ): Promise<PlatosTool[]> {
+    const params = new URLSearchParams({ q });
+    if (opts.limit !== undefined) params.set("limit", String(opts.limit));
+    if (opts.entity) params.set("entity", opts.entity);
+    const res = await this.client._fetch<{ tools: PlatosTool[] }>(
+      `/api/v1/agent/tools/search?${params.toString()}`,
+      { method: "GET" },
+      scope,
+    );
+    return res?.tools ?? [];
+  }
+
+  /**
+   * Registry index stats — tool count, entity count, BM25 index size.
+   * Mostly useful for debug + dashboard headers.
+   */
+  async stats(scope?: PlatosScope): Promise<PlatosToolStats | null> {
+    try {
+      return await this.client._fetch<PlatosToolStats>(
+        "/api/v1/agent/tools/stats",
+        { method: "GET" },
+        scope,
+      );
+    } catch (err) {
+      if (err instanceof PlatosNotFoundError) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Per-entity matrix — every tool in scope with full metadata
+   * (description, paramSchema, callbackUrl, enabled flag) plus health
+   * data (totalCalls, failCount, p95LatencyMs, lastCalledAt). The
+   * dashboard's Tools tab uses this exact shape.
+   */
+  async matrix(scope?: PlatosScope): Promise<PlatosToolMatrixRow[]> {
+    const res = await this.client._fetch<{ tools: PlatosToolMatrixRow[] }>(
+      "/api/v1/agent/tools/matrix",
+      { method: "GET" },
+      scope,
+    );
+    return res?.tools ?? [];
+  }
+
+  /**
+   * Toggle a single tool's `enabled` flag on a specific entity. The
+   * scope tuple defines which environment the flag applies to;
+   * dev/staging/prod can independently enable/disable the same tool.
+   */
+  async setEnabled(
+    entityId: string,
+    toolName: string,
+    enabled: boolean,
+    scope?: PlatosScope,
+  ): Promise<{ enabled: boolean }> {
+    return await this.client._fetch<{ enabled: boolean }>(
+      `/api/v1/agent/tools/${encodeURIComponent(entityId)}/${encodeURIComponent(toolName)}/enabled`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled }),
+      },
+      scope,
+    );
+  }
+
+  /**
+   * Invoke a tool against its entity with sample params, useful for
+   * smoke-testing connections from the dashboard's Test button. Does
+   * NOT count against the agent's rate limits or budgets.
+   */
+  async test(
+    toolId: string,
+    params: Record<string, unknown>,
+    scope?: PlatosScope,
+  ): Promise<PlatosToolTestResult> {
+    return await this.client._fetch<PlatosToolTestResult>(
+      `/api/v1/agent/tools/${encodeURIComponent(toolId)}/test`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ params }),
+      },
+      scope,
+    );
+  }
+}

--- a/packages/platos-client/src/client.ts
+++ b/packages/platos-client/src/client.ts
@@ -26,6 +26,7 @@ import { ApprovalsApi } from "./apis/approvals.js";
 import { BudgetsApi } from "./apis/budgets.js";
 import { MonitoringApi } from "./apis/monitoring.js";
 import { ThreadsApi } from "./apis/threads.js";
+import { ToolsApi } from "./apis/tools.js";
 import { TriggerApi } from "./apis/trigger.js";
 import type {
   PlatosClientOptions,
@@ -76,6 +77,16 @@ export class PlatosClient {
   /** EOBD.85 — runs / traces / cost rollups. */
   readonly monitoring: MonitoringApi;
   /**
+   * Tool catalog (issue #2). Backs the dashboard's Tools tab + Matrix.
+   *   `client.tools.list({ category? })`
+   *   `client.tools.search(q, { limit?, entity? })`
+   *   `client.tools.matrix()`        — per-entity grid with health data
+   *   `client.tools.stats()`         — registry index counts
+   *   `client.tools.setEnabled(entityId, toolName, enabled)`
+   *   `client.tools.test(toolId, params)`
+   */
+  readonly tools: ToolsApi;
+  /**
    * Theme BGO — unified background-operations surface. Backed by the
    * trigger.dev engine; exposes `client.bgo.tasks` (catalog), `.runs`,
    * `.schedules`, `.batches`.
@@ -111,6 +122,7 @@ export class PlatosClient {
     this.approvals = new ApprovalsApi(this);
     this.budgets = new BudgetsApi(this);
     this.monitoring = new MonitoringApi(this);
+    this.tools = new ToolsApi(this);
     // Theme BGO — `bgo` is the canonical namespace; `trigger` is the
     // deprecated alias pointing at the same instance. Kept for one
     // release (see docs/BGO_RENAME.md).

--- a/packages/platos-client/src/index.ts
+++ b/packages/platos-client/src/index.ts
@@ -56,5 +56,15 @@ export type {
   TriggerHandle,
 } from "./apis/trigger.js";
 
+export type {
+  PlatosTool,
+  PlatosToolHealth,
+  PlatosToolMatrixRow,
+  PlatosToolStats,
+  PlatosToolListOptions,
+  PlatosToolSearchOptions,
+  PlatosToolTestResult,
+} from "./apis/tools.js";
+
 import { PlatosClient } from "./client.js";
 export default PlatosClient;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1959,6 +1959,31 @@ importers:
 
   packages/platos-embed: {}
 
+  packages/platos-react-widget:
+    dependencies:
+      '@platosdev/client':
+        specifier: workspace:*
+        version: link:../platos-client
+    devDependencies:
+      '@types/node':
+        specifier: 20.14.14
+        version: 20.14.14
+      '@types/react':
+        specifier: ^18.3.0
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: 5.5.4
+        version: 5.5.4
+
   packages/platos-token-mint:
     devDependencies:
       '@types/node':
@@ -8730,8 +8755,16 @@ packages:
   '@types/react-dom@18.2.7':
     resolution: {integrity: sha512-GRaAEriuT4zp9N4p1i8BDBYmEyfo+xQ3yHjJU4eiK5NDa1RmUZG+unZABUTK4/Ox/M+GaHwb6Ow8rUITrtjszA==}
 
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
   '@types/react@18.2.69':
     resolution: {integrity: sha512-W1HOMUWY/1Yyw0ba5TkCV+oqynRjG7BnteBB+B7JmAK7iw3l2SW+VGOxL+akPweix6jk2NNJtyJKpn4TkpfK3Q==}
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
   '@types/readable-stream@4.0.14':
     resolution: {integrity: sha512-xZn/AuUbCMShGsqH/ehZtGDwQtbx00M9rZ2ENLe4tOjFZ/JFeWMhEZkk2fEe1jAUqqEAURIkFJ7Az/go8mM1/w==}
@@ -10192,6 +10225,9 @@ packages:
 
   csstype@3.2.0:
     resolution: {integrity: sha512-si++xzRAY9iPp60roQiFta7OFbhrgvcthrhlNAGeQptSY25uJjkfUV8OArC3KLocB8JT8ohz+qgxWCmz8RhjIg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
@@ -14715,6 +14751,11 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.0.0-rc.1:
     resolution: {integrity: sha512-k8MfDX+4G+eaa1cXXI9QF4d+pQtYol3nx8vauqRWUEOPqC7NQn2qmEqUsLoSd28rrZUL+R3T2VC+kZ2Hyx1geQ==}
     peerDependencies:
@@ -15283,6 +15324,9 @@ packages:
 
   scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.25.0-rc.1:
     resolution: {integrity: sha512-fVinv2lXqYpKConAMdergOl5owd0rY1O4P/QTe0aWKCqGtu7VsCt1iqQFxSJtqK4Lci/upVSBpGwVC7eWcuS9Q==}
@@ -23547,7 +23591,7 @@ snapshots:
       html-to-text: 9.0.5
       js-beautify: 1.15.1
       react: 18.3.1
-      react-dom: 18.2.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
 
   '@react-email/row@0.0.7(react@18.3.1)':
     dependencies:
@@ -25654,11 +25698,20 @@ snapshots:
     dependencies:
       '@types/react': 18.2.69
 
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
   '@types/react@18.2.69':
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
       csstype: 3.2.0
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.5
+      csstype: 3.2.3
 
   '@types/readable-stream@4.0.14':
     dependencies:
@@ -27383,6 +27436,8 @@ snapshots:
       lru-cache: 11.3.5
 
   csstype@3.2.0: {}
+
+  csstype@3.2.3: {}
 
   csv-generate@3.4.3: {}
 
@@ -32795,6 +32850,12 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.0
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.0.0-rc.1(react@19.0.0-rc.1):
     dependencies:
       react: 19.0.0-rc.1
@@ -33554,6 +33615,10 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.23.0:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
 


### PR DESCRIPTION
## Summary

Bundles the fixes coming out of the 2026-05-19 `play.platos.dev` outage post-mortem. Three concerns, one ship:

1. **SDK transport bugs (JS + Python parity)** — closes #3
2. **ClickHouse hardening** — prevents the OOM-loop that took the box down on 2026-05-17
3. **`client.tools` namespace** — closes #2

Deferred: issue #1 (per-tool approval gate). That's a real feature touching the hot path of every dispatch — needs its own design + rollout discussion, not a bundled bugfix PR.

## Detail

### 1. `@platosdev/platools-sdk` + `platools` (Python) — closes #3

- **`websocketUrl()` / `_ws_url()` corrupted query strings.** Old impl did `f"{base}/ws/sdk"` (string concat). A URL like `wss://play.platos.dev/tools/sync?source=…&env=prod` ended up as `…?source=…&env=prod/ws/sdk`; the server then parsed `env="prod/ws/sdk"` and rejected with `could not resolve env for entity`. Fix splits at `?`, appends `/ws/sdk` to the path, re-attaches the query.
- **Welcome decoder accepts canonical `organization_id`.** The agent emits `organization_id` (plus `entity_id`, `environment_id`, `project_id`); older SDKs only decoded `org_id`, producing a noisy `platools received malformed message` warn on every connect. Decoder now accepts either shape and exposes both names.
- Tests: `tests/transport.test.ts` (TS), `tests/test_ws_url.py` + `tests/test_protocol.py` (Py). All 110 SDK tests pass.

### 2. ClickHouse hardening

The 2026-05-19 outage post-mortem (full chain documented separately) traced the visible CPU spike to ClickHouse's *own* `system.metric_log` crossing ~1.2 M rows / 300 MiB across 108 unmerged parts on 2026-05-17. The default `mem_limit: 1200m` was insufficient for a single merge to complete — server got OOM-killed inside its cgroup, lost merge progress, next merge needed more memory, killed again. The cycle ran **523 times in 12 days** before we intervened.

- **`POSTGRES_MEM_LIMIT` default 512m → 1g.** 512m OOMed under autovacuum on storm-bloated `PlatosToolDefinition`/`PlatosEntityToolMapping`.
- **`CLICKHOUSE_MEM_LIMIT` default 1200m → 4g.** Order-of-magnitude safer for the merge memory ceiling.
- **New `.platos/clickhouse/system-tables-ttl.xml`** mounted at `/etc/clickhouse-server/config.d/`. 7-day TTL on every `system.*_log` table that grows monotonically (`metric_log`, `asynchronous_metric_log`, `query_log`, `query_metric_log`, `latency_log`, `error_log`, `processors_profile_log`, `part_log`, `opentelemetry_span_log`). Prevents the exact accumulation pattern that triggered today's outage from recurring.

### 3. `client.tools` namespace — closes #2

Wraps the agent's `/api/v1/agent/tools*` REST surface (powers the dashboard's Tools tab + per-entity matrix UI). Before this, SDK consumers had to hand-roll fetch calls with the right scope + auth headers.

```ts
const tools = await client.tools.list({ category: "communication" });
const hits  = await client.tools.search("refund", { limit: 5 });
const grid  = await client.tools.matrix();        // includes health data
await client.tools.setEnabled("fandesk", "process_refund", false);
await client.tools.test("t1", { message: "hi" });
```

Exports: `PlatosTool`, `PlatosToolHealth`, `PlatosToolMatrixRow`, `PlatosToolStats`, `PlatosToolListOptions`, `PlatosToolSearchOptions`, `PlatosToolTestResult`. 7 unit tests in `src/__tests__/tools.test.ts`.

## Test plan

- [x] `pnpm run typecheck --filter @platosdev/platools-sdk --filter @platosdev/client` — clean
- [x] `cd packages/platools-js && pnpm run test --run` — 97 pass
- [x] `cd packages/platos-client && pnpm run test --run` — 15 pass (7 new)
- [x] `cd packages/platools-py && uv run --extra dev pytest tests/test_ws_url.py tests/test_protocol.py -q` — 13 pass
- [ ] Smoke test on `play.platos.dev`: rebuild webapp + agent images, restart with new TTL config + memory limits; verify cold-start storm-resistance.

## Publish plan

Post-merge:

- `pnpm changeset:version && pnpm changeset:release` — publishes `@platosdev/platools-sdk` (patch) and `@platosdev/client` (minor) to npm.
- `cd packages/platools-py && python -m build && twine upload dist/*` — publishes `platools` 0.2.1 to PyPI.
- SSH play.platos.dev VPS, `git pull origin main`, `docker compose -f docker-compose.platos.yml up -d --build` to rebuild images with new ClickHouse config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
