### PR TITLE
fix(agent, webapp): sane defaults — entity_ids opt-in + public-docs SSG headroom

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -4584,14 +4584,15 @@ export class AgentService {
       const tlbGate: { entityIdsRequired?: boolean } =
         (agentConfig as { toolsBlockConfig?: { entityIdsRequired?: boolean } })
           .toolsBlockConfig ?? {};
-      let mandated = tlbGate.entityIdsRequired;
-      if (mandated === undefined) {
-        const visible = this.toolRouter.visibleEntitiesForAgent(scope, {
-          enabledOnly: true,
-        });
-        mandated = visible.length > 1;
-      }
-      if (mandated === true) {
+      // PIFSP-11.1 — default is now explicit opt-in. Previously we auto-
+      // enforced whenever `visibleEntitiesForAgent` returned >1, which
+      // surprised single-purpose agents the moment any second entity (a
+      // test backend, a sample one) appeared in the project. Multi-tenant
+      // operators who actually need narrowing set `entityIdsRequired: true`
+      // explicitly; the absence of that opt-in means "this agent doesn't
+      // care about per-turn entity narrowing."
+      const mandated = tlbGate.entityIdsRequired === true;
+      if (mandated) {
         const entityIdsKey =
           (scope.contextMapping as ContextMapping | null | undefined)
             ?.entityIdsKey || "entity_ids";

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -343,6 +343,12 @@ const EnvironmentSchema = z
     API_RATE_LIMIT_JWT_WINDOW: z.string().default("1m"),
     API_RATE_LIMIT_JWT_TOKENS: z.coerce.number().int().default(60),
 
+    // Public docs API (/api/v1/public/*). Has to absorb a marketing-site
+    // SSG that fans out ~250 requests from one Vercel build IP — the old
+    // 60/min default 429'd the build reliably.
+    PUBLIC_DOCS_RATE_LIMIT_WINDOW: z.string().default("60 s"),
+    PUBLIC_DOCS_RATE_LIMIT_TOKENS: z.coerce.number().int().default(600),
+
     //v3
     PROVIDER_SECRET: z.string().default("provider-secret"),
     COORDINATOR_SECRET: z.string().default("coordinator-secret"),

--- a/apps/webapp/app/services/publicDocs.server.ts
+++ b/apps/webapp/app/services/publicDocs.server.ts
@@ -61,7 +61,11 @@ export function getPublicDocsRepository(): DocRepository {
 }
 
 /**
- * Rate-limit guard for public docs endpoints. 60 req / 60s per IP.
+ * Rate-limit guard for public docs endpoints. Tokens + window come from
+ * PUBLIC_DOCS_RATE_LIMIT_TOKENS / PUBLIC_DOCS_RATE_LIMIT_WINDOW so a
+ * deployment that fronts SSG builds (platos.dev → play.platos.dev fans
+ * out ~250 requests from one Vercel build IP) can raise the cap without
+ * a code change. Default 600 / 60s.
  *
  * Reuses the existing Redis rate-limit infra (`createRedisRateLimitClient`)
  * so we share infra with the rest of the webapp's rate limits — keys are
@@ -78,7 +82,10 @@ function getLimiter(): Ratelimit {
       tlsDisabled: env.RATE_LIMIT_REDIS_TLS_DISABLED === "true",
       clusterMode: env.RATE_LIMIT_REDIS_CLUSTER_MODE_ENABLED === "1",
     }),
-    limiter: Ratelimit.slidingWindow(60, "60 s"),
+    limiter: Ratelimit.slidingWindow(
+      env.PUBLIC_DOCS_RATE_LIMIT_TOKENS,
+      env.PUBLIC_DOCS_RATE_LIMIT_WINDOW as `${number} ${"s" | "ms" | "m" | "h" | "d"}`,
+    ),
     prefix: "ratelimit:public-docs",
     analytics: false,
     ephemeralCache: new Map(),


### PR DESCRIPTION
## Summary

Two defaults that surprised the `play.platos.dev` deploy this week — both made code-permanent here so the live DB tweak and the SSG rate-limit shrug aren't needed again.

- **PIFSP-11 `entity_ids` mandate is now explicit opt-in.** Previously auto-enforced whenever an agent could see 2+ entities in its scope. The docs agent (`Platos Docs` on `play.platos.dev`) broke the moment `platos-test-entity` joined the project — every turn aborted with `ENTITY_IDS_REQUIRED` before any tokens streamed, even though the docs agent never uses entity-scoped tools. Now `undefined` means "no mandate"; operators who actually need per-turn narrowing opt in with `entityIdsRequired: true`. The docs at `content/docs/context.md` already described the explicit-flag model — runtime now matches.
- **Public-docs API rate limit raised to 600/60s default, env-driven.** Hardcoded `60/60s/IP` was below the floor needed for the marketing-site SSG that fans out ~250 requests from one Vercel build IP. Vercel builds were 429ing reliably. Pulled out to `PUBLIC_DOCS_RATE_LIMIT_TOKENS` / `PUBLIC_DOCS_RATE_LIMIT_WINDOW`. Public read-only catalog data is also cached 10 min client-side, so the abuse surface stays small.

No DB migration. No new env var is required (defaults are safe).

## Test plan
- [ ] `pnpm run typecheck --filter platos-agent` passes
- [ ] `pnpm run typecheck --filter webapp` no NEW errors (the `server.ts:240` Socket.IO type errors are pre-existing on `main`)
- [ ] Deploy to `play.platos.dev`: docs agent answers a chat-widget turn end-to-end without `ENTITY_IDS_REQUIRED` in `docker logs platos-agent-1`
- [ ] `platos.dev` Vercel build prerenders all 105 doc pages without 429

🤖 Generated with [Claude Code](https://claude.com/claude-code)