### PR TITLE
fix(trigger): cloud-harden maintenance tasks + guard bypass

### DIFF
--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -255,7 +255,18 @@ export class ScopeGuard implements CanActivate {
       url.startsWith("/api/v1/agent/internal/compaction") ||
       url.startsWith("/api/v1/agent/internal/durable-turn") ||
       url.startsWith("/api/v1/agent/internal/employee-run") ||
-      url.startsWith("/api/v1/agent/internal/skill-run")
+      url.startsWith("/api/v1/agent/internal/skill-run") ||
+      // Managed-cloud maintenance-task callbacks — same admin-token gate +
+      // scope-in-body. These run as scheduled trigger.dev tasks on Trigger
+      // Cloud and reach the agent through the public proxy; each controller
+      // re-verifies the token with a timing-safe compare.
+      url.startsWith("/api/v1/agent/monitoring/dlq/drain") ||
+      url.startsWith("/api/v1/agent/monitoring/cost/reconcile") ||
+      url.startsWith("/api/v1/agent/monitoring/budget/email") ||
+      url.startsWith("/api/v1/agent/monitoring/approvals/expiry-sweep") ||
+      url.startsWith("/api/v1/agent/evals/sample") ||
+      url.startsWith("/api/v1/agent/evals/run") ||
+      url.startsWith("/api/v1/agent/attachments/retention")
     ) {
       const expected = env.PLATOS_ADMIN_TOKEN;
       const provided = request.headers["x-platos-admin-token"];

--- a/apps/agent/src/trigger-tasks/agent-batch.task.ts
+++ b/apps/agent/src/trigger-tasks/agent-batch.task.ts
@@ -1,6 +1,6 @@
 import { task, metadata, logger } from "@trigger.dev/sdk";
 import { createHmac } from "node:crypto";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * W.1 — `agent_batch` durable executor.

--- a/apps/agent/src/trigger-tasks/agent-tool-block.task.ts
+++ b/apps/agent/src/trigger-tasks/agent-tool-block.task.ts
@@ -1,6 +1,6 @@
 import { task, metadata, logger } from "@trigger.dev/sdk";
 import { createHmac } from "node:crypto";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Durable tool block execution — PPR-25 full impl.

--- a/apps/agent/src/trigger-tasks/approvals-expiry-sweep.task.ts
+++ b/apps/agent/src/trigger-tasks/approvals-expiry-sweep.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * PPR-67 — scheduled approvals expiry sweep.
@@ -28,7 +28,7 @@ export const approvalsExpirySweep = schedules.task({
   id: "platos.approvals.expiry_sweep",
   description:
     "Every 5 minutes, flip stuck-pending PlatosAgentApproval rows whose timeout has elapsed to 'timed_out'.",
-  cron: "*/5 * * * *",
+  cron: "20 * * * *",
   maxDuration: 60,
   // EOBD.45 — singleton. Two sweepers racing to flip the same row
   // is idempotent but wastes the admin endpoint budget.

--- a/apps/agent/src/trigger-tasks/attachment-retention.task.ts
+++ b/apps/agent/src/trigger-tasks/attachment-retention.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Daily attachment retention sweep (Theme D.8).

--- a/apps/agent/src/trigger-tasks/budget-alert.task.ts
+++ b/apps/agent/src/trigger-tasks/budget-alert.task.ts
@@ -3,7 +3,7 @@ import {
   validatePublicUrl,
   describeUrlValidationError,
 } from "../shared/url-validator";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Theme H.7 — Budget alert delivery.

--- a/apps/agent/src/trigger-tasks/compaction.task.ts
+++ b/apps/agent/src/trigger-tasks/compaction.task.ts
@@ -1,5 +1,5 @@
 import { task, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * LAUNCH-11 — durable conversation compaction.

--- a/apps/agent/src/trigger-tasks/cost-reconcile.task.ts
+++ b/apps/agent/src/trigger-tasks/cost-reconcile.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * PPR-24 — nightly Redis ↔ Postgres cost reconcile.

--- a/apps/agent/src/trigger-tasks/eval-sample.task.ts
+++ b/apps/agent/src/trigger-tasks/eval-sample.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Theme J.4 — scheduled judge-LLM eval sampler.
@@ -23,7 +23,7 @@ export const evalSample = schedules.task({
   id: "platos.eval.sample",
   description:
     "Periodic judge-LLM sampler — picks recent threads + runs active criteria. Conservative default sample size.",
-  cron: "*/15 * * * *",
+  cron: "40 * * * *",
   maxDuration: 300,
   // EOBD.45 — singleton. Two workers ticking would double-charge the
   // judge-LLM budget for no new signal.

--- a/apps/agent/src/trigger-tasks/litellm-cost-refresh.task.ts
+++ b/apps/agent/src/trigger-tasks/litellm-cost-refresh.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Daily refresh of the LiteLLM model-price catalog.

--- a/apps/agent/src/trigger-tasks/memory-extraction.task.ts
+++ b/apps/agent/src/trigger-tasks/memory-extraction.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * Theme O.1 / M.5 — scheduled memory-extraction sweep.

--- a/apps/agent/src/trigger-tasks/observability-dlq-drain.task.ts
+++ b/apps/agent/src/trigger-tasks/observability-dlq-drain.task.ts
@@ -1,5 +1,5 @@
 import { schedules, logger, metadata } from "@trigger.dev/sdk";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * EOBD.100 — ClickHouse DLQ drain.
@@ -19,7 +19,7 @@ export const observabilityDlqDrain = schedules.task({
   id: "platos.observability.dlq_drain",
   description:
     "Drain the ClickHouse dual-write DLQ (Redis list). Retries failed span + cost inserts so transient CH outages don't lose telemetry.",
-  cron: "*/2 * * * *",
+  cron: "0 * * * *",
   maxDuration: 90,
   // EOBD.45 — singleton. Two drainers racing would double-fire retries.
   queue: { concurrencyLimit: 1 },

--- a/apps/agent/src/trigger-tasks/platos-custom-task.ts
+++ b/apps/agent/src/trigger-tasks/platos-custom-task.ts
@@ -1,6 +1,6 @@
 import { task, metadata, logger } from "@trigger.dev/sdk";
 import { runInNewContext } from "node:vm";
-import { env } from "../shared/env";
+const env = process.env;
 
 /**
  * PIFSP-12 — Platos custom task executor.


### PR DESCRIPTION
12 maintenance tasks crashed on Trigger Cloud (ZodError — they imported the full agent env). Swap for `process.env` (thin-shell pattern). Dial noisy crons to hourly. Extend the scope.guard admin-token bypass to their callback paths so they reach the agent through the public proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)