### PR TITLE
fix(webapp): agent-create wizard — restore model + full dynamic blocks

### DIFF
--- a/apps/webapp/app/components/agents/DynamicBlocksEditor.tsx
+++ b/apps/webapp/app/components/agents/DynamicBlocksEditor.tsx
@@ -1,0 +1,154 @@
+/**
+ * Shared dynamic-blocks editor.
+ *
+ * Dynamic blocks are per-turn content injected into a `<context>` wrapper in the
+ * USER message (not the system prompt), so they're never cached and can safely
+ * carry session-specific data (current screen, user state, live metrics).
+ *
+ * This is a controlled component: it takes `blocks` + `onChange` and renders the
+ * full editor (key / name / content template / description per block) plus a live
+ * preview of what the LLM sees. It is used in BOTH the agent-creation wizard and
+ * the agent Context tab so the two surfaces can never drift.
+ */
+
+import { CubeTransparentIcon, PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
+import { Button } from "~/components/primitives/Buttons";
+import { Paragraph } from "~/components/primitives/Paragraph";
+
+export type DynamicBlock = {
+  key: string;
+  name: string;
+  defaultContent: string;
+  description?: string;
+};
+
+interface Props {
+  blocks: DynamicBlock[];
+  onChange: (blocks: DynamicBlock[]) => void;
+  /** Hide the explanatory copy (the wizard step already frames it). */
+  hideIntro?: boolean;
+}
+
+function PreviewPane({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded border border-charcoal-700 bg-charcoal-900 p-3 text-[11px] font-mono text-text-dimmed">
+      {children}
+    </div>
+  );
+}
+
+export function DynamicBlocksEditor({ blocks, onChange, hideIntro }: Props) {
+  const addBlock = () => onChange([...blocks, { key: "", name: "", defaultContent: "", description: "" }]);
+  const updateBlock = (i: number, field: keyof DynamicBlock, value: string) =>
+    onChange(blocks.map((b, idx) => (idx === i ? { ...b, [field]: value } : b)));
+  const removeBlock = (i: number) => onChange(blocks.filter((_, idx) => idx !== i));
+
+  return (
+    <div className="space-y-4">
+      {!hideIntro && (
+        <>
+          <Paragraph variant="small">
+            Dynamic blocks are <strong>per-turn content</strong> injected into a{" "}
+            <code className="font-mono text-emerald-400">{"<context>"}</code> wrapper in the user
+            message — NOT the system prompt. This means they are <strong>never cached</strong> by
+            Anthropic and can safely contain session-specific data (current screen, user state,
+            live metrics). Keep the system prompt fully static for maximum cache efficiency;
+            put anything that changes per-turn here.
+          </Paragraph>
+          <Paragraph variant="small">
+            Each block has a <strong>key</strong> (how your backend addresses it),{" "}
+            a <strong>name</strong> (the heading the LLM sees), and a{" "}
+            <strong>content template</strong> that can reference{" "}
+            <code className="font-mono text-amber-300">{"{{session.context.keys}}"}</code>.
+          </Paragraph>
+        </>
+      )}
+
+      <div className="space-y-3">
+        {blocks.length === 0 && (
+          <div className="rounded border border-dashed border-charcoal-600 px-4 py-6 text-center text-sm text-text-dimmed">
+            No dynamic blocks yet. Add one below.
+          </div>
+        )}
+        {blocks.map((block, i) => (
+          <div key={i} className="rounded-lg border border-charcoal-700 bg-charcoal-900 p-3 space-y-2">
+            <div className="flex items-start gap-2">
+              <CubeTransparentIcon className="size-4 text-emerald-500 flex-shrink-0 mt-0.5" />
+              <div className="flex-1 grid grid-cols-2 gap-2">
+                <div>
+                  <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Key (machine ID)</label>
+                  <input
+                    value={block.key}
+                    onChange={(e) => updateBlock(i, "key", e.target.value)}
+                    placeholder="e.g. screen_context"
+                    className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Name (LLM heading)</label>
+                  <input
+                    value={block.name}
+                    onChange={(e) => updateBlock(i, "name", e.target.value)}
+                    placeholder="e.g. Current Screen"
+                    className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright"
+                  />
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeBlock(i)}
+                className="text-text-dimmed hover:text-rose-400 flex-shrink-0"
+              >
+                <TrashIcon className="size-4" />
+              </button>
+            </div>
+            <div>
+              <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">
+                Content template{" "}
+                <span className="normal-case text-text-dimmed font-normal">— use <code className="font-mono text-amber-300">{"{{key}}"}</code> for sessionContext values</span>
+              </label>
+              <textarea
+                value={block.defaultContent}
+                onChange={(e) => updateBlock(i, "defaultContent", e.target.value)}
+                rows={3}
+                placeholder={`e.g. The user is currently on the {{screen.page}} page.\nLast action: {{screen.last_action}}`}
+                spellCheck={false}
+                className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright font-mono resize-y"
+              />
+            </div>
+            <div>
+              <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Description (optional)</label>
+              <input
+                value={block.description ?? ""}
+                onChange={(e) => updateBlock(i, "description", e.target.value)}
+                placeholder="What this block provides to the agent"
+                className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-dimmed"
+              />
+            </div>
+          </div>
+        ))}
+
+        <Button type="button" variant="tertiary/small" LeadingIcon={PlusIcon} onClick={addBlock}>
+          Add block
+        </Button>
+      </div>
+
+      {/* Preview of what the LLM sees */}
+      {blocks.some((b) => b.key && b.name) && (
+        <div className="space-y-1">
+          <p className="text-[10px] text-text-dimmed uppercase tracking-wider">What the LLM sees each turn</p>
+          <PreviewPane>
+            <p className="text-text-dimmed">{"<context>"}</p>
+            {blocks.filter((b) => b.key && b.name).map((b) => (
+              <div key={b.key} className="ml-2 mt-1">
+                <p className="text-emerald-300">## {b.name}</p>
+                <p className="text-text-bright whitespace-pre-wrap">{b.defaultContent || "(content from sessionContext)"}</p>
+              </div>
+            ))}
+            <p className="text-text-dimmed mt-1">{"</context>"}</p>
+          </PreviewPane>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/webapp/app/components/agents/ModelRoutesEditor.tsx
+++ b/apps/webapp/app/components/agents/ModelRoutesEditor.tsx
@@ -43,6 +43,10 @@ interface Props {
   providers: ProviderForPicker[];
   providerKeys: ProviderKeyForEditor[];
   providersPath: string;
+  /** Lifts the current routes to the parent. Needed by multi-step forms that
+   *  UNMOUNT this editor before submit (the create wizard renders one step at a
+   *  time), so the value survives via the parent's own hidden field. */
+  onChange?: (routes: ModelRoute[]) => void;
 }
 
 const LABEL_RE = /^[a-z0-9_-]{1,32}$/;
@@ -68,6 +72,7 @@ export function ModelRoutesEditor({
   providers,
   providerKeys,
   providersPath,
+  onChange,
 }: Props) {
   const models = allModels(providers);
 
@@ -84,6 +89,15 @@ export function ModelRoutesEditor({
 
   const [routes, setRoutes] = useState<ModelRoute[]>(seed);
   const [errors, setErrors] = useState<Record<number, string>>({});
+
+  // Lift routes to the parent so a multi-step form that unmounts this editor
+  // (the create wizard) can still submit the value via its own hidden field.
+  // Fires on mount (seeded routes) + every change. setState setters are stable,
+  // so `onChange` is intentionally omitted from deps.
+  useEffect(() => {
+    onChange?.(routes);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [routes]);
 
   // Keep exactly one default at all times.
   const ensureOneDefault = (rs: ModelRoute[]): ModelRoute[] => {

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.context/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.context/route.tsx
@@ -16,7 +16,7 @@
  * Persistence: contextMapping + dynamicBlocks saved directly via Prisma.
  */
 
-import { CubeTransparentIcon, PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
+import { PlusIcon, TrashIcon } from "@heroicons/react/20/solid";
 import { telemetry } from "~/services/telemetry.server";
 import { useFetcher, type MetaFunction } from "@remix-run/react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
@@ -30,6 +30,7 @@ import { Badge } from "~/components/primitives/Badge";
 import { Button } from "~/components/primitives/Buttons";
 import { Header3 } from "~/components/primitives/Headers";
 import { Paragraph } from "~/components/primitives/Paragraph";
+import { DynamicBlocksEditor } from "~/components/agents/DynamicBlocksEditor";
 import { findProjectBySlug } from "~/models/project.server";
 import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
 import { requireUserId } from "~/services/session.server";
@@ -234,16 +235,6 @@ export default function AgentContextTab() {
     Array.isArray(savedBlocks) ? savedBlocks : [],
   );
 
-  function addBlock() {
-    setDynamicBlocks((prev) => [...prev, { key: "", name: "", defaultContent: "", description: "" }]);
-  }
-  function updateBlock(i: number, field: keyof DynamicBlock, value: string) {
-    setDynamicBlocks((prev) => prev.map((b, idx) => idx === i ? { ...b, [field]: value } : b));
-  }
-  function removeBlock(i: number) {
-    setDynamicBlocks((prev) => prev.filter((_, idx) => idx !== i));
-  }
-
   // Section 2 — Prompt substitution variables
   const [promptVars, setPromptVars] = useState<string[]>(contextMapping?.promptVars ?? []);
   const [newPromptVar, setNewPromptVar] = useState("");
@@ -353,91 +344,7 @@ export default function AgentContextTab() {
             substitution without a live backend.
           </Paragraph>
 
-          <div className="space-y-3">
-            {dynamicBlocks.length === 0 && (
-              <div className="rounded border border-dashed border-charcoal-600 px-4 py-6 text-center text-sm text-text-dimmed">
-                No dynamic blocks yet. Add one below.
-              </div>
-            )}
-            {dynamicBlocks.map((block, i) => (
-              <div key={i} className="rounded-lg border border-charcoal-700 bg-charcoal-900 p-3 space-y-2">
-                <div className="flex items-start gap-2">
-                  <CubeTransparentIcon className="size-4 text-emerald-500 flex-shrink-0 mt-0.5" />
-                  <div className="flex-1 grid grid-cols-2 gap-2">
-                    <div>
-                      <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Key (machine ID)</label>
-                      <input
-                        value={block.key}
-                        onChange={(e) => updateBlock(i, "key", e.target.value)}
-                        placeholder="e.g. screen_context"
-                        className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright font-mono"
-                      />
-                    </div>
-                    <div>
-                      <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Name (LLM heading)</label>
-                      <input
-                        value={block.name}
-                        onChange={(e) => updateBlock(i, "name", e.target.value)}
-                        placeholder="e.g. Current Screen"
-                        className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright"
-                      />
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => removeBlock(i)}
-                    className="text-text-dimmed hover:text-rose-400 flex-shrink-0"
-                  >
-                    <TrashIcon className="size-4" />
-                  </button>
-                </div>
-                <div>
-                  <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">
-                    Content template{" "}
-                    <span className="normal-case text-text-dimmed font-normal">— use <code className="font-mono text-amber-300">{"{{key}}"}</code> for sessionContext values</span>
-                  </label>
-                  <textarea
-                    value={block.defaultContent}
-                    onChange={(e) => updateBlock(i, "defaultContent", e.target.value)}
-                    rows={3}
-                    placeholder={`e.g. The user is currently on the {{screen.page}} page.\nLast action: {{screen.last_action}}`}
-                    spellCheck={false}
-                    className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-bright font-mono resize-y"
-                  />
-                </div>
-                <div>
-                  <label className="text-[10px] text-text-dimmed uppercase tracking-wider block mb-1">Description (optional)</label>
-                  <input
-                    value={block.description ?? ""}
-                    onChange={(e) => updateBlock(i, "description", e.target.value)}
-                    placeholder="What this block provides to the agent"
-                    className="w-full rounded border border-charcoal-700 bg-charcoal-800 px-2 py-1.5 text-xs text-text-dimmed"
-                  />
-                </div>
-              </div>
-            ))}
-
-            <Button type="button" variant="tertiary/small" LeadingIcon={PlusIcon} onClick={addBlock}>
-              Add block
-            </Button>
-          </div>
-
-          {/* Preview of what the LLM sees */}
-          {dynamicBlocks.some((b) => b.key && b.name) && (
-            <div className="space-y-1">
-              <p className="text-[10px] text-text-dimmed uppercase tracking-wider">What the LLM sees each turn</p>
-              <PreviewPane>
-                <p className="text-text-dimmed">{"<context>"}</p>
-                {dynamicBlocks.filter((b) => b.key && b.name).map((b) => (
-                  <div key={b.key} className="ml-2 mt-1">
-                    <p className="text-emerald-300">## {b.name}</p>
-                    <p className="text-text-bright whitespace-pre-wrap">{b.defaultContent || "(content from sessionContext)"}</p>
-                  </div>
-                ))}
-                <p className="text-text-dimmed mt-1">{"</context>"}</p>
-              </PreviewPane>
-            </div>
-          )}
+          <DynamicBlocksEditor blocks={dynamicBlocks} onChange={setDynamicBlocks} hideIntro />
         </SectionCard>
 
         {/* ── Section 2: Prompt substitution ──────────────────────── */}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
@@ -31,6 +31,7 @@ import { typedjson, useTypedLoaderData } from "remix-typedjson";
 import { ModelPicker, type ProviderForPicker } from "~/components/agents/ModelPicker";
 import { ModelRoutesEditor } from "~/components/agents/ModelRoutesEditor";
 import { PromptBlockEditor } from "~/components/agents/PromptBlockEditor";
+import { DynamicBlocksEditor, type DynamicBlock } from "~/components/agents/DynamicBlocksEditor";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button } from "~/components/primitives/Buttons";
 import { Fieldset } from "~/components/primitives/Fieldset";
@@ -288,7 +289,7 @@ type WizardStep = 1 | 2 | 3 | 4;
 const STEPS: { step: WizardStep; label: string }[] = [
   { step: 1, label: "Identity" },
   { step: 2, label: "Prompt" },
-  { step: 3, label: "Dynamic" },
+  { step: 3, label: "Behavior" },
   { step: 4, label: "Tool Mode" },
 ];
 
@@ -353,12 +354,16 @@ export default function NewAgentPage() {
 
   // Step 1.
   const [agentName, setAgentName] = useState("");
-  const [model, setModel] = useState("");
+  // Lifted from ModelRoutesEditor so the model survives step 1 unmounting.
+  // Submitted as `modelRoutes` (+ a derived `model`) via hidden fields at step 4;
+  // the action derives the default model from the routes.
+  const [modelRoutes, setModelRoutes] = useState<any[]>([]);
 
   // Step 2.
   const [blocks, setBlocks] = useState(defaultBlocks || []);
-  const [declaredKeys, setDeclaredKeys] = useState<string[]>([]);
-  const [keyInput, setKeyInput] = useState("");
+  // Full dynamic (per-turn) blocks — same editor + shape as the Context tab, so
+  // everything editable post-creation is also configurable at creation.
+  const [dynamicBlocks, setDynamicBlocks] = useState<DynamicBlock[]>([]);
 
   // Step 3.
   const [contextLimit, setContextLimit] = useState(20);
@@ -375,21 +380,7 @@ export default function NewAgentPage() {
   // Step 4.
   const [toolMode, setToolMode] = useState<"direct" | "sub-agent" | "tool-wrapper">("direct");
 
-  // Derived.
-  const dynamicBlocks = declaredKeys.map((k, i) => ({
-    key: k,
-    name: k,
-    defaultContent: "",
-    order: i,
-  }));
-
   const promptPreview = buildPromptPreview(agentName, toolMode, userProfiling, blocks as unknown[]);
-
-  function addKey(raw: string) {
-    const k = raw.trim().replace(/[^a-zA-Z0-9_.]/g, "").toLowerCase();
-    if (k && !declaredKeys.includes(k)) setDeclaredKeys((prev) => [...prev, k]);
-    setKeyInput("");
-  }
 
   function canAdvance(s: WizardStep): boolean {
     // Step 1: only require agent name — model routes are configured via
@@ -499,6 +490,7 @@ export default function NewAgentPage() {
                   providers={providers}
                   providerKeys={providerKeys.map(k => ({ id: k.id, label: k.label, provider: k.provider, envVarName: k.envVarName }))}
                   providersPath={providersPath}
+                  onChange={setModelRoutes}
                 />
                 {providers.length === 0 && (
                   <p className="mt-2 text-xs text-amber-300">
@@ -536,46 +528,16 @@ export default function NewAgentPage() {
 
               <PromptBlockEditor blocks={blocks as any[]} onChange={setBlocks} />
 
-              {/* Declared variables pill list */}
+              {/* Dynamic (per-turn) blocks — full editor, same as the Context tab */}
               <section>
-                <Header3>Declared variables</Header3>
-                <Paragraph variant="small" className="mt-1 mb-2">
-                  Keys you can reference as{" "}
-                  <code className="font-mono text-amber-300">{"{{key}}"}</code> in prompt blocks.
-                  Unresolved keys render as empty string at runtime.
+                <Header3>Dynamic blocks</Header3>
+                <Paragraph variant="small" className="mt-1 mb-3">
+                  Per-turn content injected into a{" "}
+                  <code className="font-mono text-emerald-400">{"<context>"}</code> wrapper in the
+                  user message (never cached). Configure the same blocks you can edit later on the
+                  agent's Context tab.
                 </Paragraph>
-                <div className="flex flex-wrap gap-1.5 mb-2 min-h-[28px]">
-                  {declaredKeys.map((k) => (
-                    <span
-                      key={k}
-                      className="inline-flex items-center gap-1 rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-300 font-mono"
-                    >
-                      {`{{${k}}}`}
-                      <button
-                        type="button"
-                        onClick={() => setDeclaredKeys((prev) => prev.filter((x) => x !== k))}
-                        className="hover:text-rose-400 ml-0.5"
-                      >
-                        ×
-                      </button>
-                    </span>
-                  ))}
-                </div>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    value={keyInput}
-                    onChange={(e) => setKeyInput(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") { e.preventDefault(); addKey(keyInput); }
-                    }}
-                    placeholder="e.g., current_user.name"
-                    className="flex-1 rounded border border-charcoal-700 bg-charcoal-900 px-2 py-1.5 text-xs text-text-bright font-mono"
-                  />
-                  <Button type="button" variant="tertiary/small" onClick={() => addKey(keyInput)}>
-                    + Add
-                  </Button>
-                </div>
+                <DynamicBlocksEditor blocks={dynamicBlocks} onChange={setDynamicBlocks} hideIntro />
               </section>
 
               <div className="flex justify-between pt-2">
@@ -583,7 +545,7 @@ export default function NewAgentPage() {
                   ← Back
                 </Button>
                 <Button type="button" variant="primary/medium" onClick={advance}>
-                  Next: Dynamic →
+                  Next: Behavior →
                 </Button>
               </div>
             </div>
@@ -841,9 +803,18 @@ export default function NewAgentPage() {
 
                 {/* Hidden inputs carrying all accumulated wizard state */}
                 <input type="hidden" name="name" value={agentName} />
-                <input type="hidden" name="model" value={model} />
+                <input
+                  type="hidden"
+                  name="model"
+                  value={modelRoutes.find((r: any) => r.isDefault)?.model ?? modelRoutes[0]?.model ?? ""}
+                />
+                <input type="hidden" name="modelRoutes" value={JSON.stringify(modelRoutes)} />
                 <input type="hidden" name="systemPromptBlocks" value={JSON.stringify(blocks)} />
-                <input type="hidden" name="dynamicBlocksJson" value={JSON.stringify(dynamicBlocks)} />
+                <input
+                  type="hidden"
+                  name="dynamicBlocksJson"
+                  value={JSON.stringify(dynamicBlocks.filter((b) => b.key.trim() && b.name.trim()))}
+                />
                 <input type="hidden" name="contextLimit" value={contextLimit} />
                 <input type="hidden" name="historyMode" value={historyMode} />
                 <input type="hidden" name="compactThreshold" value={compactThreshold} />


### PR DESCRIPTION
## What

Fixes two bugs in the agent-creation wizard on play.platos.dev. Both stem from the wizard rendering one step at a time (`step === N &&`), so inactive steps **unmount** and their inputs leave the DOM before submit.

### Bug 1 — "Name and model are required" (couldn't create agents at all)
`ModelRoutesEditor` lives in step 1 and unmounts when you reach step 4, taking its hidden `modelRoutes` input with it. The step-4 hidden `model` field read a dead `model` state that nothing ever fed → both `model` and `modelRoutes` were missing at submit.

**Fix:** lift routes out via `ModelRoutesEditor`'s new `onChange` prop into wizard-level state, then emit hidden `model` (derived default route) + `modelRoutes` fields at the final step.

### Bug 2 — dynamic prompt blocks "vanished" at creation
Creation only offered a keys-only "Declared variables" pill list — you couldn't set a block's name / content / description. So compared to what the Context tab lets you edit post-creation, dynamic blocks effectively disappeared.

**Fix:** extract the Context tab's inline editor into a shared `<DynamicBlocksEditor>` and use it in **both** the wizard (Prompt step) and the Context tab. Creation now configures exactly what's editable later, and the two surfaces can't drift.

## Notes
- Backend already persists `dynamicBlocks` on create via `coerceBlockList` — no server change needed.
- Relabeled wizard step 3 "Dynamic" → "Behavior" to avoid colliding with the new "Dynamic blocks" section in the Prompt step.

## Test
- Webapp Docker build (`apps/webapp/Dockerfile.platos`) is the typecheck.
- Live smoke: create an agent end-to-end through the wizard on play.platos.dev with a model route + a dynamic block; confirm both persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)