### PR TITLE
feat(sdk): thumbs up/down message rating in client + react-widget

### DIFF
--- a/.changeset/sdk-message-rating.md
+++ b/.changeset/sdk-message-rating.md
@@ -1,0 +1,21 @@
+---
+"@platosdev/client": minor
+"@platosdev/react-widget": minor
+---
+
+Add thumbs up/down message rating to the SDKs.
+
+The backend rating API (`POST/GET/DELETE /messages/:id/rating`, satisfaction
+aggregates, MCP `messages.rate`, memory-feedback loop) shipped previously but
+was never reachable from the published SDKs, so embedded chat surfaces had no
+way to let end users vote.
+
+- `@platosdev/client`: new `client.messages.rate(messageId, "up"|"down", { comment? })`,
+  `.unrate(messageId)`, and `.getForMessage(messageId)`. Exports
+  `PlatosRatingDirection`, `PlatosMessageRating`, `PlatosMessageRatingState`.
+  Added a typed `message_persisted` stream event (carries the server
+  `messageId` needed to rate a streamed message).
+- `@platosdev/react-widget`: `usePlatosChat` now captures `message_persisted`,
+  stamps `serverId` + `rating` onto each `ChatMessage`, and returns a
+  `rate(messageId, direction)` callback (optimistic, toggles to clear).
+  `<PlatosFab>` renders thumbs up/down on persisted assistant bubbles.

--- a/content/docs/react-widget.md
+++ b/content/docs/react-widget.md
@@ -157,7 +157,7 @@ Three levels:
 import { usePlatosChat } from "@platosdev/react-widget";
 
 function CustomChat() {
-  const { messages, send, status, error } = usePlatosChat({
+  const { messages, send, rate, status, error } = usePlatosChat({
     baseUrl: "...",
     agentId: "...",
     tokenUrl: "...",
@@ -167,6 +167,36 @@ function CustomChat() {
   // render however you want
 }
 ```
+
+### Message ratings (thumbs up/down)
+
+`<PlatosFab>` renders thumbs up/down on each assistant bubble once the message
+has persisted — no setup required. A vote calls the rating API; a thumbs-down
+also quarantines the memories extracted from that message, and votes roll up
+into the dashboard satisfaction views.
+
+For the headless hook, `usePlatosChat` returns a `rate` callback and stamps a
+`serverId` + `rating` onto each assistant `ChatMessage`. The widget captures the
+`message_persisted` stream event internally, so `rate` just takes the message's
+local id:
+
+```tsx
+const { messages, rate } = usePlatosChat({ /* ... */ });
+
+messages
+  .filter((m) => m.role === "assistant" && m.serverId) // rateable once persisted
+  .map((m) => (
+    <div key={m.id}>
+      {m.content}
+      <button onClick={() => rate(m.id, "up")} aria-pressed={m.rating === 1}>👍</button>
+      <button onClick={() => rate(m.id, "down")} aria-pressed={m.rating === -1}>👎</button>
+    </div>
+  ));
+```
+
+`rate` is optimistic (updates `m.rating` immediately, rolls back on failure) and
+toggles — calling it again with the same direction clears the vote. It returns
+`false` (no-op) if the message hasn't persisted yet.
 
 ### Hotkey
 

--- a/content/docs/sdks.md
+++ b/content/docs/sdks.md
@@ -83,6 +83,37 @@ for await (const event of stream) {
 }
 ```
 
+### Consumer SDK: rate a message (thumbs up/down)
+
+Collect end-user feedback on assistant replies. A thumbs-down also feeds the
+memory-quality loop (the memories extracted from that message are quarantined
+from future retrieval); ratings roll up into the per-version satisfaction views
+on the Evals and Monitoring dashboards.
+
+Rate against the **server** message id, surfaced on the `message_persisted`
+stream event (not the provisional id you may assign client-side):
+
+```ts
+let serverMessageId: string | undefined;
+for await (const event of platos.threads.send(threadId, "Hi", { agentId })) {
+  if (event.type === "token") process.stdout.write(event.text);
+  if (event.type === "message_persisted") serverMessageId = event.messageId;
+}
+
+// thumbs up (optionally with a comment); "down" maps to -1
+await platos.messages.rate(serverMessageId!, "up");
+await platos.messages.rate(serverMessageId!, "down", { comment: "missed the ask" });
+
+// remove the vote, or read current vote + anonymized aggregate counts
+await platos.messages.unrate(serverMessageId!);
+const { userRating, aggregate } = await platos.messages.getForMessage(serverMessageId!);
+// aggregate → { ups: number, downs: number }
+```
+
+The `@platosdev/react-widget` wires this for you: `usePlatosChat` returns a
+`rate(messageId, "up" | "down")` callback and `<PlatosFab>` renders the thumbs
+on each assistant bubble — see the [React widget](/docs/react-widget) doc.
+
 ### Entity SDK (Node)
 
 ```ts

--- a/packages/platos-client/src/__tests__/messages.test.ts
+++ b/packages/platos-client/src/__tests__/messages.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `client.messages` (thumbs up/down SDK rating).
+ *
+ * Mocks `globalThis.fetch` — we lock down the URL paths, request bodies
+ * (rating direction → ±1 mapping), and response unwrapping the SDK ships,
+ * not the live agent.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlatosClient } from "../client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("client.messages", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let client: PlatosClient;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    client = new PlatosClient({
+      baseUrl: "https://play.platos.dev",
+      sessionToken: "test-token",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("rate('up') — POSTs rating=1 to the message rating endpoint", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ rating: { id: "r1", messageId: "msg_1", rating: 1, comment: null } }),
+    );
+    const row = await client.messages.rate("msg_1", "up");
+    expect(row.rating).toBe(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://play.platos.dev/api/v1/agent/messages/msg_1/rating");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ rating: 1 });
+  });
+
+  it("rate('down', { comment }) — POSTs rating=-1 with comment", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ rating: { id: "r2", messageId: "msg_2", rating: -1, comment: "wrong" } }),
+    );
+    await client.messages.rate("msg_2", "down", { comment: "wrong" });
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(init.body)).toEqual({ rating: -1, comment: "wrong" });
+  });
+
+  it("rate() — throws when the server returns an error shape", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: "rating must be 1 or -1" }));
+    await expect(client.messages.rate("msg_3", "up")).rejects.toThrow(/rating must be/);
+  });
+
+  it("unrate() — DELETEs and returns removed flag", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ removed: true }));
+    const removed = await client.messages.unrate("msg_4");
+    expect(removed).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://play.platos.dev/api/v1/agent/messages/msg_4/rating");
+    expect(init.method).toBe("DELETE");
+  });
+
+  it("getForMessage() — GETs the user vote + aggregate", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ userRating: { rating: 1 }, aggregate: { ups: 3, downs: 1 } }),
+    );
+    const state = await client.messages.getForMessage("msg_5");
+    expect(state?.aggregate).toEqual({ ups: 3, downs: 1 });
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe("https://play.platos.dev/api/v1/agent/messages/msg_5/rating");
+    expect(init.method).toBe("GET");
+  });
+
+  it("rate() — URL-encodes the messageId", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ rating: { rating: 1 } }));
+    await client.messages.rate("msg/with space", "up");
+    const [url] = fetchSpy.mock.calls[0];
+    expect(url).toBe(
+      "https://play.platos.dev/api/v1/agent/messages/msg%2Fwith%20space/rating",
+    );
+  });
+});

--- a/packages/platos-client/src/apis/messages.ts
+++ b/packages/platos-client/src/apis/messages.ts
@@ -1,0 +1,116 @@
+/**
+ * @platosdev/client — message rating API surface (issue: thumbs up/down SDK gap).
+ *
+ * Wraps the message-rating REST endpoints on the agent service
+ * (`apps/agent/src/agent-runtime/agent.controller.ts`):
+ *   - POST   /api/v1/agent/messages/:messageId/rating   (upsert a vote)
+ *   - DELETE /api/v1/agent/messages/:messageId/rating   (remove the vote)
+ *   - GET    /api/v1/agent/messages/:messageId/rating    (current vote + counts)
+ *
+ * The backend, MCP tool (`messages.rate`), memory-feedback loop, and dashboard
+ * satisfaction views all shipped previously — but the rating action was never
+ * reachable from the published SDK, so embedded chat surfaces (the react-widget,
+ * custom apps) had no way to let end users vote. This namespace closes that gap.
+ *
+ * `messageId` is the SERVER-side `PlatosAgentMessage.id` — surfaced to streaming
+ * clients on the `message_persisted` event (see PlatosStreamEvent), NOT the
+ * provisional client-generated bubble id.
+ */
+
+import type { PlatosClient } from "../client.js";
+import { PlatosNotFoundError } from "../errors.js";
+import type { PlatosScope } from "../types.js";
+
+/** Up = thumbs up (+1), down = thumbs down (-1). */
+export type PlatosRatingDirection = "up" | "down";
+
+export interface PlatosMessageRating {
+  readonly id: string;
+  readonly messageId: string;
+  readonly rating: 1 | -1;
+  readonly comment: string | null;
+  readonly userId: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface PlatosMessageRatingState {
+  /** The current user's vote on this message, or null if they haven't voted. */
+  readonly userRating: PlatosMessageRating | null;
+  /** Anonymized aggregate counts across all users in scope. */
+  readonly aggregate: { ups: number; downs: number };
+}
+
+function dirToInt(dir: PlatosRatingDirection): 1 | -1 {
+  return dir === "up" ? 1 : -1;
+}
+
+export class MessagesApi {
+  constructor(private readonly client: PlatosClient) {}
+
+  /**
+   * Cast (or change) a thumbs up/down vote on an assistant message. Idempotent
+   * per (message, user) — re-rating overwrites the prior vote. Pass a `comment`
+   * to attach free-text feedback (surfaced in the dashboard +, for thumbs-down,
+   * carried into the memory-feedback flag).
+   *
+   * `messageId` MUST be the server message id from the `message_persisted`
+   * stream event, not a provisional client id.
+   */
+  async rate(
+    messageId: string,
+    direction: PlatosRatingDirection,
+    opts: { comment?: string | null } = {},
+    scope?: PlatosScope,
+  ): Promise<PlatosMessageRating> {
+    const res = await this.client._fetch<{ rating: PlatosMessageRating; error?: string }>(
+      `/api/v1/agent/messages/${encodeURIComponent(messageId)}/rating`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          rating: dirToInt(direction),
+          ...(opts.comment !== undefined ? { comment: opts.comment } : {}),
+        }),
+      },
+      scope,
+    );
+    if (!res?.rating) {
+      throw new Error(res?.error || "rating failed");
+    }
+    return res.rating;
+  }
+
+  /**
+   * Remove the current user's vote on a message (the neutral "un-rate" state).
+   * Returns true if a row was deleted.
+   */
+  async unrate(messageId: string, scope?: PlatosScope): Promise<boolean> {
+    const res = await this.client._fetch<{ removed: boolean }>(
+      `/api/v1/agent/messages/${encodeURIComponent(messageId)}/rating`,
+      { method: "DELETE" },
+      scope,
+    );
+    return res?.removed ?? false;
+  }
+
+  /**
+   * Fetch the current user's vote + anonymized aggregate counts for a message.
+   * Returns null if the message doesn't exist / isn't in scope.
+   */
+  async getForMessage(
+    messageId: string,
+    scope?: PlatosScope,
+  ): Promise<PlatosMessageRatingState | null> {
+    try {
+      return await this.client._fetch<PlatosMessageRatingState>(
+        `/api/v1/agent/messages/${encodeURIComponent(messageId)}/rating`,
+        { method: "GET" },
+        scope,
+      );
+    } catch (err) {
+      if (err instanceof PlatosNotFoundError) return null;
+      throw err;
+    }
+  }
+}

--- a/packages/platos-client/src/client.ts
+++ b/packages/platos-client/src/client.ts
@@ -25,6 +25,7 @@ import { AgentsApi } from "./apis/agents.js";
 import { ApprovalsApi } from "./apis/approvals.js";
 import { BudgetsApi } from "./apis/budgets.js";
 import { MonitoringApi } from "./apis/monitoring.js";
+import { MessagesApi } from "./apis/messages.js";
 import { ThreadsApi } from "./apis/threads.js";
 import { ToolsApi } from "./apis/tools.js";
 import { TriggerApi } from "./apis/trigger.js";
@@ -87,6 +88,12 @@ export class PlatosClient {
    */
   readonly tools: ToolsApi;
   /**
+   * Message rating — thumbs up/down votes on assistant messages, backed by
+   * the agent's `/messages/:id/rating` endpoints. `messageId` is the server
+   * id surfaced on the `message_persisted` stream event.
+   */
+  readonly messages: MessagesApi;
+  /**
    * Theme BGO — unified background-operations surface. Backed by the
    * trigger.dev engine; exposes `client.bgo.tasks` (catalog), `.runs`,
    * `.schedules`, `.batches`.
@@ -123,6 +130,7 @@ export class PlatosClient {
     this.budgets = new BudgetsApi(this);
     this.monitoring = new MonitoringApi(this);
     this.tools = new ToolsApi(this);
+    this.messages = new MessagesApi(this);
     // Theme BGO — `bgo` is the canonical namespace; `trigger` is the
     // deprecated alias pointing at the same instance. Kept for one
     // release (see docs/BGO_RENAME.md).

--- a/packages/platos-client/src/index.ts
+++ b/packages/platos-client/src/index.ts
@@ -7,6 +7,9 @@
  *   - `client.agents.list / get / listVersions`
  *   - `client.threads.create / list / get / messages / artifacts / send`
  *     (send = async-iterable Socket.IO stream with hardened reconnect/buffer)
+ *   - `client.messages.rate / unrate / getForMessage` — thumbs up/down votes
+ *     on assistant messages (uses the server messageId from the
+ *     `message_persisted` stream event)
  *   - `client.bgo.tasks / runs / schedules / batches` — unified durable
  *     background-operation ops via the agent's meta-tool shim (Theme BGO,
  *     formerly `client.trigger.*`; the old namespace is kept as a
@@ -65,6 +68,12 @@ export type {
   PlatosToolSearchOptions,
   PlatosToolTestResult,
 } from "./apis/tools.js";
+
+export type {
+  PlatosRatingDirection,
+  PlatosMessageRating,
+  PlatosMessageRatingState,
+} from "./apis/messages.js";
 
 import { PlatosClient } from "./client.js";
 export default PlatosClient;

--- a/packages/platos-client/src/types.ts
+++ b/packages/platos-client/src/types.ts
@@ -79,6 +79,7 @@ export type PlatosStreamEvent =
   | { type: "meta"; thread_id?: string; agent_id?: string; usage?: Record<string, unknown> }
   | { type: "token"; text: string }
   | { type: "message_boundary" }
+  | { type: "message_persisted"; messageId: string; threadId?: string; costCents?: number; replyToMessageId?: string }
   | { type: "thinking"; text: string }
   | { type: "tool_call"; name: string; params: Record<string, unknown>; callId: string }
   | { type: "tool_result"; name: string; result: unknown; callId: string; display?: unknown }

--- a/packages/platos-react-widget/src/PlatosFab.tsx
+++ b/packages/platos-react-widget/src/PlatosFab.tsx
@@ -304,6 +304,33 @@ export function PlatosFab(props: PlatosFabProps) {
                 >
                   {m.content}
                   {m.streaming && <span className="platos-widget-cursor" />}
+                  {/* Thumbs up/down — only on persisted assistant messages
+                      (serverId present, not mid-stream). Optimistic via
+                      chat.rate(); toggling the active vote clears it. */}
+                  {m.role === "assistant" && !m.streaming && m.serverId && (
+                    <div className="platos-widget-rating">
+                      <button
+                        type="button"
+                        className="platos-widget-rate-btn"
+                        aria-label="Good response"
+                        aria-pressed={m.rating === 1}
+                        data-active={m.rating === 1 ? "true" : undefined}
+                        onClick={() => void chat.rate(m.id, "up")}
+                      >
+                        {"\u{1F44D}"}
+                      </button>
+                      <button
+                        type="button"
+                        className="platos-widget-rate-btn"
+                        aria-label="Bad response"
+                        aria-pressed={m.rating === -1}
+                        data-active={m.rating === -1 ? "true" : undefined}
+                        onClick={() => void chat.rate(m.id, "down")}
+                      >
+                        {"\u{1F44E}"}
+                      </button>
+                    </div>
+                  )}
                 </div>
               ))}
               {chat.error && (

--- a/packages/platos-react-widget/src/styles.css
+++ b/packages/platos-react-widget/src/styles.css
@@ -238,6 +238,30 @@
   opacity: 0.6;
   animation: platos-blink 1s steps(2, start) infinite;
 }
+.platos-widget-rating {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+}
+.platos-widget-rate-btn {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+  opacity: 0.45;
+  transition: opacity 0.12s ease, background 0.12s ease;
+}
+.platos-widget-rate-btn:hover {
+  opacity: 0.85;
+  background: rgba(127, 127, 127, 0.12);
+}
+.platos-widget-rate-btn[data-active="true"] {
+  opacity: 1;
+  background: rgba(127, 127, 127, 0.18);
+}
 @keyframes platos-blink {
   to { opacity: 0; }
 }

--- a/packages/platos-react-widget/src/usePlatosChat.ts
+++ b/packages/platos-react-widget/src/usePlatosChat.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PlatosClient } from "@platosdev/client";
+import type { PlatosRatingDirection } from "@platosdev/client";
 import type { PerTurnOptions, VisitorIdentity } from "./types.js";
 
 /**
@@ -21,6 +22,14 @@ export interface ChatMessage {
   content: string;
   /** True while the assistant message is still being streamed. */
   streaming?: boolean;
+  /**
+   * Server-side PlatosAgentMessage id, surfaced on the `message_persisted`
+   * stream event. Required to rate a message; absent on the provisional
+   * client bubble until the turn persists. Only set on assistant messages.
+   */
+  serverId?: string;
+  /** Current local rating: 1 (up), -1 (down), or null/undefined (no vote). */
+  rating?: 1 | -1 | null;
 }
 
 export interface UsePlatosChatArgs {
@@ -37,6 +46,15 @@ export interface UsePlatosChatResult {
   status: ChatStatus;
   messages: ChatMessage[];
   send: (text: string) => Promise<void>;
+  /**
+   * Cast a thumbs up/down on an assistant message. Pass the message's local
+   * `id`; the hook resolves its `serverId` and calls the rating API. Toggling
+   * the same direction again clears the vote (un-rate). Optimistic: updates
+   * local `rating` immediately and rolls back on failure. No-op (returns
+   * false) if the message has no serverId yet (still streaming / not
+   * persisted).
+   */
+  rate: (messageId: string, direction: PlatosRatingDirection) => Promise<boolean>;
   abort: () => void;
   reset: () => void;
   threadId: string | null;
@@ -61,6 +79,10 @@ export function usePlatosChat(args: UsePlatosChatArgs): UsePlatosChatResult {
   const clientRef = useRef<PlatosClient | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const tokenFetchInFlightRef = useRef<Promise<string> | null>(null);
+  // Mirror of `messages` so `rate()` reads current serverId/rating without
+  // re-creating its callback on every token (which would thrash consumers).
+  const messagesRef = useRef<ChatMessage[]>([]);
+  messagesRef.current = messages;
 
   // Stable token-fetcher used by both initial mint + onTokenRefresh hook.
   const fetchToken = useCallback(async (): Promise<string> => {
@@ -185,6 +207,19 @@ export function usePlatosChat(args: UsePlatosChatArgs): UsePlatosChatResult {
                 m.id === assistantId ? { ...m, content: m.content + chunk } : m,
               ),
             );
+          } else if (
+            event.type === "message_persisted" &&
+            typeof (event as { messageId?: unknown }).messageId === "string"
+          ) {
+            // Stamp the real server message id onto the assistant bubble so
+            // rate() can target it. The provisional `assistantId` stays as the
+            // React key; `serverId` is what the rating API needs.
+            const sid = (event as { messageId: string }).messageId;
+            setMessages((prev) =>
+              prev.map((m) =>
+                m.id === assistantId ? { ...m, serverId: sid } : m,
+              ),
+            );
           } else if (event.type === "error") {
             const msg =
               typeof event.message === "string" ? event.message : "stream error";
@@ -227,6 +262,49 @@ export function usePlatosChat(args: UsePlatosChatArgs): UsePlatosChatResult {
     ],
   );
 
+  const rate = useCallback(
+    async (
+      messageId: string,
+      direction: PlatosRatingDirection,
+    ): Promise<boolean> => {
+      const msg = messagesRef.current.find((m) => m.id === messageId);
+      if (!msg?.serverId) {
+        // Not persisted yet (still streaming) — nothing to rate against.
+        return false;
+      }
+      const dirInt: 1 | -1 = direction === "up" ? 1 : -1;
+      const prevRating = msg.rating ?? null;
+      // Toggle: re-rating the same direction clears the vote.
+      const nextRating: 1 | -1 | null = prevRating === dirInt ? null : dirInt;
+      // Optimistic local update.
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === messageId ? { ...m, rating: nextRating } : m,
+        ),
+      );
+      try {
+        const client = await ensureClient();
+        if (nextRating === null) {
+          await client.messages.unrate(msg.serverId);
+        } else {
+          await client.messages.rate(msg.serverId, direction);
+        }
+        return true;
+      } catch (err) {
+        // Roll back on failure.
+        setMessages((prev) =>
+          prev.map((m) =>
+            m.id === messageId ? { ...m, rating: prevRating } : m,
+          ),
+        );
+        const e = err instanceof Error ? err : new Error(String(err));
+        args.onError?.(e);
+        return false;
+      }
+    },
+    [ensureClient, args.onError],
+  );
+
   // When the auth inputs change, reset so the next send re-authenticates.
   useEffect(() => {
     return () => {
@@ -235,7 +313,7 @@ export function usePlatosChat(args: UsePlatosChatArgs): UsePlatosChatResult {
   }, []);
 
   return useMemo(
-    () => ({ status, messages, send, abort, reset, threadId, error }),
-    [status, messages, send, abort, reset, threadId, error],
+    () => ({ status, messages, send, rate, abort, reset, threadId, error }),
+    [status, messages, send, rate, abort, reset, threadId, error],
   );
 }


### PR DESCRIPTION
## Why

The message-rating backend has been fully built for a while — `POST/GET/DELETE /api/v1/agent/messages/:id/rating`, satisfaction aggregates, the MCP `messages.rate` tool, and a memory-feedback loop (thumbs-down quarantines the memories extracted from that message; thumbs-up bumps their confidence). But **none of it was reachable from the published SDKs**, so embedded chat surfaces (the react-widget, the Winsen demo, any custom app) had no way to let end users vote. The satisfaction dashboards were effectively empty because nothing could write ratings from the product surface.

## What

**`@platosdev/client`**
- New `client.messages` namespace: `rate(messageId, "up"|"down", { comment? })`, `unrate(messageId)`, `getForMessage(messageId)`. Maps up/down → ±1, unwraps the server `{ rating }` / `{ removed }` / `{ userRating, aggregate }` shapes.
- Typed `message_persisted` stream event — already emitted by the agent (`agent-task.service.ts` → forwarded by the connections gateway), it carries the **server** `PlatosAgentMessage.id`, which is what you must rate (not the provisional client bubble id).
- Exports `PlatosRatingDirection`, `PlatosMessageRating`, `PlatosMessageRatingState`.
- 6 unit tests (URL path, ±1 mapping, id encoding, error shape, GET aggregate).

**`@platosdev/react-widget`**
- `usePlatosChat` captures `message_persisted` and stamps `serverId` + `rating` onto each assistant `ChatMessage`; returns a `rate(messageId, direction)` callback — optimistic, toggling the active vote clears it (un-rate), rolls back on failure.
- `<PlatosFab>` renders thumbs up/down on **persisted** assistant bubbles (only once `serverId` exists), with active-state styling.

## Notes
- **No agent/runtime change** — the backend was already deployed; this is purely the SDK surface. So no VPS rebuild needed for this PR.
- Changeset included (both packages, minor).
- Both packages build clean; client test suite 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)