### PR TITLE
fix(webapp): persist picked model when going back to wizard step 1

### DIFF
--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
@@ -487,6 +487,12 @@ export default function NewAgentPage() {
                 </Paragraph>
                 <ModelRoutesEditor
                   name="modelRoutes"
+                  // Re-seed from the lifted state so returning to step 1 (the editor
+                  // fully unmounts on step change) restores the picked model instead
+                  // of resetting to the provider default. seed() prefers non-empty
+                  // initialRoutes; it only runs in the mount initializer, so passing
+                  // this while mounted is a no-op (no feedback loop).
+                  initialRoutes={modelRoutes.length > 0 ? modelRoutes : undefined}
                   providers={providers}
                   providerKeys={providerKeys.map(k => ({ id: k.id, label: k.label, provider: k.provider, envVarName: k.envVarName }))}
                   providersPath={providersPath}


### PR DESCRIPTION
## Bug
In the agent-create wizard: pick a model + name in step 1 → go to step 2 → go back to step 1. The name persists but the selected model resets to the provider default (Sonnet 4.6).

## Cause
`ModelRoutesEditor` fully unmounts when step 1 leaves the DOM (`step === N &&`). On remount, its `seed()` re-initializes `routes` from `models[0]`, ignoring the value already lifted to the wizard's parent state. So the parent holds the selection but the editor discards it.

## Fix
Pass the lifted `modelRoutes` back in as `initialRoutes`. `seed()` already prefers non-empty `initialRoutes`, and it only runs in the `useState` initializer (once per mount), so passing it while mounted is a no-op — no feedback loop. First mount (empty) still falls through to the provider default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)