### PR TITLE
fix(agent): builder toolchain for native deps + docs for persistent sandbox

### DIFF
--- a/apps/agent/Dockerfile
+++ b/apps/agent/Dockerfile
@@ -15,7 +15,11 @@ ARG NODE_IMAGE=node:20-slim
 # ───────────────────────────────────────────────────────────
 FROM ${NODE_IMAGE} AS builder
 
-RUN apt-get update && apt-get install -y openssl ca-certificates \
+# openssl/ca-certificates for Prisma + TLS; python3/make/g++ so node-gyp can
+# compile native modules pulled in transitively at install time (e.g.
+# better-sqlite3 via the `evalite` dev tool). These live ONLY in the builder
+# stage — the runtime image below stays slim and never sees the toolchain.
+RUN apt-get update && apt-get install -y openssl ca-certificates python3 make g++ \
     && rm -rf /var/lib/apt/lists/*
 RUN corepack enable && corepack prepare pnpm@10.23.0 --activate
 

--- a/content/docs/official-skills.md
+++ b/content/docs/official-skills.md
@@ -19,9 +19,9 @@ related:
   - attachments-and-files
 source_files_referenced:
   - apps/agent/src/skills/official
+  - apps/agent/src/skills/official/code_execution.skill.md
+  - apps/agent/src/skills/official/skill-handlers.ts
   - apps/agent/src/skills/official-skills-seeder.service.ts
-  - packages/skills/platos-code-runner
-  - docs/pra/PRA_SPEC_CODE_EXECUTION.md
 ---
 
 # Official skills catalog
@@ -32,7 +32,7 @@ Platos ships with a small set of first-party skills you can toggle on without au
 
 The official catalogue currently includes:
 
-- **platos-code-runner**: sandboxed Python and shell execution via E2B. Tools include `execute_python`, `execute_shell`, `read_file`, `write_file`, `list_dir`, plus a MinIO bridge so the agent can reference uploaded attachments and emit output files. Requires `E2B_API_KEY`.
+- **platos.code_execution** (Code Execution): Python, Node.js, **and arbitrary shell** execution in a secure E2B cloud sandbox that **persists across calls within a conversation**. Tools: `run_python`, `run_node`, `run_shell`, `install_package`, `upload_to_sandbox`. The agent can `git clone` a repo, `cd` into it, install deps, and run CLI tools (`psql`, `ffmpeg`, `duckdb`, `curl`, `pnpm`…) as separate turns — the filesystem, working directory, and installed packages all carry over. Requires `E2B_API_KEY`.
 - **csv-ops**: streaming CSV operations (filter, group, aggregate, pivot, join) without loading the file into the LLM context. Useful for the "30k-row Excel" workload that would otherwise blow the context window. No external env required.
 - **file-operations**: read, write, and edit files inside the conversation's attachment scope. Pairs naturally with code-runner.
 - **image-generation**: generate images via OpenAI or Anthropic image endpoints. Requires the matching provider key.
@@ -54,9 +54,44 @@ Official skills are how Platos solves the "I want my agent to crunch a CSV" or "
 
 From the dashboard, navigate to the Skills tab on an agent's detail page, then toggle the skill on. If the skill has `required_env` and any are missing, the toggle stays off and points you at [Providers](/docs/providers) or the environment variables panel.
 
-### Code-runner sandbox lifecycle
+### Persistent sandbox sessions
 
-`platos-code-runner` provisions an E2B sandbox at first tool call within a turn and reuses it for the remainder of that turn. Files uploaded to the conversation are mounted at `/mnt/attachments`. Output files written to `/mnt/outputs` are picked up at turn end and uploaded to MinIO as artifacts. Wall-clock and CPU caps are enforced by E2B itself; Platos enforces a token budget on top.
+The sandbox is bound to the **conversation thread**, not a single turn. On the first
+tool call Platos creates an E2B sandbox tagged with the thread id (`metadata.platosThread`);
+every later `run_python` / `run_node` / `run_shell` / `install_package` / `upload_to_sandbox`
+call in the same thread reconnects to that one sandbox. Files you write, the working
+directory, and packages you install all carry over. Each result includes
+`sessionPersistent: true` to confirm state will survive to the next call.
+
+This makes multi-step CLI workflows possible across turns:
+
+```
+run_shell: git clone https://github.com/acme/widgets && cd widgets && ls
+run_shell: cd widgets && pnpm install
+run_shell: cd widgets && pnpm test
+```
+
+`run_shell` is full CLI access — `git`, `psql "$DATABASE_URL" -c '…'`, `ffmpeg`, `duckdb`,
+`pandoc`, `curl`, `ripgrep`, etc. A **non-zero exit code is returned as data** (`exitCode`,
+`stdout`, `stderr`) rather than thrown, so the model can read `stderr` and recover.
+`run_shell` is capped at 120s per command; `run_python`/`run_node` at 60s.
+
+**Lifecycle / cost.** The sandbox auto-reaps after ~10 minutes of inactivity, after which
+the next call creates a fresh one (state resets). There is no per-turn teardown — the session
+is what makes the workflow above work — so long idle gaps, not active use, are what end it.
+When no thread is in scope (e.g. a one-shot SDK call), the sandbox is ephemeral and torn down
+immediately after the call.
+
+**Network.** Egress is **off by default** (deny-all). Set `E2B_SANDBOX_ALLOW_INTERNET=true`
+to let the sandbox reach the internet — required for `git clone`, `pip install`, and `curl`.
+Leave it off for agents that take untrusted input. Optionally pin a custom microVM image with
+`E2B_SANDBOX_TEMPLATE`.
+
+**Where these vars live.** `E2B_API_KEY`, `E2B_SANDBOX_ALLOW_INTERNET`, and
+`E2B_SANDBOX_TEMPLATE` are resolved **per scope** from the dashboard's environment-variables
+panel (org/project/environment), the same way `RESEND_API_KEY` and the other skill keys are —
+they are *not* read from the agent container's process environment. Set them on the
+environment you run the agent in; each tenant brings their own E2B key.
 
 ### Disable a seeded skill
 
@@ -68,7 +103,9 @@ The official catalogue lives next to its tests (`*.test.ts`). When you fork and 
 
 ## Common pitfalls
 
-- E2B charges per-second of sandbox runtime. A long-lived turn that holds a sandbox open is more expensive than two short turns. Code-runner releases the sandbox at turn end automatically, but `spawn_bgo` calls inherit the pricing.
+- E2B charges per-second of sandbox runtime. Because the sandbox now persists for the whole thread, it stays billable until the ~10-minute idle reap — not just for one turn. That is the intended trade for cross-turn state; if you only need a one-shot run, the ephemeral path (no thread in scope) tears down immediately.
+- `run_shell` does not thread `cwd` between separate calls automatically — a `cd` only lasts for the command it runs in. Chain steps in one command (`cd dir && …`) or pass `cwd` explicitly to anchor where a command runs.
+- With `E2B_SANDBOX_ALLOW_INTERNET=true`, the sandbox can reach the internet. Don't run commands supplied verbatim by an untrusted user with egress enabled — review them first.
 - `platos-rag` only retrieves from indices the agent has access to. Cross-project retrieval is rejected at the auth layer.
 - The seeder runs every boot. If you renamed a slug locally, the old row stays and a new row is created. Clean up old rows before relying on slug uniqueness.
 - `csv-ops` opens files via the file-operations bridge. It does not pull from external URLs; upload first.


### PR DESCRIPTION
Deploy-enablers for the persistent `code_execution` sandbox (#26).

## Dockerfile — native build toolchain in the builder stage

The agent image build (`docker compose build agent`) was failing at `pnpm install --no-frozen-lockfile`:

```
better-sqlite3 install: gyp ERR! find Python - Could not find any Python installation to use
```

`better-sqlite3` (a native module) is pulled in **transitively via the `evalite` dev tool**. The full workspace install in the builder stage runs its `node-gyp` postinstall, but `node:20-slim` ships no Python/`make`/`g++`. The last agent rebuild predated `evalite` entering the tree, so this is a latent build break — not caused by #26, but surfaced by deploying it.

Fix: add `python3 make g++` to the **builder** stage only. better-sqlite3 bundles its own SQLite amalgamation, so no extra `-dev` headers are needed. The **runtime** image is untouched and stays slim (it never sees the toolchain).

## Docs — official-skills catalog

The catalog described a stale `platos-code-runner` with tools (`execute_python`, `execute_shell`) that don't exist. Corrected to the real skill:

- `platos.code_execution` → `run_python`, `run_node`, `run_shell`, `install_package`, `upload_to_sandbox`.
- Documented **persistent per-thread sessions** (sandbox bound via E2B `metadata.platosThread`, ~10-min idle reap), the `run_shell` CLI (non-zero exit returned as data), egress deny-by-default (`E2B_SANDBOX_ALLOW_INTERNET`), and that `E2B_*` keys resolve **per-scope from the dashboard** (like `RESEND_API_KEY`), not the container env.

## Verification

This is build/docs only — CI typecheck is unaffected and stays the gate. The Dockerfile fix is verified by the VPS rebuild after merge; `up -d` only swaps the container after a clean build, so a failed build leaves the current container serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)