### PR TITLE
fix(agent, webapp): guard promptBlocks/dynamicBlocks against double-encoded writes

### DIFF
--- a/apps/agent/src/agent-runtime/agent-crud.service.ts
+++ b/apps/agent/src/agent-runtime/agent-crud.service.ts
@@ -25,6 +25,39 @@ export interface DynamicBlockTemplate {
 }
 
 /**
+ * PIFSP-19 — coerce a block-list field (`promptBlocks` / `dynamicBlocks`) to a
+ * JSON array (or null) before it is persisted into a Prisma `Json?` column.
+ *
+ * The contract for these columns is "array of block objects". Postgres `jsonb`
+ * also accepts a bare string scalar, so a client that double-encodes the field
+ * — sends `JSON.stringify(blocks)` instead of `blocks` — lands a *string* in
+ * the column and Prisma stores it verbatim. Every downstream reader assumes an
+ * array:
+ *   - the dashboard does `blocks.map(...)` → `"...".map is not a function`
+ *     (minified: `z.map is not a function`), crashing the agent detail page;
+ *   - the runtime guards with `Array.isArray(...)`, so a string silently drops
+ *     every dynamic block and the agent answers ungrounded (no {{vars}}).
+ *
+ * One bad write therefore corrupts the row permanently. This normalizes at the
+ * write boundary: parse-if-string, require-array, drop-to-null otherwise. It is
+ * idempotent on already-correct arrays.
+ */
+function coerceBlockList(value: unknown): unknown[] | null {
+  if (value === undefined || value === null) return null;
+  let v: unknown = value;
+  if (typeof v === "string") {
+    const trimmed = v.trim();
+    if (trimmed === "") return null;
+    try {
+      v = JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  return Array.isArray(v) ? v : null;
+}
+
+/**
  * TL.2 — display-mode keys. Drives how the main-LLM's tool layer is
  * rendered each turn. Values map 1:1 to `buildMetaTools()` branches:
  *
@@ -358,8 +391,8 @@ export class AgentCrudService {
       model: agent.model,
       modelRoutes: (agent.modelRoutes as ModelRoute[] | null) ?? null,
       systemPrompt: agent.systemPrompt ?? null,
-      promptBlocks: (agent.promptBlocks as PromptBlock[] | null) ?? null,
-      dynamicBlocks: (agent.dynamicBlocks as DynamicBlockTemplate[] | null) ?? null,
+      promptBlocks: coerceBlockList(agent.promptBlocks) as PromptBlock[] | null,
+      dynamicBlocks: coerceBlockList(agent.dynamicBlocks) as DynamicBlockTemplate[] | null,
       maxSteps: agent.maxSteps ?? 20,
       contextLimit: agent.contextLimit ?? 20,
       historyMode: agent.historyMode ?? "rolling",
@@ -449,8 +482,8 @@ export class AgentCrudService {
         slug,
         model: dto.model,
         systemPrompt: dto.systemPrompt || derivedSystemPrompt || null,
-        promptBlocks: (dto.promptBlocks as any) || null,
-        dynamicBlocks: (dto.dynamicBlocks as any) || null,
+        promptBlocks: coerceBlockList(dto.promptBlocks) as any,
+        dynamicBlocks: coerceBlockList(dto.dynamicBlocks) as any,
         maxSteps: dto.maxSteps || 20,
         contextLimit: dto.contextLimit ?? 20,
         historyMode: dto.historyMode || "rolling",
@@ -592,8 +625,8 @@ export class AgentCrudService {
         ...(dto.name !== undefined && { name: dto.name }),
         ...(dto.model !== undefined && { model: dto.model }),
         ...(updateSystemPrompt !== undefined && { systemPrompt: updateSystemPrompt }),
-        ...(dto.promptBlocks !== undefined && { promptBlocks: (dto.promptBlocks as any) }),
-        ...(dto.dynamicBlocks !== undefined && { dynamicBlocks: (dto.dynamicBlocks as any) }),
+        ...(dto.promptBlocks !== undefined && { promptBlocks: coerceBlockList(dto.promptBlocks) as any }),
+        ...(dto.dynamicBlocks !== undefined && { dynamicBlocks: coerceBlockList(dto.dynamicBlocks) as any }),
         ...(dto.maxSteps !== undefined && { maxSteps: dto.maxSteps }),
         ...(dto.contextLimit !== undefined && { contextLimit: dto.contextLimit }),
         ...(dto.historyMode !== undefined && { historyMode: dto.historyMode }),
@@ -823,8 +856,8 @@ export class AgentCrudService {
       data: {
         model: snap.model,
         systemPrompt: snap.systemPrompt,
-        promptBlocks: (snap.promptBlocks as any) ?? null,
-        dynamicBlocks: (snap.dynamicBlocks as any) ?? null,
+        promptBlocks: coerceBlockList(snap.promptBlocks) as any,
+        dynamicBlocks: coerceBlockList(snap.dynamicBlocks) as any,
         maxSteps: snap.maxSteps,
         contextLimit: snap.contextLimit,
         historyMode: snap.historyMode,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
@@ -70,6 +70,27 @@ function scopeHeaders(scope: {
   };
 }
 
+/**
+ * PIFSP-19 — read-side defense for block-list columns (promptBlocks /
+ * dynamicBlocks). These are array columns, but a double-encoded write (a client
+ * sending `JSON.stringify(blocks)`) can land a string scalar. A truthy string
+ * slips past `|| []` and the editor then calls `.map` on it
+ * (`z.map is not a function`), crashing the agent detail page. Parse-if-string,
+ * require-array, fall back to []. Belt to the write-path braces in
+ * agent-crud.service.ts.
+ */
+function asBlockArray<T>(raw: unknown): T[] {
+  let v: unknown = raw;
+  if (typeof v === "string") {
+    try {
+      v = JSON.parse(v);
+    } catch {
+      return [];
+    }
+  }
+  return Array.isArray(v) ? (v as T[]) : [];
+}
+
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const userId = await requireUserId(request);
   const agentId = params.agentId!;
@@ -696,7 +717,7 @@ export default function AgentDetailPage() {
   );
   const [dynamicBlocks, setDynamicBlocks] = useState<
     Array<{ key: string; name: string; defaultContent: string; description?: string }>
-  >(((agent as any).dynamicBlocks as any[]) || []);
+  >(asBlockArray((agent as any).dynamicBlocks));
   // Theme G.7 — local state for the feature flags editor. Seed from the
   // saved value; the PATCH action replaces the whole map on submit.
   const initialFlags = useMemo<Record<string, boolean>>(

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.context/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.context/route.tsx
@@ -55,6 +55,26 @@ type DynamicBlock = {
   description?: string;
 };
 
+/**
+ * PIFSP-19 — read-side defense. `dynamicBlocks` is an array column, but a
+ * double-encoded write (a client sending `JSON.stringify(blocks)`) can land a
+ * string scalar in the JSON column. A truthy string slips past `?? []` and the
+ * editor then calls `.map` on it (`z.map is not a function`), crashing the
+ * page. Parse-if-string, require-array, fall back to []. Belt to the write-path
+ * braces in agent-crud.service.ts.
+ */
+function asBlockArray(raw: unknown): DynamicBlock[] {
+  let v: unknown = raw;
+  if (typeof v === "string") {
+    try {
+      v = JSON.parse(v);
+    } catch {
+      return [];
+    }
+  }
+  return Array.isArray(v) ? (v as DynamicBlock[]) : [];
+}
+
 // ─── Loader ───────────────────────────────────────────────────────────────────
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
@@ -79,7 +99,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   return typedjson({
     agentName: agentRow?.name ?? agentId,
     contextMapping: (agentRow?.contextMapping as ContextMapping | null) ?? null,
-    dynamicBlocks: (agentRow?.dynamicBlocks as DynamicBlock[] | null) ?? [],
+    dynamicBlocks: asBlockArray(agentRow?.dynamicBlocks),
     scope: {
       organizationId: project.organizationId,
       projectId: project.id,


### PR DESCRIPTION
## What broke

`PlatosAgent.promptBlocks` and `.dynamicBlocks` are array-shaped `Json?` columns. Postgres `jsonb` also accepts a bare string scalar, so a client that **double-encodes** the field (sends `JSON.stringify(blocks)` instead of `blocks`) lands a *string* in the column and Prisma persists it verbatim. One bad write corrupts the row permanently, with two faces:

- **Dashboard crash.** The agent detail page + Context tab call `blocks.map(...)`. A truthy string slips past `|| []` / `?? []`, so `.map` runs on a string → `"...".map is not a function` → minified to **`z.map is not a function`**.
- **Ungrounded responses.** The runtime guards with `Array.isArray(...)`, so a string silently drops *every* dynamic block. The agent answers with its `{{context}}` variables unresolved (no `{{seed_brain}}`, etc.) — looks like a bad model, is actually a config-shape bug.

Hit **Demo Walle** on `play.platos.dev` (its `dynamicBlocks` was stored as a string; the other six agents in the project were fine). Live data already repaired (agent row + 2 corrupt version snapshots, transactionally, guarded on `jsonb_typeof = 'string'`). This PR stops recurrence.

## Fix

**Write-path (cause)** — `apps/agent/src/agent-runtime/agent-crud.service.ts`:
- `coerceBlockList()`: parse-if-string, require-array, drop-to-null otherwise. Idempotent on correct arrays.
- Applied at all four persist sites: `createAgent`, `updateAgent`, `restoreVersion`, and `buildSnapshot` (so a corrupt live row can't be re-snapshotted as a string).

**Read-path (crash surface)** — webapp agent routes:
- `asBlockArray()` in the `$agentId._index` editor state and the `$agentId.context` loader: parse-if-string, require-array, fall back to `[]`. Cheap insurance so a malformed row can never crash the page again.

No schema change, no migration. Runtime read paths already `Array.isArray`-guard, so responses are covered by the write-path fix plus the data repair.

## Test plan
- [x] `pnpm run typecheck --filter platos-agent` — clean
- [x] `pnpm run typecheck --filter webapp` — no new errors (pre-existing `server.ts:240` Socket.IO errors only)
- [ ] On `play.platos.dev`: Demo Walle detail page + Context tab load without `z.map` crash
- [ ] Demo Walle answers a turn citing brain facts (`{{seed_brain}}` resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)