### PR TITLE
fix(agent): restore double-cast in reflection agent_diff promptBlocks

### DIFF
--- a/apps/agent/src/mcp-platform/tools/reflection.ts
+++ b/apps/agent/src/mcp-platform/tools/reflection.ts
@@ -707,8 +707,8 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
         // that can hold a string scalar (double-encoded write). `?? []` only
         // catches null/undefined, so a string would slip through and get
         // iterated character-by-character, producing a garbage diff.
-        const pbA = Array.isArray(a.promptBlocks) ? (a.promptBlocks as Array<Record<string, unknown>>) : [];
-        const pbB = Array.isArray(b.promptBlocks) ? (b.promptBlocks as Array<Record<string, unknown>>) : [];
+        const pbA = (Array.isArray(a.promptBlocks) ? a.promptBlocks : []) as unknown as Array<Record<string, unknown>>;
+        const pbB = (Array.isArray(b.promptBlocks) ? b.promptBlocks : []) as unknown as Array<Record<string, unknown>>;
         const maxBlocks = Math.max(pbA.length, pbB.length);
         const promptBlocksDiff = Array.from({ length: maxBlocks }, (_, i) => {
           const left = pbA[i] ?? null;


### PR DESCRIPTION
Follow-up to #15. The `Array.isArray` guard added there dropped the `as unknown as` double-cast the original line used, producing **TS2352** (`PromptBlock[]` does not overlap `Record<string, unknown>[]`). `nest build` runs `tsc`, so #15 broke the agent Docker build (caught before it reached a running container — prod stayed on the prior image).

Guard kept, cast restored:
```ts
const pbA = (Array.isArray(a.promptBlocks) ? a.promptBlocks : []) as unknown as Array<Record<string, unknown>>;
```

`pnpm run typecheck --filter platos-agent` — clean (6/6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)