### PR TITLE
fix: post-mortem follow-ups — register rate-limit, approval-gate wiring, AI SDK warning, prune docs

### DIFF
--- a/.platos/clickhouse/apply-system-table-ttls.sh
+++ b/.platos/clickhouse/apply-system-table-ttls.sh
@@ -29,9 +29,25 @@ set -e
 
 echo "[apply-system-table-ttls] target=${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT} ttl=${TTL_DAYS}d"
 
-# Each system log table has a slightly different schema. Use
-# `IF EXISTS` so we don't fail on tables this build doesn't have, and
-# wrap each in its own statement so one failure doesn't abort the rest.
+# Each system log table has a slightly different schema. We can't use
+# `ALTER TABLE IF EXISTS` — ClickHouse rejects that form on MODIFY TTL —
+# so each ALTER runs in its own statement and the shell `||` swallows
+# failures (UNKNOWN_TABLE when the table isn't enabled on this build,
+# or column-mismatch when a table uses a non-default time column).
+run_alter() {
+  table="$1"
+  time_col="${2:-event_date}"
+  echo "[apply-system-table-ttls] ALTER system.${table} (TTL on ${time_col})"
+  clickhouse-client \
+    --host "${CLICKHOUSE_HOST}" \
+    --port "${CLICKHOUSE_PORT}" \
+    --user "${CLICKHOUSE_USER}" \
+    --password "${CLICKHOUSE_PASSWORD}" \
+    --query "ALTER TABLE system.${table} MODIFY TTL ${time_col} + INTERVAL ${TTL_DAYS} DAY DELETE" \
+    2>&1 | grep -v "^$" || echo "[apply-system-table-ttls]   (skipped: table may not exist on this build)"
+}
+
+# Tables that use `event_date` as the time column (the common case).
 for table in \
     metric_log \
     asynchronous_metric_log \
@@ -43,16 +59,12 @@ for table in \
     processors_profile_log \
     part_log \
     text_log \
-    trace_log \
-    opentelemetry_span_log; do
-  echo "[apply-system-table-ttls] ALTER system.${table}"
-  clickhouse-client \
-    --host "${CLICKHOUSE_HOST}" \
-    --port "${CLICKHOUSE_PORT}" \
-    --user "${CLICKHOUSE_USER}" \
-    --password "${CLICKHOUSE_PASSWORD}" \
-    --query "ALTER TABLE IF EXISTS system.${table} MODIFY TTL event_date + INTERVAL ${TTL_DAYS} DAY DELETE" \
-    || echo "[apply-system-table-ttls]   (skipped: table may use a different time column or not exist)"
+    trace_log; do
+  run_alter "${table}"
 done
+
+# `opentelemetry_span_log` uses `finish_date` instead of `event_date`
+# (the row is dated when the span finishes, not when the event starts).
+run_alter "opentelemetry_span_log" "finish_date"
 
 echo "[apply-system-table-ttls] done"

--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -4272,6 +4272,11 @@ export class AgentService {
       tools: subTools,
       stopWhen: stepCountIs(maxSteps),
       abortSignal: args.abortSignal,
+      // Sub-agent prompt rides in `messages[]` (not the top-level `system:`)
+      // specifically so we can attach `providerOptions.anthropic.cacheControl`
+      // on the system message (see subCacheOpts above). Suppresses the
+      // AI SDK v6 warning that nudges toward top-level `system:`.
+      allowSystemInMessages: true,
     });
     const subEndNs = Date.now() * 1_000_000;
 
@@ -5677,6 +5682,10 @@ export class AgentService {
         model,
         messages,
         tools,
+        // Main agent turn — system prompt rides in `messages[]` so
+        // per-message `providerOptions` (anthropic cacheControl) can be
+        // attached. Suppresses the AI SDK v6 warning nudge.
+        allowSystemInMessages: true,
         // AI SDK v6 — `maxSteps: N` removed; use `stopWhen` predicate.
         // `stepCountIs(N)` halts the tool-calling loop after N steps.
         stopWhen: stepCountIs(agentConfig.maxSteps),
@@ -6230,6 +6239,10 @@ export class AgentService {
             messages: attemptMessages as any,
             schema: turnSchema as any,
             abortSignal: turnOverrides?.abortSignal,
+            // System prompt rides inside `attemptMessages` rather than as a
+            // top-level `system:` so the retry path (line 6251) can keep
+            // it as a fixed first message while appending corrections.
+            allowSystemInMessages: true,
           });
           parsed = genResult.object;
           usage = genResult.usage;

--- a/apps/agent/src/tool-gateway/tool-gateway.module.ts
+++ b/apps/agent/src/tool-gateway/tool-gateway.module.ts
@@ -5,6 +5,19 @@ import { ToolRouterService } from "./tool-router.service"; // PIFSP-11
 import { ToolSyncWsService } from "./tool-sync-ws.service"; // canonical raw-WS service speaking platools protocol
 import { SchemaInjectorService } from "./schema-injector.service";
 import { MonitoringModule } from "../monitoring/monitoring.module";
+// Issue #1 — `MCPPermissionGatewayService` is also exported by
+// `McpPlatformModule`, but that module already imports
+// `ToolGatewayModule` (for ToolExecutorService). Importing it back
+// here would create a circular module graph that has to be broken
+// with `forwardRef` on both sides — risky for boot order.
+//
+// The service is stateless (the only constructor dep is PRISMA_TOKEN,
+// which is global via DatabaseModule), so registering it directly as
+// a provider here gives ToolExecutorService a working instance via DI
+// without any circular wiring. Two instances exist in the DI graph;
+// they have identical behaviour because the service holds no state
+// between calls.
+import { MCPPermissionGatewayService } from "../mcp-platform/permission-gateway.service";
 
 @Module({
   // Importing MonitoringModule makes SpansService (Theme E.1) and
@@ -17,6 +30,11 @@ import { MonitoringModule } from "../monitoring/monitoring.module";
     ToolRouterService,
     ToolSyncWsService,
     SchemaInjectorService,
+    // Issue #1 — see import comment above. Local registration avoids
+    // a circular import. When the gate is enabled via
+    // PLATOS_TOOL_DISPATCH_PERMISSION_GATE=1, ToolExecutorService now
+    // has a real `MCPPermissionGatewayService` to inject.
+    MCPPermissionGatewayService,
   ],
   exports: [
     ToolRegistryService,

--- a/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
+++ b/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
@@ -67,6 +67,20 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
   private connections = new Map<string, Conn>();
   private pending = new Map<string, PendingCall>(); // callId → pending promise
 
+  /**
+   * Per-(entity, env) sliding window of tool_register timestamps (ms).
+   * Used to throttle clients that re-register at storm rates — the
+   * 2026-05-19 outage was driven by a fandesk bridge with broken
+   * leader election that re-registered 403 tools every ~15 s for 7
+   * days, each registration costing ~200 KB JSON parse + 403 DB
+   * UPSERTs + BM25 rebuild. The bug lives in the client's leader
+   * election, but the server has no business letting one bad client
+   * monopolize CPU. Anything above PLATOS_TOOL_REGISTER_MAX_PER_MIN
+   * gets a `register_throttled` reply (with retry-after hint) instead
+   * of the full re-registration path.
+   */
+  private registerWindow = new Map<string, number[]>();
+
   constructor(
     @Inject(PRISMA_TOKEN) private readonly prisma: any,
     private readonly toolRegistry: ToolRegistryService,
@@ -392,6 +406,35 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
     this.logger.log(`[msg ${entityId}/${environmentId}] type=${msg.type}`);
     switch (msg.type) {
       case "tool_register": {
+        // Defense-in-depth (2026-05-19 post-mortem): cap re-registration
+        // frequency per (entity, env). Bug-free clients hit this once at
+        // startup and rarely after; the only callers that exceed the cap
+        // are buggy reconnect loops. Without this gate, one broken
+        // client can monopolize the agent's CPU.
+        const rateLimitKey = this.connKey(entityId, environmentId);
+        const nowMs = Date.now();
+        const maxPerMin = Number(
+          process.env.PLATOS_TOOL_REGISTER_MAX_PER_MIN ?? "6",
+        );
+        const windowMs = 60_000;
+        const recent = (this.registerWindow.get(rateLimitKey) ?? []).filter(
+          (ts) => nowMs - ts < windowMs,
+        );
+        if (recent.length >= maxPerMin) {
+          const retryAfterMs = windowMs - (nowMs - recent[0]!);
+          this.logger.warn(
+            `entity ${entityId}/${environmentId}: tool_register throttled (${recent.length}/${maxPerMin} per min) — retry-after ${Math.ceil(retryAfterMs / 1000)}s`,
+          );
+          this.send(ws, {
+            type: "register_throttled",
+            error: `tool_register exceeded ${maxPerMin}/min; retry after ${Math.ceil(retryAfterMs / 1000)}s`,
+            retry_after_ms: retryAfterMs,
+          });
+          return;
+        }
+        recent.push(nowMs);
+        this.registerWindow.set(rateLimitKey, recent);
+
         const tools = Array.isArray(msg.tools) ? msg.tools : [];
         const normalized: ToolSchema[] = tools.map((t: any) => ({
           name: t.name,

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -640,6 +640,32 @@ Before going live:
 - [ ] **OTEL traces include no raw provider keys.** The SDK sanitizers redact `Authorization`, `x-api-key`, etc. Verify your collector isn't logging request bodies.
 - [ ] **Audit logs.** Enable the audit-log feature flag for `Settings → Audit Log` to track sensitive admin actions.
 
+## Quarterly maintenance
+
+A short list of host-level chores that prevent slow accumulation from biting you. Calendar these once a quarter; each one is a single command.
+
+### `docker builder prune` — reclaim build-cache disk
+
+Every `docker compose build` (deploys, image rebuilds, dependency bumps) leaves cached layers in `/var/lib/docker/buildkit`. They accumulate forever — on the reference deploy we found 149.7 GB of stale build cache across 566 entries (out of a 193 GB disk) after ~16 days of normal operation. The cache is **never load-bearing at runtime**; pruning is always safe.
+
+```sh
+sudo docker system df                # see what's reclaimable
+sudo docker builder prune -af        # reclaim everything
+```
+
+This recovers tens to hundreds of GB on a long-lived host. Run before every dependency upgrade — fresh builds are faster anyway when the cache is clean and small.
+
+Also worth checking opportunistically:
+
+```sh
+sudo docker image prune -af          # untagged image layers from old image versions
+df -h /                              # spot inode pressure ("Use%" climbing above 75%)
+```
+
+### ClickHouse system-table sanity (operationally automatic)
+
+Since `docker-compose.platos.yml` ships a `clickhouse-ttl-apply` sidecar that runs on every stack boot, ClickHouse's own observability tables (`system.metric_log`, `system.asynchronous_metric_log`, etc.) cannot grow past 7 days. There's nothing to maintain manually. If you ever bump the ClickHouse major version, re-run the sidecar once after the upgrade in case a new system log table got added that the script doesn't yet know about — the script's `run_alter` helper logs each table it touches.
+
 ## Upgrades
 
 - Pin a version (`PLATOS_VERSION=0.5.2`).


### PR DESCRIPTION
Closes 4 of the 5 follow-ups listed in #9. The 5th (stream-aware approval pause flow) is multi-day work and remains the sole open item in #9.

## Agent-side `tool_register` rate-limit (defense-in-depth)

`tool-sync-ws.service.ts` now caps re-registrations per (entity, env) at `PLATOS_TOOL_REGISTER_MAX_PER_MIN` (default 6). Above that, the server replies with `register_throttled` + `retry_after_ms` and skips the expensive 196 KB parse + per-tool UPSERT + BM25 rebuild. The fandesk supersede storm hit ~one re-registration every 15 s; this cap fails fast on the same workload. Bug-free clients touch this once at startup — no production caller will trip it.

## ToolGateway wiring for the approval gate (#1 scaffold)

`ToolGatewayModule` now registers `MCPPermissionGatewayService` as a local provider. Going through `McpPlatformModule` would create a circular module graph (it already imports `ToolGatewayModule`) that needs `forwardRef` on both sides — risky for boot order. Direct local registration works because the service is stateless. With this in place, `PLATOS_TOOL_DISPATCH_PERMISSION_GATE=1` actually runs the resolver instead of silently no-op'ing on the missing injection.

## AI SDK v6 `allowSystemInMessages` warning suppression

Three call sites in `agent.service.ts` ride the system prompt inside `messages[]` rather than the top-level `system:` option — intentional, so per-message `providerOptions.anthropic.cacheControl` can be attached. AI SDK v6 nags every call with a warning unless the flag is explicitly set. All three now pass `allowSystemInMessages: true` with comments explaining why the per-message shape is load-bearing.

## `docker builder prune` quarterly maintenance

`docs/self-hosting.md` now has a "Quarterly maintenance" section documenting the build-cache reclamation (the 2026-05-19 audit found 149.7 GB of stale build cache on a 193 GB disk; pruning recovered 66 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)