### PR TITLE
feat(providers): Sakana AI Fugu provider (fugu + fugu-ultra)

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -205,6 +205,13 @@ const OPENAI_COMPAT_BASE_URLS: Record<string, string> = {
   perplexity: "https://api.perplexity.ai",
   together: "https://api.together.xyz/v1",
   fireworks: "https://api.fireworks.ai/inference/v1",
+  // Sakana Fugu — multi-agent orchestration model (Fugu + Fugu Ultra) served
+  // OpenAI-compatible. NOTE: Fugu orchestrates across a pool of frontier models
+  // server-side BEFORE it streams, so first-token latency can be tens of
+  // seconds (fugu) to minutes (fugu-ultra). The retry-aware fetch below + the
+  // per-turn PLATOS_TURN_MAX_MS budget must be generous for fugu-ultra. Not
+  // available in EU/EEA/UK/CH (geo-blocked upstream).
+  sakana: "https://api.sakana.ai/v1",
 };
 
 function resolveModel(modelString: string, apiKey?: string, retryRules?: RetryRule[]) {
@@ -323,6 +330,7 @@ const PROVIDER_API_KEY_ENV: Record<string, string> = {
   perplexity: "PERPLEXITY_API_KEY",
   together: "TOGETHER_API_KEY",
   fireworks: "FIREWORKS_API_KEY",
+  sakana: "SAKANA_API_KEY",
 };
 
 /** Which env-var holds the API key for each provider. */

--- a/apps/agent/src/monitoring/cost.service.ts
+++ b/apps/agent/src/monitoring/cost.service.ts
@@ -177,6 +177,19 @@ const FALLBACK_PRICING: Record<string, { input: number; output: number }> = {
   "perplexity:sonar-reasoning": { input: 100, output: 500 },
   "perplexity:sonar-reasoning-pro": { input: 200, output: 800 },
   "perplexity:sonar-deep-research": { input: 200, output: 800 },
+
+  // Sakana Fugu — verified against https://console.sakana.ai/pricing 2026-07-16.
+  // fugu-ultra: $5/M in, $30/M out → 500/3000 cents/M (standard ≤272K tier;
+  // above 272K input it rises to $10/$45 — not modeled, fixed-tier fallback).
+  // Cached input ($0.50/M, 90% off) is applied via CACHE_RATES `sakana`.
+  // `fugu` has no published fixed rate (blended/underlying-model pricing); we
+  // default it to the fugu-ultra ceiling so the ledger never under-prices.
+  // CAVEAT: Fugu bills hidden orchestration tokens (~1.3K/request floor) that
+  // may be additive and are reported under usage._details — if the AI SDK does
+  // not surface them, this fallback under-counts real spend. Follow-up: read
+  // prompt_tokens_details / completion_tokens_details orchestration fields.
+  "sakana:fugu-ultra": { input: 500, output: 3000 },
+  "sakana:fugu": { input: 500, output: 3000 },
 };
 
 /**

--- a/apps/agent/src/providers/manifests/index.ts
+++ b/apps/agent/src/providers/manifests/index.ts
@@ -346,6 +346,32 @@ export const PROVIDER_MANIFESTS: ProviderManifest[] = [
     },
   },
   {
+    id: "sakana",
+    displayName: "Sakana AI (Fugu)",
+    description:
+      "Sakana Fugu — one model that orchestrates a swappable pool of frontier LLMs " +
+      "(Trinity/Conductor). `fugu` for everyday work, `fugu-ultra` for hard multi-step " +
+      "problems. OpenAI-compatible. Orchestrates server-side before streaming, so " +
+      "responses can be slow (seconds→minutes on fugu-ultra) — use generous timeouts. " +
+      "Not available in the EU/EEA, UK, or Switzerland.",
+    requiredEnv: ["SAKANA_API_KEY"],
+    optionalEnv: [],
+    models: [
+      "sakana:fugu",
+      "sakana:fugu-ultra",
+    ],
+    healthCheck: {
+      kind: "openai-compat",
+      probeModel: "fugu",
+      baseURL: "https://api.sakana.ai/v1",
+    },
+    modelsEndpoint: {
+      url: "https://api.sakana.ai/v1/models",
+      auth: "bearer",
+      shape: "openai",
+    },
+  },
+  {
     id: "azure",
     displayName: "Azure OpenAI",
     description:

--- a/internal-packages/cost-rates/src/index.ts
+++ b/internal-packages/cost-rates/src/index.ts
@@ -25,6 +25,10 @@ export const CACHE_RATES: Record<string, { write: number; read: number }> = {
   openai: { write: 1.0, read: 0.5 },
   google: { write: 1.0, read: 0.25 },
   "google-vertex": { write: 1.0, read: 0.25 },
+  // Sakana Fugu: OpenAI-style automatic prompt caching (no explicit cache_control,
+  // no write premium). Cached input billed at $0.50/M vs $5/M fresh → 90% read
+  // discount. Cached tokens surface as prompt_tokens_details.cached_tokens.
+  sakana: { write: 1.0, read: 0.1 },
 };
 
 const ANTHROPIC_FALLBACK_RATES = CACHE_RATES.anthropic!;


### PR DESCRIPTION
OpenAI-compatible provider at `https://api.sakana.ai/v1` (`SAKANA_API_KEY`, BYOK via dashboard).

- Runtime: `sakana` in `OPENAI_COMPAT_BASE_URLS` + `PROVIDER_API_KEY_ENV`
- Manifest: picker entry, `/v1/models` dynamic discovery, openai-compat health probe
- Cost: fugu-ultra $5/$30 per 1M (fugu priced at the same ceiling — no fixed published rate); cache rates `{write:1.0, read:0.1}` (auto caching, 90% read discount)
- Zero webapp changes (picker is manifest-driven)

Verified live on test.platos — streamed real turns through both the direct and durable-session paths (Ada on `sakana:fugu`).

Known caveats: server-side orchestration before streaming (slow first token; minutes on fugu-ultra), EU/EEA/UK/CH geo-block, hidden orchestration tokens may under-count the ledger (follow-up: read usage `_details`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)