### PR TITLE
feat(agent, skills): persistent per-thread sandbox sessions + run_shell CLI

### DIFF
--- a/apps/agent/src/skills/official/code_execution.skill.md
+++ b/apps/agent/src/skills/official/code_execution.skill.md
@@ -1,8 +1,8 @@
 ---
 id: platos.code_execution
 name: Code Execution
-description: Run Python or Node.js code in a secure E2B cloud sandbox. Handles data processing, ML, calculations, and file transformations without burning LLM tokens on raw data.
-version: 0.2.0
+description: Run Python, Node.js, AND arbitrary shell commands in a secure E2B cloud sandbox that PERSISTS across calls within a conversation. Clone repos, install packages, run CLI tools (git, psql, ffmpeg, duckdb), and build up state turn over turn.
+version: 0.3.0
 author: Platos
 origin: official
 spec_version: 1
@@ -10,24 +10,30 @@ tags:
   - code
   - compute
   - data
+  - cli
+  - shell
   - official
 required_env:
   - E2B_API_KEY
 provides_tools:
   - name: run_python
-    description: Execute Python 3 code in an isolated E2B sandbox. Returns stdout, stderr, and any error. Ideal for data processing, pandas/numpy, ML inference, chart generation, and file transformations. The sandbox has internet access and supports pip-installed packages via run_python itself (import pip; pip.main(['install', 'package'])).
+    description: Execute Python 3 in the conversation's persistent E2B sandbox. Returns stdout, stderr, and any error. Ideal for data processing, pandas/numpy, ML inference, chart generation, and file transformations. State persists across calls in the same conversation — files you write, packages you install, and the working directory all carry over to later run_python / run_node / run_shell calls.
     inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Python 3 source code to execute."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000,"description":"Max execution time in milliseconds. Default 15s, max 60s."}},"required":["code"]}
     handler: skill:platos.code_execution:run_python
   - name: run_node
-    description: Execute Node.js (JavaScript) code in an isolated E2B sandbox. Returns stdout, stderr, and any error. Ideal for JSON processing, string manipulation, and quick scripting tasks.
+    description: Execute Node.js (JavaScript) in the conversation's persistent E2B sandbox. Returns stdout, stderr, and any error. Ideal for JSON processing, string manipulation, and quick scripting. Shares the same persistent filesystem + installed packages as run_python and run_shell.
     inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Node.js source code to execute."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000,"description":"Max execution time in milliseconds. Default 15s, max 60s."}},"required":["code"]}
     handler: skill:platos.code_execution:run_node
+  - name: run_shell
+    description: Run an arbitrary shell command in the conversation's persistent E2B sandbox. This is full CLI access — git, psql, ffmpeg, duckdb, curl, pandoc, pnpm/npm, ripgrep, etc. The working directory and filesystem persist across calls, so you can clone a repo, cd into it, install deps, and run tests as separate steps. Returns exitCode (0 = success), stdout, and stderr — a non-zero exitCode is returned as data (not an error) so you can read stderr and decide what to do next.
+    inputSchema: {"type":"object","properties":{"command":{"type":"string","description":"The shell command to run, e.g. 'git clone https://github.com/x/y && cd y && pnpm install'."},"cwd":{"type":"string","description":"Working directory to run the command in. Persists from a prior command's cd only within that command; pass cwd explicitly to anchor. Optional."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":120000,"default":30000,"description":"Max execution time in milliseconds. Default 30s, max 120s."}},"required":["command"]}
+    handler: skill:platos.code_execution:run_shell
   - name: install_package
-    description: Install one or more Python (pip) or Node.js (npm) packages into an E2B sandbox session. Use this before run_python or run_node when a library is not available by default.
+    description: Install one or more Python (pip) or Node.js (npm) packages into the conversation's persistent sandbox. Installed packages stay available for every later run_python / run_node / run_shell call in the same conversation.
     inputSchema: {"type":"object","properties":{"packages":{"oneOf":[{"type":"string"},{"type":"array","items":{"type":"string"}}],"description":"Package name(s) to install. E.g. 'scikit-learn' or ['pandas','numpy']."},"manager":{"type":"string","enum":["pip","npm"],"default":"pip","description":"Package manager. Default: pip."}},"required":["packages"]}
     handler: skill:platos.code_execution:install_package
   - name: upload_to_sandbox
-    description: Download a Platos attachment (file the user uploaded) into the E2B sandbox filesystem so run_python or run_node can access it. Returns the sandbox file path to use in your code.
+    description: Download a Platos attachment (a file the user uploaded) into the conversation's persistent sandbox filesystem so run_python / run_node / run_shell can access it. Returns the sandbox file path. The file persists for the rest of the conversation.
     inputSchema: {"type":"object","properties":{"attachmentId":{"type":"string","description":"The Platos attachment ID from the user's message."},"destPath":{"type":"string","description":"Destination path in the sandbox. E.g. '/tmp/data.xlsx'. Defaults to /tmp/{attachmentId}."}},"required":["attachmentId"]}
     handler: skill:platos.code_execution:upload_to_sandbox
 ---
@@ -65,7 +71,34 @@ print(df.describe().to_string())
 print(f"Rows: {len(df)}, Columns: {list(df.columns)}")
 ```
 
+**Persistent CLI sessions (`run_shell`):**
+The sandbox lives for the whole conversation, so multi-step CLI workflows work
+as separate tool calls — the filesystem and installed tools carry over:
+```
+run_shell: git clone https://github.com/acme/widgets && cd widgets && ls
+run_shell: cd widgets && pnpm install
+run_shell: cd widgets && pnpm test
+```
+Use `run_shell` for anything a terminal does: `git`, `psql "$DATABASE_URL" -c '...'`,
+`ffmpeg -i in.mp4 out.gif`, `duckdb -c 'SELECT ...'`, `pandoc`, `curl`. Check the
+returned `exitCode` (0 = success) and read `stderr` on failure.
+
+**Sessions + lifecycle:**
+- Within one conversation, all calls share ONE sandbox: files, cwd, and
+  installed packages persist. `run_python`, `run_node`, `run_shell`,
+  `install_package`, and `upload_to_sandbox` all hit the same session.
+- The sandbox auto-reaps after ~10 minutes of inactivity, then a fresh one is
+  created on the next call (state resets). Don't rely on it surviving long gaps.
+- `sessionPersistent: true` in a tool result confirms state will carry over.
+
+**Network:**
+- Egress is OFF by default (deny-all). Set `E2B_SANDBOX_ALLOW_INTERNET=true` in
+  the environment to allow the sandbox to reach the internet (needed for
+  `git clone`, `pip install`, `curl`). Leave it off for untrusted-input agents.
+
 **Safety:**
-- Each execution runs in a fresh isolated sandbox — no state persists between calls
-- Sandboxes are killed immediately after execution completes
-- Never execute code that was supplied verbatim by an untrusted user without reviewing it
+- The sandbox is fully isolated from the Platos host; nothing it does can touch
+  the server. But it persists within a conversation — treat what you write there
+  as conversation-scoped state.
+- Never run commands supplied verbatim by an untrusted user without reviewing
+  them, especially with internet access enabled.

--- a/apps/agent/src/skills/official/code_execution.test.ts
+++ b/apps/agent/src/skills/official/code_execution.test.ts
@@ -10,10 +10,19 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockKill = vi.fn().mockResolvedValue(undefined);
 const mockRunCode = vi.fn();
+const mockCommandsRun = vi.fn();
+const mockSetTimeout = vi.fn().mockResolvedValue(undefined);
 const mockSandboxCreate = vi.fn();
+const mockSandboxConnect = vi.fn();
+const mockNextItems = vi.fn().mockResolvedValue([]); // default: no live session
+const mockSandboxList = vi.fn(() => ({ nextItems: mockNextItems }));
 
 vi.mock("@e2b/code-interpreter", () => ({
-  Sandbox: { create: mockSandboxCreate },
+  Sandbox: {
+    create: mockSandboxCreate,
+    connect: mockSandboxConnect,
+    list: mockSandboxList,
+  },
 }));
 
 function makeScopedEnv(keys: Record<string, string | null>) {
@@ -32,7 +41,16 @@ const SCOPE = { organizationId: "org1", projectId: "proj1", environmentId: "env1
 describe("platos.code_execution — run_python / run_node", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSandboxCreate.mockResolvedValue({ runCode: mockRunCode, kill: mockKill });
+    mockNextItems.mockResolvedValue([]); // no live session by default → ephemeral create
+    mockSandboxList.mockReturnValue({ nextItems: mockNextItems });
+    const sandboxStub = {
+      runCode: mockRunCode,
+      kill: mockKill,
+      setTimeout: mockSetTimeout,
+      commands: { run: mockCommandsRun },
+    };
+    mockSandboxCreate.mockResolvedValue(sandboxStub);
+    mockSandboxConnect.mockResolvedValue(sandboxStub);
   });
 
   it("returns stdout on successful execution", async () => {
@@ -109,7 +127,16 @@ describe("platos.code_execution — run_python / run_node", () => {
 describe("platos.code_execution — install_package", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSandboxCreate.mockResolvedValue({ runCode: mockRunCode, kill: mockKill });
+    mockNextItems.mockResolvedValue([]); // no live session by default → ephemeral create
+    mockSandboxList.mockReturnValue({ nextItems: mockNextItems });
+    const sandboxStub = {
+      runCode: mockRunCode,
+      kill: mockKill,
+      setTimeout: mockSetTimeout,
+      commands: { run: mockCommandsRun },
+    };
+    mockSandboxCreate.mockResolvedValue(sandboxStub);
+    mockSandboxConnect.mockResolvedValue(sandboxStub);
   });
 
   it("rejects package names with shell-dangerous characters", async () => {
@@ -141,5 +168,95 @@ describe("platos.code_execution — install_package", () => {
     const handler = await makeHandler();
     const result = await handler["installPackage"](SCOPE, { packages: ["scikit-learn>=1.0"] }) as Record<string, unknown>;
     expect(result.packages).toEqual(["scikit-learn>=1.0"]);
+  });
+});
+
+describe("platos.code_execution — run_shell (CLI)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNextItems.mockResolvedValue([]);
+    mockSandboxList.mockReturnValue({ nextItems: mockNextItems });
+    const stub = { runCode: mockRunCode, kill: mockKill, setTimeout: mockSetTimeout, commands: { run: mockCommandsRun } };
+    mockSandboxCreate.mockResolvedValue(stub);
+    mockSandboxConnect.mockResolvedValue(stub);
+  });
+
+  it("runs a command and returns exitCode + stdout", async () => {
+    mockCommandsRun.mockResolvedValue({ exitCode: 0, stdout: "file.txt\n", stderr: "" });
+    const handler = await makeHandler();
+    const result = await handler["runShell"](SCOPE, { command: "ls" }) as Record<string, unknown>;
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("file.txt");
+    expect(mockCommandsRun).toHaveBeenCalledWith("ls", { timeoutMs: 30_000 });
+  });
+
+  it("returns non-zero exit as data (not a thrown error)", async () => {
+    const exitErr: any = new Error("command failed");
+    exitErr.exitCode = 2;
+    exitErr.stderr = "fatal: not a git repo";
+    exitErr.stdout = "";
+    mockCommandsRun.mockRejectedValue(exitErr);
+    const handler = await makeHandler();
+    const result = await handler["runShell"](SCOPE, { command: "git status" }) as Record<string, unknown>;
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain("not a git repo");
+  });
+
+  it("requires E2B_API_KEY", async () => {
+    const handler = await makeHandler({ E2B_API_KEY: null });
+    await expect(handler["runShell"](SCOPE, { command: "ls" })).rejects.toThrow("E2B_API_KEY");
+  });
+
+  it("requires a command", async () => {
+    const handler = await makeHandler();
+    await expect(handler["runShell"](SCOPE, { command: "  " })).rejects.toThrow("command is required");
+  });
+
+  it("clamps timeoutMs to 120s max", async () => {
+    mockCommandsRun.mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+    const handler = await makeHandler();
+    await handler["runShell"](SCOPE, { command: "sleep 1", timeoutMs: 999_999 });
+    expect(mockCommandsRun).toHaveBeenCalledWith("sleep 1", { timeoutMs: 120_000 });
+  });
+});
+
+describe("platos.code_execution — persistent thread session", () => {
+  const THREAD_SCOPE = { ...SCOPE, threadId: "thr_abc" } as typeof SCOPE & { threadId: string };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSandboxList.mockReturnValue({ nextItems: mockNextItems });
+    const stub = { runCode: mockRunCode, kill: mockKill, setTimeout: mockSetTimeout, commands: { run: mockCommandsRun } };
+    mockSandboxCreate.mockResolvedValue(stub);
+    mockSandboxConnect.mockResolvedValue(stub);
+    mockRunCode.mockResolvedValue({ logs: { stdout: ["ok"], stderr: [] }, error: null });
+  });
+
+  it("reconnects to an existing session sandbox and does NOT kill it", async () => {
+    mockNextItems.mockResolvedValue([{ sandboxId: "sbx_live" }]);
+    const handler = await makeHandler();
+    const result = await handler["runCode"](THREAD_SCOPE, "python", { code: "print(1)" }) as Record<string, unknown>;
+    expect(mockSandboxConnect).toHaveBeenCalledWith("sbx_live", expect.objectContaining({ apiKey: "test-key" }));
+    expect(mockSandboxCreate).not.toHaveBeenCalled();
+    expect(mockKill).not.toHaveBeenCalled(); // session persists
+    expect(result.sessionPersistent).toBe(true);
+  });
+
+  it("creates a thread-tagged session when none exists, and keeps it alive", async () => {
+    mockNextItems.mockResolvedValue([]); // no live session
+    const handler = await makeHandler();
+    const result = await handler["runCode"](THREAD_SCOPE, "python", { code: "print(1)" }) as Record<string, unknown>;
+    expect(mockSandboxCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ metadata: { platosThread: "thr_abc", platos: "session" } }),
+    );
+    expect(mockKill).not.toHaveBeenCalled(); // session persists across calls
+    expect(result.sessionPersistent).toBe(true);
+  });
+
+  it("ephemeral (no threadId) sandbox IS killed", async () => {
+    const handler = await makeHandler();
+    const result = await handler["runCode"](SCOPE, "python", { code: "print(1)" }) as Record<string, unknown>;
+    expect(mockKill).toHaveBeenCalledOnce();
+    expect(result.sessionPersistent).toBe(false);
   });
 });

--- a/apps/agent/src/skills/official/skill-handlers.ts
+++ b/apps/agent/src/skills/official/skill-handlers.ts
@@ -67,6 +67,7 @@ export class OfficialSkillHandlers {
       case "platos.code_execution":
         if (toolName === "run_python") return this.runCode(scope, "python", input);
         if (toolName === "run_node") return this.runCode(scope, "node", input);
+        if (toolName === "run_shell") return this.runShell(scope, input);
         if (toolName === "install_package") return this.installPackage(scope, input);
         if (toolName === "upload_to_sandbox") return this.uploadToSandbox(scope, input);
         break;
@@ -777,6 +778,94 @@ export class OfficialSkillHandlers {
   // platos.code_execution
   // ──────────────────────────────────────────────────────────────────────────
 
+  // ──────────────────────────────────────────────────────────────────────────
+  // Persistent per-thread sandbox session (CE.2).
+  //
+  // The original code_execution skill created a throwaway sandbox per call and
+  // killed it in `finally` — so files, cwd, installed packages, and `git clone`
+  // results never survived between tool calls. That makes real CLI workflows
+  // (clone → cd → install → test, or write data → transform → export)
+  // impossible.
+  //
+  // This binds ONE sandbox to the PlatosAgentThread, reused across every tool
+  // call in that thread. We need no new table or Redis: E2B sandboxes carry
+  // `metadata` and are discoverable via `Sandbox.list({ query: { metadata } })`.
+  // We tag each session sandbox with the threadId, look it up + `connect` on the
+  // next call, and bump its idle timeout. When the thread has no id (meta-tool
+  // paths), we fall back to an ephemeral per-call sandbox (killed by the caller).
+  //
+  // Lifetime is governed by E2B's own idle timeout (default 5m, bumped on each
+  // use) — when the thread goes quiet the sandbox auto-reaps server-side, so
+  // there is no orphan-reaper to run. Network egress is deny-by-default unless
+  // the agent's E2B_SANDBOX_ALLOW_INTERNET env opts in.
+  // ──────────────────────────────────────────────────────────────────────────
+
+  private static readonly SESSION_TIMEOUT_MS = 600_000; // 10 min idle ceiling per use
+
+  private threadIdFromScope(scope: ScopeTuple): string {
+    const raw = (scope as Record<string, unknown>)["threadId"];
+    return typeof raw === "string" ? raw.trim() : "";
+  }
+
+  /**
+   * Resolve the sandbox for this thread: reconnect to the live session if one
+   * exists, otherwise create + tag a fresh one. Returns the sandbox plus an
+   * `ephemeral` flag — ephemeral sandboxes (no threadId) MUST be killed by the
+   * caller; session sandboxes are left running for the next tool call.
+   */
+  private async resolveSandbox(
+    scope: ScopeTuple,
+    apiKey: string,
+  ): Promise<{ sandbox: Sandbox; ephemeral: boolean }> {
+    const threadId = this.threadIdFromScope(scope);
+    const template = await this.scopedEnv.get(scope, "E2B_SANDBOX_TEMPLATE");
+    const allowInternet =
+      (await this.scopedEnv.get(scope, "E2B_SANDBOX_ALLOW_INTERNET")) === "true";
+
+    // Ephemeral fallback when there's no thread to anchor to.
+    if (!threadId) {
+      const sandbox = await (template
+        ? Sandbox.create(template, { apiKey, allowInternetAccess: allowInternet })
+        : Sandbox.create({ apiKey, allowInternetAccess: allowInternet }));
+      return { sandbox, ephemeral: true };
+    }
+
+    const metaTag = `platos-thread:${threadId}`;
+
+    // Try to reconnect to an existing running session for this thread.
+    try {
+      const paginator = Sandbox.list({
+        query: { metadata: { platosThread: threadId }, state: ["running"] },
+        apiKey,
+      });
+      const running = await paginator.nextItems();
+      if (running.length > 0) {
+        const sandbox = await Sandbox.connect(running[0].sandboxId, { apiKey });
+        await sandbox
+          .setTimeout(OfficialSkillHandlers.SESSION_TIMEOUT_MS)
+          .catch(() => { /* best effort idle bump */ });
+        return { sandbox, ephemeral: false };
+      }
+    } catch (err: any) {
+      // List/connect failure → fall through to create a fresh session.
+      this.logger.debug(
+        `[code_execution] session reconnect miss for ${metaTag}: ${err?.message ?? err}`,
+      );
+    }
+
+    // No live session → create one, tagged so the next call finds it.
+    const opts = {
+      apiKey,
+      metadata: { platosThread: threadId, platos: "session" },
+      timeoutMs: OfficialSkillHandlers.SESSION_TIMEOUT_MS,
+      allowInternetAccess: allowInternet,
+    };
+    const sandbox = await (template
+      ? Sandbox.create(template, opts)
+      : Sandbox.create(opts));
+    return { sandbox, ephemeral: false };
+  }
+
   private async runCode(
     scope: ScopeTuple,
     lang: "python" | "node",
@@ -795,12 +884,7 @@ export class OfficialSkillHandlers {
 
     const timeoutMs = Math.max(1000, Math.min(60_000, Number(input.timeoutMs ?? 15_000)));
 
-    // Pro plan default: 2 vCPU. Set E2B_SANDBOX_TEMPLATE to a custom template
-    // ID when the agent needs more RAM (built via `e2b template build`).
-    const template = await this.scopedEnv.get(scope, "E2B_SANDBOX_TEMPLATE");
-    const sandbox = await (template
-      ? Sandbox.create(template, { apiKey })
-      : Sandbox.create({ apiKey }));
+    const { sandbox, ephemeral } = await this.resolveSandbox(scope, apiKey);
     const startedAt = Date.now();
 
     try {
@@ -814,7 +898,7 @@ export class OfficialSkillHandlers {
       const hasError = execution.error != null;
 
       this.logger.debug(
-        `[code_execution] run_${lang} exitOk=${!hasError} latencyMs=${latencyMs} ` +
+        `[code_execution] run_${lang} session=${!ephemeral} exitOk=${!hasError} latencyMs=${latencyMs} ` +
         `stdout_chars=${stdout.length} stderr_chars=${stderr.length}`,
       );
 
@@ -824,10 +908,67 @@ export class OfficialSkillHandlers {
         stderr: stderr || null,
         error: hasError ? (execution.error?.value ?? "Execution error") : null,
         latencyMs,
+        // Surface whether state persists so the LLM knows it can build on prior calls.
+        sessionPersistent: !ephemeral,
       };
     } finally {
-      // Always kill sandbox — never leave resources dangling
-      await sandbox.kill().catch(() => { /* best effort */ });
+      // Only tear down ephemeral (no-thread) sandboxes. Session sandboxes stay
+      // alive for the next tool call and auto-reap on idle.
+      if (ephemeral) await sandbox.kill().catch(() => { /* best effort */ });
+    }
+  }
+
+  /**
+   * CE.2 — run an arbitrary shell command in the thread's persistent sandbox.
+   * This is what turns "code interpreter" into "CLI on demand": `git`, `psql`,
+   * `ffmpeg`, `duckdb`, `pnpm test`, etc. all run here, with cwd + filesystem
+   * surviving across calls. Output is byte-capped; exit code is surfaced so the
+   * LLM can branch on failure.
+   */
+  private async runShell(scope: ScopeTuple, input: Record<string, unknown>) {
+    const apiKey = await this.scopedEnv.get(scope, "E2B_API_KEY");
+    if (!apiKey) throw new Error("run_shell: E2B_API_KEY is not set in this environment.");
+
+    const cmd = String(input.command ?? "").trim();
+    if (!cmd) throw new Error("run_shell: command is required");
+
+    const timeoutMs = Math.max(1000, Math.min(120_000, Number(input.timeoutMs ?? 30_000)));
+    const cwd = typeof input.cwd === "string" && input.cwd.trim() ? input.cwd.trim() : undefined;
+    const MAX_OUT = 100_000; // cap each stream so a runaway command can't blow the context window
+
+    const { sandbox, ephemeral } = await this.resolveSandbox(scope, apiKey);
+    const startedAt = Date.now();
+    try {
+      const result = await sandbox.commands.run(cmd, {
+        timeoutMs,
+        ...(cwd ? { cwd } : {}),
+      });
+      const clip = (s: string) =>
+        s.length > MAX_OUT ? s.slice(0, MAX_OUT) + `\n…[truncated ${s.length - MAX_OUT} chars]` : s;
+      return {
+        command: cmd,
+        exitCode: result.exitCode,
+        stdout: clip(result.stdout ?? "").trim() || null,
+        stderr: clip(result.stderr ?? "").trim() || null,
+        latencyMs: Date.now() - startedAt,
+        sessionPersistent: !ephemeral,
+      };
+    } catch (err: any) {
+      // E2B throws CommandExitError on non-zero exit — surface it as a result,
+      // not a thrown skill error, so the LLM can read stderr + branch.
+      const exitCode = typeof err?.exitCode === "number" ? err.exitCode : 1;
+      const stderr = typeof err?.stderr === "string" ? err.stderr : (err?.message ?? String(err));
+      const stdout = typeof err?.stdout === "string" ? err.stdout : "";
+      return {
+        command: cmd,
+        exitCode,
+        stdout: stdout.slice(0, MAX_OUT).trim() || null,
+        stderr: stderr.slice(0, MAX_OUT).trim() || null,
+        latencyMs: Date.now() - startedAt,
+        sessionPersistent: !ephemeral,
+      };
+    } finally {
+      if (ephemeral) await sandbox.kill().catch(() => { /* best effort */ });
     }
   }
 
@@ -846,7 +987,9 @@ export class OfficialSkillHandlers {
       ? `const { execSync } = require('child_process'); execSync('npm install ${validPackages.join(" ")}', { stdio: 'inherit' });`
       : `import subprocess; subprocess.run(['pip', 'install', '--quiet', ${validPackages.map((p) => `'${p}'`).join(", ")}], check=True); print("Installed: ${validPackages.join(", ")}")`;
 
-    const sandbox = await Sandbox.create({ apiKey });
+    // Install into the thread's persistent session so the packages are still
+    // there on the next run_python / run_node / run_shell call.
+    const { sandbox, ephemeral } = await this.resolveSandbox(scope, apiKey);
     try {
       const execution = manager === "npm"
         ? await sandbox.runCode(code, { language: "js", timeoutMs: 60_000 })
@@ -857,9 +1000,10 @@ export class OfficialSkillHandlers {
         stdout: execution.logs.stdout.join("\n").trim() || null,
         stderr: execution.logs.stderr.join("\n").trim() || null,
         error: execution.error?.value ?? null,
+        sessionPersistent: !ephemeral,
       };
     } finally {
-      await sandbox.kill().catch(() => { /* best effort */ });
+      if (ephemeral) await sandbox.kill().catch(() => { /* best effort */ });
     }
   }
 
@@ -902,7 +1046,9 @@ urllib.request.urlretrieve('${presignedUrl.replace(/'/g, "\\'")}', '${destPath}'
 print(f"Downloaded {os.path.getsize('${destPath}')} bytes to ${destPath}")
 `.trim();
 
-    const sandbox = await Sandbox.create({ apiKey });
+    // Download into the thread's persistent session so the file is available to
+    // every subsequent run_python / run_node / run_shell call.
+    const { sandbox, ephemeral } = await this.resolveSandbox(scope, apiKey);
     try {
       const execution = await sandbox.runCode(code, { timeoutMs: 60_000 });
       return {
@@ -912,9 +1058,10 @@ print(f"Downloaded {os.path.getsize('${destPath}')} bytes to ${destPath}")
         sandboxPath: destPath,
         stdout: execution.logs.stdout.join("\n").trim() || null,
         error: execution.error?.value ?? null,
+        sessionPersistent: !ephemeral,
       };
     } finally {
-      await sandbox.kill().catch(() => { /* best effort */ });
+      if (ephemeral) await sandbox.kill().catch(() => { /* best effort */ });
     }
   }
 


### PR DESCRIPTION
## What

Upgrades the `platos.code_execution` skill from **ephemeral-per-call** E2B sandboxes to **persistent per-thread sessions with full CLI access** — the agent can `git clone`, `cd`, install packages, and run arbitrary CLI tools (`psql`, `ffmpeg`, `duckdb`, `curl`, `pnpm`…) with the filesystem, cwd, and installed packages **persisting across tool calls within a conversation**.

## How

- **`resolveSandbox()`** — binds a sandbox to the conversation via E2B `metadata: { platosThread: threadId }`, looked up with `Sandbox.list` and reconnected with `Sandbox.connect`. **No new DB table or Redis** — E2B's idle timeout auto-reaps (~10 min). Falls back to ephemeral `Sandbox.create` when no `threadId` is in scope.
- **`run_shell`** — new tool for arbitrary shell commands. A non-zero exit is returned as **data** (`exitCode`/`stdout`/`stderr`) rather than thrown, so the model can read `stderr` and recover. `timeoutMs` clamped to 120s.
- **`run_python` / `run_node` / `install_package` / `upload_to_sandbox`** now share the one session. Ephemeral sandboxes are still killed; session sandboxes are left alive.
- **Egress deny-by-default** (`allowInternetAccess: false`) unless `E2B_SANDBOX_ALLOW_INTERNET=true`. Optional `E2B_SANDBOX_TEMPLATE`.
- Manifest → **v0.3.0**; every result carries a `sessionPersistent` flag.

## Security

- Untrusted code stays off the host — it runs in E2B microVMs, never on the Hostinger box.
- Network egress is **off by default**; `git clone`/`pip install`/`curl` require explicitly enabling `E2B_SANDBOX_ALLOW_INTERNET`.
- Multi-tenant scope unchanged — `threadId` is read from the already-scoped request, sandbox binding is per-thread.

## Tests

+8 tests (run_shell success / non-zero-exit-as-data / missing-key guard / missing-command guard / timeout clamp; session reconnect; session create-and-keep-alive; ephemeral-kill). **20/20 pass.** `typecheck --filter platos-agent` green.

## Deploy note

This is `apps/agent` runtime code → **needs a VPS rebuild/restart** of the agent container after merge. Requires `E2B_API_KEY` in the agent env (already present for the existing skill); `E2B_SANDBOX_ALLOW_INTERNET` optional. Not a published package — no npm release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)