### PR TITLE
docs(mcp): token-minting doc reflects the visual permission picker

### DIFF
--- a/content/docs/mcp-tokens-and-pat.md
+++ b/content/docs/mcp-tokens-and-pat.md
@@ -50,7 +50,7 @@ Both paths land at the same enforcement point, so the auth surface stays simple.
 
 ### Create a PAT
 
-`/settings/mcp-tokens` -> "New token". Name, scope (org/project/env), permission scopes. Copy the `pmt_...` string. The dashboard shows it once; lost tokens cannot be retrieved.
+`/settings/integrations/mcp` -> "Mint a new token". Name, TTL, and a **visual permission picker**: toggle tool categories (with live tool counts) or pick a preset — read-only, operator, full, or admin (cross-scope) — and a running "this token sees N tools" preview shows the effective grant. The dashboard shows the token string once; lost tokens cannot be retrieved. Paste the generated config into your MCP client — it uses streamable HTTP (`type: "http"`), the transport modern clients speak.
 
 ### Use a PAT
 


### PR DESCRIPTION
Small docs follow-up to v1.3.0 — updates the MCP token doc for the new picker + streamable-HTTP client config.