### PR TITLE
fix(trigger): correct project ref in agent trigger.config

### DIFF
--- a/apps/agent/trigger.config.ts
+++ b/apps/agent/trigger.config.ts
@@ -19,7 +19,7 @@ import { defineConfig } from "@trigger.dev/sdk";
  * response to the LLM).
  */
 export default defineConfig({
-  project: process.env.TRIGGER_PROJECT_REF || "proj_mwhvvqlhrykhbdicnmze",
+  project: process.env.TRIGGER_PROJECT_REF || "proj_hovobxjmqdvnduupguwa",
   dirs: ["./src/trigger-tasks"],
   maxDuration: 600,
   retries: {


### PR DESCRIPTION
The hardcoded default `proj_mwhvvqlhrykhbdicnmze` was a stale project — deploys landed in the wrong Trigger project. Point it at `proj_hovobxjmqdvnduupguwa` (the project the prod secret key belongs to).

🤖 Generated with [Claude Code](https://claude.com/claude-code)