### PR TITLE
feat(agent): durable chat turns end-to-end + executionMode UI + micro machines

### DIFF
--- a/apps/agent/src/agent-runtime/agent-crud.service.ts
+++ b/apps/agent/src/agent-runtime/agent-crud.service.ts
@@ -180,6 +180,8 @@ export interface CreateAgentDto {
   historyMode?: "rolling" | "compact";
   compactThreshold?: number;
   enableUserProfiling?: boolean;
+  /** REFACTOR — direct (in-process, streamed) vs durable (runs as a Trigger.dev run). */
+  executionMode?: "direct" | "durable";
   toolMode?: string;
   toolsBlockConfig?: ToolsBlockConfig;
   subAgentConfig?: SubAgentConfig;
@@ -213,6 +215,7 @@ export interface UpdateAgentDto {
   threadingConfig?: Record<string, unknown> | null;
   /** PRA-AC: cluster membership. null = remove from cluster. */
   clusteringId?: string | null;
+  executionMode?: "direct" | "durable";
   toolMode?: string;
   toolsBlockConfig?: ToolsBlockConfig;
   subAgentConfig?: SubAgentConfig;
@@ -500,6 +503,7 @@ export class AgentCrudService {
         compactThreshold: dto.compactThreshold ?? 40,
         enableUserProfiling: dto.enableUserProfiling ?? false,
         toolMode: dto.toolMode || "direct",
+        executionMode: dto.executionMode || "direct",
         toolsBlockConfig: (dto.toolsBlockConfig as any) || null,
         subAgentConfig: (dto.subAgentConfig as any) || null,
         memoryConfig: dto.memoryConfig || null,
@@ -667,6 +671,7 @@ export class AgentCrudService {
         // PRA-AC: null explicitly clears cluster membership.
         ...(dto.clusteringId !== undefined && { clusteringId: dto.clusteringId ?? null }),
         ...(dto.toolMode !== undefined && { toolMode: dto.toolMode }),
+        ...(dto.executionMode !== undefined && { executionMode: dto.executionMode }),
         ...(dto.toolsBlockConfig !== undefined && { toolsBlockConfig: (dto.toolsBlockConfig as any) }),
         ...(dto.subAgentConfig !== undefined && { subAgentConfig: (dto.subAgentConfig as any) }),
         ...(dto.memoryConfig !== undefined && { memoryConfig: dto.memoryConfig }),

--- a/apps/agent/src/agent-runtime/agent.controller.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.ts
@@ -3789,23 +3789,52 @@ Write the summary now:`;
     if (!this.verifyAdminToken(req)) return { status: "forbidden" };
     if (!body?.message || !body?.scope) return { status: "invalid", reason: "message and scope required" };
     const start = Date.now();
+    const threadId = body.threadId;
+    const room = `thread:${threadId}`;
     try {
-      const result = await this.agentTaskService.executeNonStreamingTurn(body.message, body.scope as any, {
+      // Run the turn in-process and RELAY each stream event to the thread room via
+      // the gateway's generic Redis forwarder (`overview:event` → server.to(room).emit).
+      // The durable-dispatch path (connections.gateway) joins the client socket to
+      // `thread:<id>` before triggering this task, so the reply streams to the chat
+      // exactly like the direct path — durability is transparent to the client.
+      let fullText = "";
+      let messageId: string | undefined;
+      let costCents = 0;
+      for await (const event of this.agentTaskService.executeStreamingTurn(body.message, body.scope as any, {
         agentId: body.agentId,
         threadId: body.threadId,
-      });
+        replyToMessageId: body.replyToMessageId ?? undefined,
+        idempotencyKey: body.clientMessageId ?? undefined,
+      })) {
+        this.redis
+          .publish("overview:event", JSON.stringify({ room, event: "agent_event", data: { ...event, threadId } }))
+          .catch(() => undefined);
+        if (event.type === "token") fullText += (event as any).text ?? "";
+        else if ((event as any).type === "message_persisted") {
+          messageId = (event as any).messageId;
+          costCents = (event as any).costCents ?? costCents;
+        }
+      }
       return {
         status: "ok" as const,
-        threadId: result.threadId ?? body.threadId,
-        text: result.text,
-        costCents: result.costCents ?? 0,
+        threadId,
+        text: fullText,
+        messageId,
+        costCents,
         durationMs: Date.now() - start,
       };
     } catch (err: any) {
+      // Surface the failure to the chat client too so a durable turn never hangs silently.
+      this.redis
+        .publish(
+          "overview:event",
+          JSON.stringify({ room, event: "agent_event", data: { type: "error", message: err?.message ?? String(err), threadId } }),
+        )
+        .catch(() => undefined);
       return {
         status: "failed" as const,
         reason: err?.message ?? String(err),
-        threadId: body.threadId,
+        threadId,
         durationMs: Date.now() - start,
       };
     }

--- a/apps/agent/trigger.config.ts
+++ b/apps/agent/trigger.config.ts
@@ -21,6 +21,10 @@ import { defineConfig } from "@trigger.dev/sdk";
 export default defineConfig({
   project: process.env.TRIGGER_PROJECT_REF || "proj_hovobxjmqdvnduupguwa",
   dirs: ["./src/trigger-tasks"],
+  // Every task is a thin shell — it POSTs to the agent and waits; the real work
+  // (turns, DLQ drain, …) runs on the agent, not the task machine. `micro` is the
+  // right size. (A task can override if it ever runs work in-worker.)
+  machine: "micro",
   maxDuration: 600,
   retries: {
     enabledInDev: true,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
@@ -129,6 +129,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     contextLimit: 20,
     historyMode: "rolling",
     compactThreshold: 40,
+    executionMode: "direct",
     enableUserProfiling: false,
     toolsBlockConfig: null as null | { mode: string; enabledTools?: string[]; perToolPerms?: Record<string, unknown> },
     subAgentConfig: null as null | { model: string; maxSteps: number; systemPrompt?: string },
@@ -563,6 +564,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const contextLimitRaw = formData.get("contextLimit") as string | null;
   const historyMode = formData.get("historyMode") as string | null;
   const compactThresholdRaw = formData.get("compactThreshold") as string | null;
+  const executionMode = formData.get("executionMode") as string | null;
   const enableUserProfiling = formData.get("enableUserProfiling") === "on";
   const enableThreading = formData.get("enableThreading") === "on";
   const clusterMode = formData.get("clusterMode") as string | null;
@@ -610,6 +612,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   if (contextLimitRaw) body.contextLimit = parseInt(contextLimitRaw, 10);
   if (historyMode) body.historyMode = historyMode;
   if (compactThresholdRaw) body.compactThreshold = parseInt(compactThresholdRaw, 10);
+  if (executionMode) body.executionMode = executionMode;
   body.enableUserProfiling = enableUserProfiling;
   body.enableThreading = enableThreading;
   // PRA-AC: null clears cluster membership; non-empty string sets it.
@@ -1065,6 +1068,49 @@ export default function AgentDetailPage() {
                 />
                 <span className="text-xs text-text-dimmed">Thread length at which compaction fires</span>
               </Fieldset>
+            </section>
+
+            {/* Execution mode */}
+            <section>
+              <Header3>Execution mode</Header3>
+              <Paragraph variant="small" className="mt-1 mb-3">
+                How this agent's turns are executed.
+              </Paragraph>
+              <div className="space-y-2">
+                {(
+                  [
+                    {
+                      value: "direct",
+                      label: "Direct",
+                      desc: "Runs in-process, streamed live.",
+                    },
+                    {
+                      value: "durable",
+                      label: "Durable",
+                      desc: "Runs as a Trigger.dev run — survives restarts/redeploys and can suspend for human approval.",
+                    },
+                  ] as const
+                ).map((opt) => (
+                  <label
+                    key={opt.value}
+                    className="flex items-start gap-3 rounded border border-charcoal-700 p-3 cursor-pointer hover:border-charcoal-600"
+                  >
+                    <input
+                      type="radio"
+                      name="executionMode"
+                      value={opt.value}
+                      defaultChecked={
+                        ((agent as any).executionMode || "direct") === opt.value
+                      }
+                      className="mt-0.5 accent-emerald-500"
+                    />
+                    <div>
+                      <p className="text-sm font-medium text-text-bright">{opt.label}</p>
+                      <p className="text-xs text-text-dimmed">{opt.desc}</p>
+                    </div>
+                  </label>
+                ))}
+              </div>
             </section>
 
             {/* User Profiling */}

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.new/route.tsx
@@ -173,6 +173,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const contextLimitRaw = formData.get("contextLimit") as string | null;
   const historyMode = (formData.get("historyMode") as string | null) || "rolling";
   const compactThresholdRaw = formData.get("compactThreshold") as string | null;
+  const executionMode = formData.get("executionMode") as string | null;
   const enableUserProfiling = formData.get("enableUserProfiling") === "on";
   const enableSemanticMemory = formData.get("enableSemanticMemory") === "on";
   const enableKnowledgeGraph = formData.get("enableKnowledgeGraph") === "on";
@@ -257,6 +258,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
         enableUserProfiling,
         enableSemanticMemory,
         enableKnowledgeGraph,
+        executionMode: executionMode || "direct",
         dynamicBlocks,
         ...(extractionPolicy ? { extractionPolicy } : {}),
         ...(modelRoutes ? { modelRoutes } : {}),
@@ -376,6 +378,7 @@ export default function NewAgentPage() {
   const [extractKinds, setExtractKinds] = useState(["fact", "preference", "event", "relationship"]);
   const [extractConfidence, setExtractConfidence] = useState(0.6);
   const [extractMax, setExtractMax] = useState(10);
+  const [executionMode, setExecutionMode] = useState<"direct" | "durable">("direct");
 
   // Step 4.
   const [toolMode, setToolMode] = useState<"direct" | "sub-agent" | "tool-wrapper">("direct");
@@ -620,6 +623,52 @@ export default function NewAgentPage() {
                 )}
               </section>
 
+              {/* Execution mode */}
+              <section>
+                <Header3>Execution mode</Header3>
+                <Paragraph variant="small" className="mt-1 mb-3">
+                  How this agent's turns are executed.
+                </Paragraph>
+                <div className="space-y-2">
+                  {(
+                    [
+                      {
+                        value: "direct",
+                        label: "Direct",
+                        desc: "Runs in-process, streamed live.",
+                      },
+                      {
+                        value: "durable",
+                        label: "Durable",
+                        desc: "Runs as a Trigger.dev run — survives restarts/redeploys and can suspend for human approval.",
+                      },
+                    ] as const
+                  ).map((opt) => (
+                    <label
+                      key={opt.value}
+                      className={`flex items-start gap-3 rounded border p-3 cursor-pointer ${
+                        executionMode === opt.value
+                          ? "border-emerald-500/60 bg-emerald-500/5"
+                          : "border-charcoal-700 hover:border-charcoal-600"
+                      }`}
+                    >
+                      <input
+                        type="radio"
+                        name="executionModeChoice"
+                        value={opt.value}
+                        checked={executionMode === opt.value}
+                        onChange={() => setExecutionMode(opt.value)}
+                        className="mt-0.5 accent-emerald-500"
+                      />
+                      <div>
+                        <p className="text-sm font-medium text-text-bright">{opt.label}</p>
+                        <p className="text-xs text-text-dimmed">{opt.desc}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </section>
+
               {/* User profiling + memory */}
               <section>
                 <Header3>Memory</Header3>
@@ -823,6 +872,7 @@ export default function NewAgentPage() {
                 />
                 <input type="hidden" name="contextLimit" value={contextLimit} />
                 <input type="hidden" name="historyMode" value={historyMode} />
+                <input type="hidden" name="executionMode" value={executionMode} />
                 <input type="hidden" name="compactThreshold" value={compactThreshold} />
                 {userProfiling && <input type="hidden" name="enableUserProfiling" value="on" />}
                 {semanticMemory && <input type="hidden" name="enableSemanticMemory" value="on" />}


### PR DESCRIPTION
Makes `executionMode: durable` agents run real streamed chat turns through Trigger.dev (not the BLOCK-2 stub). Relays the turn's stream to the chat client via the gateway's Redis forwarder; wires executionMode through the DTO + a Direct/Durable UI control (wizard + detail); sets task machines to `micro` (thin shells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)