### PR TITLE
fix(agent, skills): seed code_execution with run_shell + full toolset

### DIFF
--- a/apps/agent/src/skills/official/code_execution.skill.md
+++ b/apps/agent/src/skills/official/code_execution.skill.md
@@ -15,6 +15,9 @@ tags:
   - official
 required_env:
   - E2B_API_KEY
+optional_env:
+  - E2B_SANDBOX_ALLOW_INTERNET
+  - E2B_SANDBOX_TEMPLATE
 provides_tools:
   - name: run_python
     description: Execute Python 3 in the conversation's persistent E2B sandbox. Returns stdout, stderr, and any error. Ideal for data processing, pandas/numpy, ML inference, chart generation, and file transformations. State persists across calls in the same conversation — files you write, packages you install, and the working directory all carry over to later run_python / run_node / run_shell calls.

--- a/apps/agent/src/skills/official/official-skills.test.ts
+++ b/apps/agent/src/skills/official/official-skills.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Theme S — Official skill source blobs are the SEED source of truth.
+ *
+ * The seeder (OfficialSkillsSeederService) registers tools from the embedded
+ * string constants in `official-skills.ts`, NOT from the sibling `.skill.md`
+ * files. The two are kept in sync by hand, and they HAVE drifted before
+ * (code_execution shipped run_shell + install_package + upload_to_sandbox in
+ * the .md while the embedded constant still only declared run_python/run_node).
+ *
+ * These tests parse every embedded source through the real manifest parser so
+ * a malformed blob or a missing tool can never reach the seeder again.
+ */
+import { describe, expect, it } from "vitest";
+import { OFFICIAL_SKILL_SOURCES } from "./official-skills";
+import { parseSkill } from "../skill-manifest.parser";
+
+describe("OFFICIAL_SKILL_SOURCES", () => {
+  it("every embedded official skill parses and declares its id", () => {
+    for (const { id, source } of OFFICIAL_SKILL_SOURCES) {
+      const parsed = parseSkill(source);
+      expect(parsed.manifest.id, `${id} should parse`).toBe(id);
+      expect(parsed.manifest.provides_tools.length, `${id} has tools`).toBeGreaterThan(0);
+      // Every tool handler is namespaced under the skill id.
+      for (const tool of parsed.manifest.provides_tools) {
+        expect(tool.handler, `${id}.${tool.name} handler`).toBe(
+          `skill:${id}:${tool.name}`,
+        );
+      }
+    }
+  });
+
+  it("code_execution exposes the full persistent-sandbox toolset at v0.3.0", () => {
+    const src = OFFICIAL_SKILL_SOURCES.find((s) => s.id === "platos.code_execution");
+    expect(src).toBeDefined();
+    const parsed = parseSkill(src!.source);
+    expect(parsed.manifest.version).toBe("0.3.0");
+    const toolNames = parsed.manifest.provides_tools.map((t) => t.name).sort();
+    expect(toolNames).toEqual(
+      ["install_package", "run_node", "run_python", "run_shell", "upload_to_sandbox"].sort(),
+    );
+    expect(parsed.manifest.required_env).toContain("E2B_API_KEY");
+
+    // run_shell schema requires `command` and caps timeout at 120s.
+    const shell = parsed.manifest.provides_tools.find((t) => t.name === "run_shell");
+    expect(shell?.inputSchema).toBeDefined();
+    const schema = shell!.inputSchema as Record<string, any>;
+    expect(schema.required).toContain("command");
+    expect(schema.properties.timeoutMs.maximum).toBe(120000);
+  });
+});

--- a/apps/agent/src/skills/official/official-skills.ts
+++ b/apps/agent/src/skills/official/official-skills.ts
@@ -53,40 +53,84 @@ You can search the public web and fetch URLs.
 export const CODE_EXECUTION_SKILL = `---
 id: platos.code_execution
 name: Code Execution
-description: Run Python or Node.js snippets in an isolated sandbox. Uses E2B when configured, otherwise the local seccomp-sandboxed container.
-version: 0.1.0
+description: Run Python, Node.js, AND arbitrary shell commands in a secure E2B cloud sandbox that PERSISTS across calls within a conversation. Clone repos, install packages, run CLI tools (git, psql, ffmpeg, duckdb), and build up state turn over turn.
+version: 0.3.0
 author: Platos
 origin: official
 spec_version: 1
 tags:
   - code
   - compute
+  - data
+  - cli
+  - shell
   - official
 required_env:
   - E2B_API_KEY
 optional_env:
-  - PLATOS_SANDBOX_IMAGE
+  - E2B_SANDBOX_ALLOW_INTERNET
+  - E2B_SANDBOX_TEMPLATE
 provides_tools:
   - name: run_python
-    description: Execute a Python 3 snippet in an isolated sandbox. Returns stdout, stderr, and any returned value.
-    inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Python source code."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000}},"required":["code"]}
+    description: Execute Python 3 in the conversation's persistent E2B sandbox. Returns stdout, stderr, and any error. Ideal for data processing, pandas/numpy, ML inference, chart generation, and file transformations. State persists across calls in the same conversation — files you write, packages you install, and the working directory all carry over to later run_python / run_node / run_shell calls.
+    inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Python 3 source code to execute."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000,"description":"Max execution time in milliseconds. Default 15s, max 60s."}},"required":["code"]}
     handler: skill:platos.code_execution:run_python
   - name: run_node
-    description: Execute a Node.js snippet in an isolated sandbox.
-    inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Node.js source code."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000}},"required":["code"]}
+    description: Execute Node.js (JavaScript) in the conversation's persistent E2B sandbox. Returns stdout, stderr, and any error. Ideal for JSON processing, string manipulation, and quick scripting. Shares the same persistent filesystem + installed packages as run_python and run_shell.
+    inputSchema: {"type":"object","properties":{"code":{"type":"string","description":"Node.js source code to execute."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":60000,"default":15000,"description":"Max execution time in milliseconds. Default 15s, max 60s."}},"required":["code"]}
     handler: skill:platos.code_execution:run_node
+  - name: run_shell
+    description: Run an arbitrary shell command in the conversation's persistent E2B sandbox. This is full CLI access — git, psql, ffmpeg, duckdb, curl, pandoc, pnpm/npm, ripgrep, etc. The working directory and filesystem persist across calls, so you can clone a repo, cd into it, install deps, and run tests as separate steps. Returns exitCode (0 = success), stdout, and stderr — a non-zero exitCode is returned as data (not an error) so you can read stderr and decide what to do next.
+    inputSchema: {"type":"object","properties":{"command":{"type":"string","description":"The shell command to run, e.g. 'git clone https://github.com/x/y && cd y && pnpm install'."},"cwd":{"type":"string","description":"Working directory to run the command in. Persists from a prior command's cd only within that command; pass cwd explicitly to anchor. Optional."},"timeoutMs":{"type":"integer","minimum":1000,"maximum":120000,"default":30000,"description":"Max execution time in milliseconds. Default 30s, max 120s."}},"required":["command"]}
+    handler: skill:platos.code_execution:run_shell
+  - name: install_package
+    description: Install one or more Python (pip) or Node.js (npm) packages into the conversation's persistent sandbox. Installed packages stay available for every later run_python / run_node / run_shell call in the same conversation.
+    inputSchema: {"type":"object","properties":{"packages":{"oneOf":[{"type":"string"},{"type":"array","items":{"type":"string"}}],"description":"Package name(s) to install. E.g. 'scikit-learn' or ['pandas','numpy']."},"manager":{"type":"string","enum":["pip","npm"],"default":"pip","description":"Package manager. Default: pip."}},"required":["packages"]}
+    handler: skill:platos.code_execution:install_package
+  - name: upload_to_sandbox
+    description: Download a Platos attachment (a file the user uploaded) into the conversation's persistent sandbox filesystem so run_python / run_node / run_shell can access it. Returns the sandbox file path. The file persists for the rest of the conversation.
+    inputSchema: {"type":"object","properties":{"attachmentId":{"type":"string","description":"The Platos attachment ID from the user's message."},"destPath":{"type":"string","description":"Destination path in the sandbox. E.g. '/tmp/data.xlsx'. Defaults to /tmp/{attachmentId}."}},"required":["attachmentId"]}
+    handler: skill:platos.code_execution:upload_to_sandbox
 ---
 
-You can run short Python and Node.js scripts in an isolated sandbox.
+You can execute Python, Node.js, and arbitrary shell commands in a secure,
+isolated cloud sandbox that persists for the whole conversation.
 
-**When to use:**
-- The user asks for a calculation, data transformation, or quick experiment.
-- You need to verify a numerical claim before answering.
+**When to use \`run_python\`:**
+- Process a large file, dataset, or spreadsheet (never read raw data into your
+  context — write code that opens the file path and processes it directly).
+- Run calculations, statistics, or ML on data; generate a chart or CSV.
+
+**When to use \`run_node\`:**
+- Quick JSON manipulation, string operations, or JavaScript-specific tasks.
+
+**When to use \`run_shell\`:**
+- Anything a terminal does: \`git\`, \`psql "$DATABASE_URL" -c '...'\`,
+  \`ffmpeg -i in.mp4 out.gif\`, \`duckdb -c 'SELECT ...'\`, \`pandoc\`, \`curl\`.
+- The sandbox persists, so multi-step CLI workflows run as separate calls:
+  1. \`git clone https://github.com/acme/widgets && cd widgets && ls\`
+  2. \`cd widgets && pnpm install\`
+  3. \`cd widgets && pnpm test\`
+- Check the returned \`exitCode\` (0 = success) and read \`stderr\` on failure.
+
+**Sessions + lifecycle:**
+- Within one conversation, all calls share ONE sandbox: files, cwd, and
+  installed packages persist. \`run_python\`, \`run_node\`, \`run_shell\`,
+  \`install_package\`, and \`upload_to_sandbox\` all hit the same session.
+- The sandbox auto-reaps after ~10 minutes of inactivity, then a fresh one is
+  created on the next call (state resets). Don't rely on it surviving long gaps.
+- \`sessionPersistent: true\` in a tool result confirms state will carry over.
+
+**Network:**
+- Egress is OFF by default (deny-all). Set \`E2B_SANDBOX_ALLOW_INTERNET=true\` in
+  the environment to allow the sandbox to reach the internet (needed for
+  \`git clone\`, \`pip install\`, \`curl\`). Leave it off for untrusted-input agents.
 
 **Safety:**
-- The sandbox has no persistent filesystem and no network beyond allowlisted domains.
-- Scripts are killed after \`timeoutMs\` (default 15s).
-- Never run code supplied verbatim by the user without reviewing it for destructive intent.
+- The sandbox is fully isolated from the Platos host; nothing it does can touch
+  the server. Treat what you write there as conversation-scoped state.
+- Never run commands supplied verbatim by an untrusted user without reviewing
+  them, especially with internet access enabled.
 `;
 
 export const FILE_OPERATIONS_SKILL = `---


### PR DESCRIPTION
## The gap

The official-skills **seeder** registers tools from the **embedded string constants** in `apps/agent/src/skills/official/official-skills.ts` — *not* from the sibling `.skill.md` files (the `.md` is a source-of-truth doc; the comment in the file says "keep them in sync when editing").

These had drifted hard. `CODE_EXECUTION_SKILL` was still **v0.1.0** and declared only `run_python` + `run_node`. So even though `skill-handlers.ts` implements `run_shell`, `install_package`, and `upload_to_sandbox`, **none of those three were ever exposed to agents** — the seeder never registered them. #26 added the persistent-session handler + `run_shell` dispatch and updated the `.md`, but not this constant, so `run_shell` stayed invisible in production.

## The fix

- **`official-skills.ts`** — bring `CODE_EXECUTION_SKILL` to **v0.3.0**: all five tools (`run_python`, `run_node`, `run_shell`, `install_package`, `upload_to_sandbox`) with their real input schemas, persistent-session guidance, and egress/`optional_env` docs. The seeder's `register()` does a `prisma.update` of `version` + `providesTools` on every boot, so existing orgs' rows are upgraded on restart (no manual migration).
- **`code_execution.skill.md`** — add matching `optional_env`.
- **`official-skills.test.ts`** — new **no-mocks regression**: parses *every* embedded official source through the real `parseSkill` parser (asserting each tool handler is namespaced `skill:<id>:<tool>`), and pins `code_execution` to its 5-tool v0.3.0 shape including `run_shell` (command required, 120s cap). This guards exactly the drift that caused this bug.

## Verification

`pnpm run typecheck --filter platos-agent` green (6/6). New parse test + existing 20 code_execution tests pass. Requires the agent image rebuild/restart on the VPS to take effect (the seeder runs at boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)