### PR TITLE
fix(agent): complete block-shape hardening sweep (PIFSP-19 follow-up)

### DIFF
--- a/apps/agent/src/agent-runtime/agent-task.service.ts
+++ b/apps/agent/src/agent-runtime/agent-task.service.ts
@@ -644,9 +644,14 @@ export class AgentTaskService {
         }
       } catch { /* swallow — missing memory rows shouldn't block a turn */ }
     }
-    // Merge caller-provided dynamic blocks against declared templates
+    // Merge caller-provided dynamic blocks against declared templates.
+    // PIFSP-19 — guard the log line with Array.isArray too: dynamicBlocks is a
+    // Json? column that can hold a string scalar if a client double-encodes it.
+    // A bare truthiness check lets a string through, and `.map` on a string
+    // throws ("...".map is not a function). The dispatch loop below already
+    // guards; this log line must match or it crashes the turn before we reach it.
     console.log(
-      `[agent.task] dynamicBlocks: ${config.dynamicBlocks ? `${(config.dynamicBlocks as any[]).length} block(s): ${(config.dynamicBlocks as any[]).map((b: any) => b.key).join(", ")}` : "none"}`,
+      `[agent.task] dynamicBlocks: ${Array.isArray(config.dynamicBlocks) ? `${config.dynamicBlocks.length} block(s): ${config.dynamicBlocks.map((b: any) => b.key).join(", ")}` : "none"}`,
     );
     if (config.dynamicBlocks && Array.isArray(config.dynamicBlocks)) {
       for (const template of config.dynamicBlocks) {

--- a/apps/agent/src/mcp-platform/tools/reflection.ts
+++ b/apps/agent/src/mcp-platform/tools/reflection.ts
@@ -703,8 +703,12 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
 
         // Prompt blocks — array-of-objects, compared positionally. We compute
         // per-block equality + flag added / removed tail entries.
-        const pbA = (a.promptBlocks ?? []) as unknown as Array<Record<string, unknown>>;
-        const pbB = (b.promptBlocks ?? []) as unknown as Array<Record<string, unknown>>;
+        // PIFSP-19 — Array.isArray, not `?? []`: promptBlocks is a Json? column
+        // that can hold a string scalar (double-encoded write). `?? []` only
+        // catches null/undefined, so a string would slip through and get
+        // iterated character-by-character, producing a garbage diff.
+        const pbA = Array.isArray(a.promptBlocks) ? (a.promptBlocks as Array<Record<string, unknown>>) : [];
+        const pbB = Array.isArray(b.promptBlocks) ? (b.promptBlocks as Array<Record<string, unknown>>) : [];
         const maxBlocks = Math.max(pbA.length, pbB.length);
         const promptBlocksDiff = Array.from({ length: maxBlocks }, (_, i) => {
           const left = pbA[i] ?? null;


### PR DESCRIPTION
## Summary

Robustness-audit follow-up to #14. A sweep over every reader of the array-shaped `Json?` columns (`promptBlocks` / `dynamicBlocks`) found two stragglers of the exact class #14 fixed — a column that can hold a string scalar (double-encoded write) being read as an array without an `Array.isArray` guard.

- **`agent-task.service.ts:649`** — the per-turn `dynamicBlocks` log line did `(config.dynamicBlocks as any[]).length` + `.map()` behind only a truthiness check. A string crashes `.map` *here*, before the correctly-guarded dispatch loop on the very next line runs. **Hot path — logs on every turn.** Now `Array.isArray`-guarded.
- **`reflection.ts:706`** — the MCP `agent_diff` tool coalesced `promptBlocks` with `?? []` (only catches null/undefined). A string slips through and gets iterated character-by-character → garbage diff. Now `Array.isArray`-guarded.

## Verification
- `pnpm run typecheck --filter platos-agent` — clean (6/6).
- Audited the other audit hits and rejected the false positives: the `ws.on("close")` handler's only await is already in try/catch; the OAuth `Number(parsed.ts)` runs after HMAC verify (not forgeable). Those are not in this PR.

## Not in this PR (flagged separately)
- OAuth entity-by-slug lookup (`oauth.controller.ts:64`) resolves by slug without org/project — a **multi-tenant slug-uniqueness design question**, not a surgical fix (these are public discovery endpoints with no scope in the request). Needs a design call.
- `cross-scope-isolation.test.ts` has 8/10 cases `it.skip()` — real coverage gap, separate effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)