### PR TITLE
ci(deploy): build images off-box on GHCR, pull-only on the VPS

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,84 @@
+name: Build & publish container images
+
+# Tier-1 robustness: build the agent + webapp images on GitHub's runners and
+# push them to GHCR, so the production VPS NEVER runs `nest build` / `tsc`
+# itself. Compiling on the 4-vCPU reference box spiked load average past 40 and
+# degraded the live service (the same Hostinger-throttle class as the May 2026
+# outage). With this workflow the VPS only ever `docker compose pull`s a
+# pre-built, immutable, SHA-tagged image. See docs/deployment/off-box-build.md.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/agent/**"
+      - "apps/webapp/**"
+      - "packages/**"
+      - "internal-packages/**"
+      - "apps/agent/Dockerfile"
+      - "apps/webapp/Dockerfile.platos"
+      - ".github/workflows/build-images.yml"
+  workflow_dispatch: {} # allow manual rebuilds without a code change
+
+concurrency:
+  # One build per ref at a time; a newer push cancels an in-flight build so we
+  # never publish a stale :latest after a newer commit landed.
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: agent
+            image: platos-agent
+            dockerfile: apps/agent/Dockerfile
+          - name: webapp
+            image: platos-webapp
+            dockerfile: apps/webapp/Dockerfile.platos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=long
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GitHub Actions layer cache keeps rebuilds fast without a self-hosted
+          # cache. mode=max caches intermediate stages too (the pnpm/tsc layers).
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          provenance: false

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,37 @@
+# Production deploy override — pull pre-built images, never build on the box.
+#
+# Usage on the VPS:
+#   docker compose -f docker-compose.platos.yml -f docker-compose.deploy.yml \
+#     --profile app pull agent webapp worker
+#   docker compose -f docker-compose.platos.yml -f docker-compose.deploy.yml \
+#     --profile app up -d
+#
+# This override REPLACES the `build:` blocks from docker-compose.platos.yml with
+# registry image refs from GHCR (published by .github/workflows/build-images.yml).
+# Compose ignores `build:` when you don't pass `build`, but pinning `image:` to a
+# registry path + a specific tag guarantees `pull` fetches the off-box artifact
+# instead of ever compiling locally.
+#
+# PLATOS_IMAGE_TAG defaults to `latest`; pin it to `sha-<commit>` for an
+# immutable, rollback-friendly deploy (recommended for prod):
+#   PLATOS_IMAGE_TAG=sha-<full-commit-sha> docker compose ... pull ...
+#
+# PLATOS_IMAGE_NAMESPACE is the GHCR owner (default: winsenlabs).
+
+services:
+  agent:
+    image: ghcr.io/${PLATOS_IMAGE_NAMESPACE:-winsenlabs}/platos-agent:${PLATOS_IMAGE_TAG:-latest}
+    # Drop the build context so `docker compose build` is a no-op here and a
+    # stray build can never compile on the prod box again.
+    build: !reset null
+    pull_policy: always
+
+  worker:
+    image: ghcr.io/${PLATOS_IMAGE_NAMESPACE:-winsenlabs}/platos-agent:${PLATOS_IMAGE_TAG:-latest}
+    build: !reset null
+    pull_policy: always
+
+  webapp:
+    image: ghcr.io/${PLATOS_IMAGE_NAMESPACE:-winsenlabs}/platos-webapp:${PLATOS_IMAGE_TAG:-latest}
+    build: !reset null
+    pull_policy: always

--- a/docs/deployment/off-box-build.md
+++ b/docs/deployment/off-box-build.md
@@ -1,0 +1,85 @@
+# Off-box builds — never compile on the production VPS
+
+## Why
+
+The reference deploy (`play.platos.dev`) is a 4-vCPU / 16 GB Hostinger VPS. The
+original deploy flow was:
+
+```bash
+# on the VPS
+git pull origin main
+docker compose -f docker-compose.platos.yml build agent webapp
+docker compose -f docker-compose.platos.yml up -d agent webapp
+```
+
+That `build` step runs `nest build` / `tsc` for the agent and the full Remix +
+Vite bundle for the webapp **on the production box, while it is also serving
+traffic**. On 4 vCPUs this spikes the load average past 40, and the host's
+fair-use CPU throttle kicks in — the same failure class as the May 2026 outage.
+`/login` latency went from sub-second to 30+ seconds during a build. Compiling
+on the box you are trying to keep up is the definition of brittle.
+
+## The fix: build on CI, pull on the box
+
+`.github/workflows/build-images.yml` builds both images on GitHub's runners on
+every push to `main` (and on demand via *workflow_dispatch*), then pushes them
+to GHCR:
+
+- `ghcr.io/winsenlabs/platos-agent:latest` + `:sha-<commit>`
+- `ghcr.io/winsenlabs/platos-webapp:latest` + `:sha-<commit>`
+
+The VPS never compiles. It only ever **pulls** a finished, immutable image.
+
+## Deploying
+
+`docker-compose.deploy.yml` is an override that swaps the `build:` blocks for
+GHCR `image:` refs. Use `scripts/deploy-platos.sh` (run on the VPS, from the
+repo root, e.g. `/opt/platos`):
+
+```bash
+scripts/deploy-platos.sh              # deploy :latest
+scripts/deploy-platos.sh sha-<commit> # deploy a pinned, rollback-friendly tag
+```
+
+The script:
+
+1. **Refuses to deploy if 1-min load > 8.0** — never stack a recreate on an
+   already-hot box.
+2. `git pull`s (for compose files + migrations only — *not* to build).
+3. `docker compose ... pull agent webapp worker` — fetches the off-box images.
+4. Runs `migrations-init` one-shot.
+5. Recreates only the app services (`--no-deps`), leaving Postgres / ClickHouse
+   / Redis / MinIO untouched.
+6. Waits for `healthy` and prints final load + status.
+
+### One-time VPS setup
+
+GHCR images published by this repo are public, so no login is needed to pull.
+If they are ever made private:
+
+```bash
+echo "$GITHUB_PAT" | docker login ghcr.io -u <user> --password-stdin
+```
+
+### Rolling back
+
+Every build is tagged `sha-<commit>`. To roll back, deploy the previous SHA:
+
+```bash
+scripts/deploy-platos.sh sha-<previous-commit>
+```
+
+No rebuild, no compile — just pull the older image and recreate. Seconds, not
+minutes, and it cannot fail a type-check because it was already built green.
+
+## Emergency: a build is crushing the box right now
+
+If someone runs the old `docker compose build` on the VPS and load climbs:
+
+```bash
+pkill -f buildx; pkill -f "nest build"; pkill -f tsc
+```
+
+The Docker daemon finishes or abandons the build server-side and load drains on
+its own within a few minutes. Do **not** open more SSH sessions to "check" — each
+one competes for the CPU the box needs to recover. One probe, then wait.

--- a/scripts/deploy-platos.sh
+++ b/scripts/deploy-platos.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Off-box deploy for play.platos.dev (and any compose-based Platos host).
+#
+# Tier-1 robustness: this NEVER builds on the box. It pulls pre-built images
+# from GHCR (published by .github/workflows/build-images.yml) and restarts the
+# app services. Building `nest build` / `tsc` on the 4-vCPU reference VPS spiked
+# load past 40 and degraded the live service — the same throttle class as the
+# May 2026 outage. Pull-only deploys keep the box responsive throughout.
+#
+# Usage (run ON the VPS, from the repo root, e.g. /opt/platos):
+#   scripts/deploy-platos.sh                 # deploy :latest
+#   scripts/deploy-platos.sh sha-<commit>    # deploy a pinned, immutable tag
+#
+# Env:
+#   PLATOS_IMAGE_NAMESPACE  GHCR owner (default: winsenlabs)
+#   COMPOSE_FILES           override the -f chain if your layout differs
+set -euo pipefail
+
+TAG="${1:-latest}"
+export PLATOS_IMAGE_TAG="$TAG"
+export PLATOS_IMAGE_NAMESPACE="${PLATOS_IMAGE_NAMESPACE:-winsenlabs}"
+
+COMPOSE_FILES="${COMPOSE_FILES:--f docker-compose.platos.yml -f docker-compose.deploy.yml}"
+SERVICES="agent webapp worker"
+
+say() { printf '\n\033[1;36m== %s\033[0m\n' "$*"; }
+
+say "Pre-flight: current load + container health"
+cat /proc/loadavg
+docker compose $COMPOSE_FILES ps --format '{{.Name}}\t{{.Status}}' 2>/dev/null || true
+
+# Refuse to deploy onto an already-saturated box — pulling + recreating under
+# load is how a slow box becomes a down box. 8.0 is 2x the 4-vCPU core count.
+LOAD1="$(cut -d' ' -f1 /proc/loadavg)"
+if awk "BEGIN{exit !($LOAD1 > 8.0)}"; then
+  echo "ABORT: 1-min load is $LOAD1 (> 8.0). Box is too busy to deploy safely."
+  echo "Wait for it to settle, then re-run. (Pull-only deploy is light, but a"
+  echo "recreate still briefly competes; don't stack it on an existing spike.)"
+  exit 1
+fi
+
+say "Sync code (compose files + migrations only; images come from GHCR)"
+git fetch origin main
+git checkout main
+git pull --ff-only origin main
+
+say "Pull pre-built images: tag=$TAG namespace=$PLATOS_IMAGE_NAMESPACE"
+docker compose $COMPOSE_FILES pull $SERVICES
+
+say "Run DB migrations (one-shot, completes before app restart)"
+docker compose $COMPOSE_FILES run --rm migrations-init || {
+  echo "WARN: migrations-init returned non-zero. Inspect before continuing."
+  echo "If migrations already applied, this is expected; re-run up manually."
+}
+
+say "Recreate app services from the pulled images"
+docker compose $COMPOSE_FILES up -d --no-deps $SERVICES
+
+say "Post-deploy: wait for health"
+for svc in agent webapp; do
+  cname="$(docker compose $COMPOSE_FILES ps -q "$svc" 2>/dev/null)"
+  [ -z "$cname" ] && { echo "  $svc: no container?"; continue; }
+  for i in $(seq 1 30); do
+    status="$(docker inspect --format '{{.State.Health.Status}}' "$cname" 2>/dev/null || echo unknown)"
+    [ "$status" = "healthy" ] && { echo "  $svc: healthy"; break; }
+    [ "$i" -eq 30 ] && echo "  $svc: still '$status' after 30 checks — investigate"
+    sleep 5
+  done
+done
+
+say "Done. Final state:"
+cat /proc/loadavg
+docker compose $COMPOSE_FILES ps --format '{{.Name}}\t{{.Status}}'


### PR DESCRIPTION
## Why

The deploy flow compiled **on the production box**: `docker compose build` runs `nest build`/`tsc` (agent) + the Remix/Vite bundle (webapp) on the 4-vCPU reference VPS while it serves traffic. That spikes load average past 40 and trips the host CPU throttle — the same class as the May 2026 outage. **It recurred during this session**: a routine agent rebuild drove load to ~42 and `/login` from 0.8s to 32s. Compiling on the box you are trying to keep up is brittle by construction.

## What

Move builds to GitHub runners; make the VPS pull-only.

- **`.github/workflows/build-images.yml`** — builds agent + webapp on every push to `main` (+ `workflow_dispatch`), pushes to GHCR as `:latest` and `:sha-<commit>`. GHA layer cache (`mode=max`) keeps rebuilds fast.
- **`docker-compose.deploy.yml`** — override swapping `build:` blocks for GHCR `image:` refs. `build: !reset null` so a stray `compose build` on the box is a no-op. Validated with real `docker compose config` (v2.39, `!reset` resolves; agent/webapp/worker → `ghcr.io/...`, build blocks gone).
- **`scripts/deploy-platos.sh`** — safe deploy: **aborts if 1-min load > 8.0**, pulls images, runs migrations, recreates only app services (`--no-deps`), waits for `healthy`. Rollback = `deploy-platos.sh sha-<prev>` (no rebuild).
- **`docs/deployment/off-box-build.md`** — the why, the runbook, and the emergency "a build is crushing the box" recovery.

## Validation

- Workflow YAML parses clean; both referenced Dockerfiles exist.
- Compose override validated with `docker compose config` (exit 0): image refs win, `build:` removed via `!reset`.
- No runtime code change. Merging triggers the workflow, which must build both images green before any pull-deploy can use them.

## Follow-ups (tracked, not in this PR)

Tier 2 — enable the 8 skipped `cross-scope-isolation.test.ts` cases. Tier 3 — input-robustness sweep (unguarded `JSON.parse` on DB text, `Number()`→NaN). Tier 4 — characterization tests on the agent god-files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)