### PR TITLE
fix(agent): bound embedding + memory-injection latency so a slow provider can't stall a turn

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -4919,21 +4919,41 @@ export class AgentService {
         }
         if (policyEnabled) {
           const budget = Math.max(100, env.PLATOS_MEMORY_INJECT_BUDGET_TOKENS ?? 800);
-          const hits = await this.memoryService.semanticSearch(
-            {
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-              environmentId: scope.environmentId,
-            },
-            {
-              query: message,
-              userId: scope.userId,
-              limit: 8,
-              minScore: 0.35,
-              // Defaults exclude "private"; pass agent-visible + hidden.
-              visibilityIn: ["agent_visible", "hidden"],
-            },
-          );
+          // Memory injection is best-effort and must NEVER block the response.
+          // semanticSearch embeds the query (an external provider HTTP call) +
+          // hits pgvector; a slow embedding key once stalled a turn ~64s
+          // pre-LLM. Race it against a hard timeout (default 5s). On timeout
+          // the catch below logs + proceeds with no memory block — the LLM
+          // still answers, just without the "things I remember" enrichment.
+          const injectTimeoutMs = env.PLATOS_MEMORY_INJECT_TIMEOUT_MS ?? 5000;
+          const hits = await Promise.race([
+            this.memoryService.semanticSearch(
+              {
+                organizationId: scope.organizationId,
+                projectId: scope.projectId,
+                environmentId: scope.environmentId,
+              },
+              {
+                query: message,
+                userId: scope.userId,
+                limit: 8,
+                minScore: 0.35,
+                // Defaults exclude "private"; pass agent-visible + hidden.
+                visibilityIn: ["agent_visible", "hidden"],
+              },
+            ),
+            new Promise<never>((_, reject) =>
+              setTimeout(
+                () =>
+                  reject(
+                    new Error(
+                      `memory semanticSearch exceeded ${injectTimeoutMs}ms inject budget`,
+                    ),
+                  ),
+                injectTimeoutMs,
+              ),
+            ),
+          ]);
           // Theme M.5 — drop memories flagged by a thumbs-down rating.
           // The metadata.flaggedByRating marker is written by
           // MemoryFeedbackService.applyRating; we treat it as "quarantined

--- a/apps/agent/src/memory/embedding.service.test.ts
+++ b/apps/agent/src/memory/embedding.service.test.ts
@@ -1,0 +1,61 @@
+/**
+ * EmbeddingService timeout regression (latency fix, 2026-06-01).
+ *
+ * A bare `await fetch` to the embedding provider with no timeout once stalled
+ * a whole agent turn ~64s pre-LLM on a cold/slow provider key (the demo-site
+ * slowness investigation). `fetchWithTimeout` now bounds the provider call with
+ * `AbortSignal.timeout(PLATOS_EMBEDDING_TIMEOUT_MS)`. These tests pin that:
+ *   - a hung provider rejects within the timeout, not after the hang resolves;
+ *   - the abort surfaces as a readable "timed out" error, not a raw DOMException.
+ *
+ * We stub global.fetch — the EXTERNAL provider HTTP boundary — which the
+ * no-mocks-for-owned-services rule explicitly permits (the embedding API is not
+ * a service Platos owns). EmbeddingService itself is real.
+ */
+// env.ts parse-caches on FIRST access (Proxy), so these must be set at module
+// load — before EmbeddingService's constructor touches `env`. Pin provider to
+// voyage + supply its key + a >500ms timeout (schema floor).
+process.env.PLATOS_EMBEDDING_PROVIDER = "voyage";
+process.env.VOYAGE_API_KEY = process.env.VOYAGE_API_KEY || "test-voyage-key";
+process.env.PLATOS_EMBEDDING_TIMEOUT_MS = "600";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EmbeddingService } from "./embedding.service";
+
+const realFetch = global.fetch;
+
+function makeService(): EmbeddingService {
+  // No ScopedEnvService / CostService — the key path resolves from env
+  // (voyage), and cost recording is fire-and-forget optional.
+  return new EmbeddingService();
+}
+
+describe("EmbeddingService.embed — provider timeout", () => {
+  afterEach(() => {
+    global.fetch = realFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("rejects with a readable timeout error when the provider hangs", async () => {
+    // Provider that never resolves on its own, but honours the abort signal
+    // the way real fetch does — rejecting with an AbortError when aborted.
+    global.fetch = vi.fn((_url: any, init: any) => {
+      return new Promise((_resolve, reject) => {
+        const signal: AbortSignal | undefined = init?.signal;
+        if (signal) {
+          signal.addEventListener("abort", () => {
+            const e = new Error("aborted");
+            e.name = "TimeoutError";
+            reject(e);
+          });
+        }
+      });
+    }) as any;
+
+    const svc = makeService();
+    const start = Date.now();
+    await expect(svc.embed("hello world")).rejects.toThrow(/timed out after 600ms/);
+    // Must reject promptly at the timeout, not hang indefinitely.
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+});

--- a/apps/agent/src/memory/embedding.service.ts
+++ b/apps/agent/src/memory/embedding.service.ts
@@ -245,12 +245,40 @@ export class EmbeddingService {
     return this.callOpenAi(inputs, apiKey, scope);
   }
 
+  /**
+   * Bound the embedding-provider HTTP call. A bare `await fetch` with no
+   * timeout will hang a whole turn if the provider is slow or rate-limited
+   * — observed as a 64s pre-LLM stall on a cold key. We abort after
+   * PLATOS_EMBEDDING_TIMEOUT_MS (default 8s) and surface a clear error so
+   * the caller (memory inject is best-effort + caught) degrades instead of
+   * blocking. Wraps a DOMException AbortError into a readable message.
+   */
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    const timeoutMs = env.PLATOS_EMBEDDING_TIMEOUT_MS ?? 8000;
+    try {
+      return await fetch(url, {
+        ...init,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (err: any) {
+      if (err?.name === "TimeoutError" || err?.name === "AbortError") {
+        throw new Error(
+          `Embedding provider call to ${url} timed out after ${timeoutMs}ms`,
+        );
+      }
+      throw err;
+    }
+  }
+
   private async callOpenAi(
     inputs: string[],
     apiKey: string,
     scope?: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
   ): Promise<number[][]> {
-    const resp = await fetch("https://api.openai.com/v1/embeddings", {
+    const resp = await this.fetchWithTimeout("https://api.openai.com/v1/embeddings", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -314,7 +342,7 @@ export class EmbeddingService {
     if (this.model.startsWith("voyage-3")) {
       body.output_dimension = EmbeddingService.DIMENSION;
     }
-    const resp = await fetch("https://api.voyageai.com/v1/embeddings", {
+    const resp = await this.fetchWithTimeout("https://api.voyageai.com/v1/embeddings", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/apps/agent/src/shared/env.ts
+++ b/apps/agent/src/shared/env.ts
@@ -201,6 +201,21 @@ export const AgentEnvSchema = z
       "PLATOS_MEMORY_INJECT_BUDGET_TOKENS",
       { min: 0 },
     ),
+    // Hard ceiling on the embedding-provider HTTP call (ms). A bare
+    // `await fetch` to Voyage/OpenAI with no timeout will hang a whole
+    // turn if the provider is slow/rate-limited (observed: 64s pre-LLM
+    // stall on a cold key). Default 8s. Consumed in EmbeddingService.
+    PLATOS_EMBEDDING_TIMEOUT_MS: intString("PLATOS_EMBEDDING_TIMEOUT_MS", {
+      min: 500,
+    }),
+    // Ceiling on the inline pre-LLM memory-injection semanticSearch (ms).
+    // Memory enrichment is best-effort; it must never block the response.
+    // If it doesn't return in time we skip the block and call the LLM.
+    // Default 5s. Consumed in AgentService.stream.
+    PLATOS_MEMORY_INJECT_TIMEOUT_MS: intString(
+      "PLATOS_MEMORY_INJECT_TIMEOUT_MS",
+      { min: 250 },
+    ),
     PLATOS_WORKING_MEMORY_TTL: intString("PLATOS_WORKING_MEMORY_TTL", {
       min: 0,
     }),


### PR DESCRIPTION
## Diagnosis (winsen-bridge-demo "slow on demo, fast on dashboard")

Timestamped agent logs of two fresh-thread turns to the **same agent + model** (`together:Kimi-K2.6`):

| Phase | Dashboard | Demo |
|---|---|---|
| WS connect → agent.task | 3.0s | 0.26s |
| **agent.task → OUTBOUND LLM request** | **0.8s** | **64.3s** ⚠️ |
| LLM request → done | 5.1s | 5.4s |

The model is identical and ~5s on both. The demo lost **~64 seconds server-side, before the LLM was called.**

## Root cause

`AgentService.stream` injects a "things I remember about this user" block by calling `memoryService.semanticSearch` **inline + awaited before the LLM call**. That embeds the query via `EmbeddingService.embed`, which did a bare `await fetch` to Voyage/OpenAI with **no timeout**. The demo's fresh `userId` hit a cold/slow embedding key → the fetch hung ~64s and blocked the whole turn. The dashboard `userId` hit the embed cache / warm path, so it never stalled.

**This affects every SDK consumer** — the slow path is the shared agent runtime, not the demo. The dashboard just happened to mask it.

## Fix (two layers, both fail-open)

1. **`EmbeddingService.fetchWithTimeout`** wraps both provider fetches with `AbortSignal.timeout(PLATOS_EMBEDDING_TIMEOUT_MS`, default **8s**) and converts the abort into a readable `timed out after Nms` error.
2. **Memory injection races** `semanticSearch` against `PLATOS_MEMORY_INJECT_TIMEOUT_MS` (default **5s**). On timeout the existing try/catch logs and proceeds with **no memory block** — the LLM still answers, just without enrichment. Memory injection is best-effort and must never block the response.

## Test

`embedding.service.test.ts` stubs the **external** provider HTTP boundary (permitted — not a Platos-owned service) and asserts `embed()` rejects promptly at the timeout instead of hanging. `typecheck --filter platos-agent` clean (6/6).

No schema change. Defaults safe; both timeouts env-tunable.

## Separate follow-ups found during diagnosis (NOT in this PR)
- The model picker writes `modelRoutes` but never the legacy `model` column, so the agent list shows a stale model (display desync). 
- `{{seed_brain}}`/`{{seed_intent}}` promptVars log as `unresolved` for this agent — the demo's brain/voice context isn't being injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)