### PR TITLE
fix(deploy): gate on steal-aware real-CPU idle, not load average

### DIFF
--- a/scripts/deploy-platos.sh
+++ b/scripts/deploy-platos.sh
@@ -14,6 +14,7 @@
 # Env:
 #   PLATOS_IMAGE_NAMESPACE  GHCR owner (default: winsenlabs)
 #   COMPOSE_FILES           override the -f chain if your layout differs
+#   DEPLOY_MIN_IDLE_PCT     min real-CPU idle to allow deploy (default: 20)
 set -euo pipefail
 
 TAG="${1:-latest}"
@@ -22,20 +23,47 @@ export PLATOS_IMAGE_NAMESPACE="${PLATOS_IMAGE_NAMESPACE:-winsenlabs}"
 
 COMPOSE_FILES="${COMPOSE_FILES:--f docker-compose.platos.yml -f docker-compose.deploy.yml}"
 SERVICES="agent webapp worker"
+MIN_IDLE="${DEPLOY_MIN_IDLE_PCT:-20}"
 
 say() { printf '\n\033[1;36m== %s\033[0m\n' "$*"; }
 
-say "Pre-flight: current load + container health"
-cat /proc/loadavg
+# Real-CPU headroom over a 1s window, as a percentage of WALL-CLOCK CPU time
+# (steal included in the denominator). We gate on this, not load average.
+#
+# Why: on the Hostinger reference box the host hypervisor applies a fair-use CPU
+# cap. When it engages, `top` shows ~95% `st` (steal) and the 1-min load average
+# pins near 38 while user CPU is ~2%. Load average is meaningless here — it would
+# refuse to ever deploy. What actually matters is "does this VM have real cycles
+# to spare." steal time is time the host took away from us, so it counts against
+# available headroom: idle% = idle / (idle + busy + steal). On a throttled box
+# this collapses toward 0 and we correctly abort; on a healthy box steal≈0 and
+# idle reflects true free CPU.
+cpu_idle_pct() {
+  # /proc/stat cpu line fields: user nice system idle iowait irq softirq steal ...
+  local a b
+  a=$(awk '/^cpu /{i=$5+$6; t=$2+$3+$4+$5+$6+$7+$8+$9; print i, t}' /proc/stat)
+  sleep 1
+  b=$(awk '/^cpu /{i=$5+$6; t=$2+$3+$4+$5+$6+$7+$8+$9; print i, t}' /proc/stat)
+  awk -v a="$a" -v b="$b" 'BEGIN{
+    split(a, x); split(b, y);
+    di = y[1] - x[1]; dt = y[2] - x[2];
+    if (dt <= 0) { print 100; exit }
+    printf "%d\n", di * 100 / dt;
+  }'
+}
+
+say "Pre-flight: CPU headroom + container health"
+IDLE="$(cpu_idle_pct)"
+LOAD1="$(cut -d' ' -f1 /proc/loadavg)"
+echo "real-CPU idle: ${IDLE}%  (1-min load avg ${LOAD1} — informational; steal inflates it)"
 docker compose $COMPOSE_FILES ps --format '{{.Name}}\t{{.Status}}' 2>/dev/null || true
 
-# Refuse to deploy onto an already-saturated box — pulling + recreating under
-# load is how a slow box becomes a down box. 8.0 is 2x the 4-vCPU core count.
-LOAD1="$(cut -d' ' -f1 /proc/loadavg)"
-if awk "BEGIN{exit !($LOAD1 > 8.0)}"; then
-  echo "ABORT: 1-min load is $LOAD1 (> 8.0). Box is too busy to deploy safely."
-  echo "Wait for it to settle, then re-run. (Pull-only deploy is light, but a"
-  echo "recreate still briefly competes; don't stack it on an existing spike.)"
+if [ "$IDLE" -lt "$MIN_IDLE" ]; then
+  echo
+  echo "ABORT: only ${IDLE}% real-CPU idle (< ${MIN_IDLE}%). The box has no spare"
+  echo "cycles — likely a host CPU throttle (check 'top' for high 'st'/steal). A"
+  echo "recreate now risks tipping it over. Wait for the throttle window to clear,"
+  echo "then re-run. Override the threshold with DEPLOY_MIN_IDLE_PCT if you must."
   exit 1
 fi
 
@@ -69,5 +97,5 @@ for svc in agent webapp; do
 done
 
 say "Done. Final state:"
-cat /proc/loadavg
+echo "real-CPU idle: $(cpu_idle_pct)%   load: $(cut -d' ' -f1-3 /proc/loadavg)"
 docker compose $COMPOSE_FILES ps --format '{{.Name}}\t{{.Status}}'


### PR DESCRIPTION
Follow-up to the off-box pipeline (#17).

Diagnosing the reference VPS during this session, `top` showed **95% steal (`st`)** with 1-min load ~38 but user CPU ~2% and `/login` still sub-4s — a host-level Hostinger CPU throttle, not real app load (ClickHouse also had 4 background merges running underneath). A load-average gate would refuse to ever deploy on this box; an idle-only gate that ignores steal would green-light a deploy onto a VM with no real cycles.

The guard now samples `/proc/stat` over 1s:

```
idle% = (idle + iowait) / (user + nice + sys + idle + iowait + irq + softirq + steal)
```

so **steal counts against available headroom**. On a throttled box this collapses toward 0 and we abort; on a healthy box steal≈0 and it reflects true free CPU. Threshold via `DEPLOY_MIN_IDLE_PCT` (default 20). awk math unit-tested for both healthy (→80%) and throttled (→0%) cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)