### PR TITLE
feat(chat): durable chat on Trigger Sessions (flag-gated) + durable UX fixes

### DIFF
--- a/apps/agent/scripts/smoke-chat-session.mjs
+++ b/apps/agent/scripts/smoke-chat-session.mjs
@@ -1,0 +1,55 @@
+// Smoke test for the platos.chat.session durable chat worker (Phase 2′).
+// Drives a session server-side via AgentChat — the same way the Platos
+// gateway will in Phase 5 (client never touches Trigger).
+//
+// Usage: TRIGGER_SECRET_KEY=tr_prod_... node scripts/smoke-chat-session.mjs
+import { AgentChat } from "@trigger.dev/sdk/chat";
+
+const chatId = `smoke-p2-${process.env.SMOKE_ID || Math.random().toString(36).slice(2, 10)}`;
+
+// Ada the SDR on test.platos + her existing thread (same fixture as the
+// durable-turn smoke that proved the relay path).
+const clientData = {
+  agentId: "cmreyqssd0001s4018uqp4cd8",
+  threadId: "cmrmej5e00007qx018s7oqd2b",
+  scope: {
+    organizationId: "cmrci93gg0009pb0jjcekjh6o",
+    projectId: "cmrci97tt000cpb0jtcwm8h7s",
+    environmentId: "cmrci97ty000dpb0jq01pbdac",
+    userId: "cmrci21ns0004pb0jm1681sr5",
+  },
+};
+
+const chat = new AgentChat({
+  agent: "platos.chat.session",
+  id: chatId,
+  clientData,
+  onTriggered: ({ runId }) => console.log(`[smoke] session run triggered: ${runId}`),
+});
+
+console.log(`[smoke] chatId=${chatId} — sending message…`);
+const stream = await chat.sendMessage(
+  "Durable-session smoke test: in one short sentence, what is your core job?",
+);
+
+let chunks = 0;
+let dataEvents = 0;
+let text = "";
+for await (const part of stream) {
+  chunks++;
+  if (part?.type === "data-platos-event") dataEvents++;
+  if (part?.type === "text-delta") {
+    text += part.delta ?? "";
+    process.stdout.write(part.delta ?? "");
+  } else console.log(`[chunk] ${JSON.stringify(part).slice(0, 300)}`);
+}
+console.log(`\n[smoke] stream ended: ${chunks} chunks, ${dataEvents} platos data events, ${text.length} text chars`);
+
+// Assert on the streamed deltas — that's what the Phase-5 proxy-bridge
+// consumes. (stream.result().text is not populated for customAgent relays.)
+if (text.length < 5) {
+  console.error("[smoke] FAIL — no streamed text");
+  process.exit(1);
+}
+console.log("[smoke] PASS");
+process.exit(0);

--- a/apps/agent/src/agent-runtime/agent.controller.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.ts
@@ -3841,6 +3841,69 @@ Write the summary now:`;
   }
 
   /**
+   * REFACTOR (Trigger Sessions — Option 1, Platos proxies) — SSE turn for the
+   * durable chat-session worker. The `platos.chat.session` `chat.customAgent`
+   * worker POSTs here once per turn; we run the EXISTING
+   * `executeStreamingTurn` (config, BYOK key, tools, memory, cost, scope,
+   * persistence are ALL reused — no reimplementation in the worker) and stream
+   * its AgentStreamEvents back as SSE. The worker converts each event to a
+   * UIMessageChunk and writes it to the durable Trigger session `.out`; Platos
+   * then proxies `.out` to the chat client. Mirrors `agentChatStream` (SSE +
+   * heartbeat) with the admin-token + body-scope gate of `internalDurableTurn`
+   * (this is called by the Trigger worker through the public proxy, not a
+   * browser). See docs/durable-chat-sessions-migration-plan.md.
+   */
+  @Post("internal/chat/stream-turn")
+  async internalChatStreamTurn(
+    @Req() req: Request,
+    @Res() res: Response,
+    @Body() body: {
+      threadId: string;
+      agentId: string;
+      message: string;
+      replyToMessageId?: string | null;
+      clientMessageId?: string | null;
+      scope: {
+        organizationId: string;
+        projectId: string;
+        environmentId: string;
+        userId: string;
+        agentId?: string;
+        threadId?: string;
+      };
+    },
+  ) {
+    if (!env.PLATOS_ADMIN_TOKEN) {
+      res.status(503).json({ error: "PLATOS_ADMIN_TOKEN not set" });
+      return;
+    }
+    if (!this.verifyAdminToken(req)) {
+      res.status(403).json({ error: "forbidden" });
+      return;
+    }
+    if (!body?.message || !body?.scope) {
+      res.status(400).json({ error: "message and scope required" });
+      return;
+    }
+    const ac = new AbortController();
+    const onClose = () => {
+      if (!ac.signal.aborted) ac.abort();
+    };
+    req.on("close", onClose);
+    res.on("close", onClose);
+    const rawEvents = this.agentTaskService.executeStreamingTurn(body.message, body.scope as any, {
+      agentId: body.agentId,
+      threadId: body.threadId,
+      replyToMessageId: body.replyToMessageId ?? undefined,
+      idempotencyKey: body.clientMessageId ?? undefined,
+      abortSignal: ac.signal,
+    });
+    const heartbeatMs = Math.max(1000, env.PLATOS_STREAM_HEARTBEAT_MS ?? 15_000);
+    const events = withHeartbeat(rawEvents, { intervalMs: heartbeatMs, signal: ac.signal });
+    await this.streamingService.streamToSSE(events, res);
+  }
+
+  /**
    * REFACTOR — AI-employee run callback. Invoked by the
    * `platos.agent.employee-run` trigger task. Multi-step autonomous
    * orchestration (sub-turns, tools, waitpoints) is a follow-up; this initial

--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -254,6 +254,7 @@ export class ScopeGuard implements CanActivate {
     if (
       url.startsWith("/api/v1/agent/internal/compaction") ||
       url.startsWith("/api/v1/agent/internal/durable-turn") ||
+      url.startsWith("/api/v1/agent/internal/chat/stream-turn") ||
       url.startsWith("/api/v1/agent/internal/employee-run") ||
       url.startsWith("/api/v1/agent/internal/skill-run") ||
       // Managed-cloud maintenance-task callbacks — same admin-token gate +

--- a/apps/agent/src/connections/connections.gateway.ts
+++ b/apps/agent/src/connections/connections.gateway.ts
@@ -506,6 +506,15 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
       // to the thread panel (not the main timeline), including done/error.
       const threadSuffix = replyToMessageId ? { replyToMessageId } : {};
 
+      // REFACTOR (Trigger Sessions — Option 1) — durable chat via a Trigger
+      // SESSION (platos.chat.session worker + Platos proxy-bridge). Flag-gated
+      // rollout: PLATOS_CHAT_SESSIONS=true routes durable agents through the
+      // session path; otherwise the older durable-turn task path below runs.
+      // Phase 6 (cutover) flips the flag on and deletes the old path.
+      if (await this.tryDispatchSession(data, scopeWithAgent, agentId, replyToMessageId, client)) {
+        return;
+      }
+
       // REFACTOR (control-plane + trigger substrate) — durable executionMode.
       // If the agent is executionMode="durable" AND managed trigger is
       // configured, hand the turn to the platos.agent.durable-turn task and
@@ -583,12 +592,157 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
    * `platos.agent.durable-turn` trigger task (and its run bridged to the
    * thread room); false to fall back to the in-process (direct) path.
    *
-   * Dormant unless ALL hold: agent.executionMode==="durable",
-   * TRIGGER_SECRET_KEY set (managed trigger configured), and an existing
-   * threadId (new-thread durable turns fall back to direct for now). So on a
-   * deployment without managed trigger every turn stays direct — zero
-   * behaviour change until the substrate exists.
+   * Dormant unless ALL hold: agent.executionMode==="durable" and
+   * TRIGGER_SECRET_KEY set (managed trigger configured). So on a deployment
+   * without managed trigger every turn stays direct — zero behaviour change
+   * until the substrate exists.
+   *
+   * New-thread turns are supported: when the client sends no threadId (a fresh
+   * conversation, e.g. the demo chat's first message), we mint the thread
+   * up-front so the client can be joined to its room before the async run
+   * starts streaming, and so message #1 runs durably too. (Previously the first
+   * message of every durable conversation silently fell back to the direct
+   * path — the agent looked like it "wasn't using trigger" until the 2nd turn.)
    */
+  /**
+   * REFACTOR (Trigger Sessions — Option 1, Platos proxies) — durable chat via
+   * a Trigger SESSION. The `platos.chat.session` `chat.customAgent` worker owns
+   * the durable session; each turn calls back into this agent's
+   * `/internal/chat/stream-turn` (so the EXISTING executeStreamingTurn does
+   * config/keys/tools/memory/cost/persistence), and the reply lands in the
+   * session's durable `.out`. This method is the PROXY-BRIDGE: it drives the
+   * session server-side via `AgentChat` and forwards stream parts to the
+   * thread room as the client's existing `agent_event` frames — the browser
+   * never talks to Trigger (3rd parties only ever touch Platos), and there is
+   * exactly ONE emit per event (no scope/thread double-emit).
+   *
+   * Wins over the durable-turn path it replaces: the turn completes even if
+   * the CLIENT disconnects mid-stream (worker keeps consuming; result persists
+   * + is resumable from `.out`), replies are re-readable after gateway
+   * restarts, and the relay is one ordered stream instead of ad-hoc
+   * multi-room emits. (Agent-process restarts still abort the in-flight
+   * generation — inherent to reusing the in-agent loop; accepted trade.)
+   *
+   * Flag-gated: PLATOS_CHAT_SESSIONS=true + executionMode="durable" +
+   * TRIGGER_SECRET_KEY. Returns false to fall through to older paths.
+   */
+  private async tryDispatchSession(
+    data: any,
+    scope: RequestScope,
+    agentId: string,
+    replyToMessageId: string | undefined,
+    client: Socket,
+  ): Promise<boolean> {
+    if (process.env.PLATOS_CHAT_SESSIONS !== "true") return false;
+    if (!process.env.TRIGGER_SECRET_KEY) return false;
+    // Sub-thread replies keep the existing paths (session wire has no
+    // replyToMessageId concept yet).
+    if (replyToMessageId) return false;
+
+    let executionMode = "direct";
+    try {
+      const agent = await this.prisma.platosAgent.findFirst({
+        where: {
+          id: agentId,
+          organizationId: scope.organizationId,
+          projectId: scope.projectId,
+          environmentId: scope.environmentId,
+        },
+        select: { executionMode: true },
+      });
+      executionMode = agent?.executionMode ?? "direct";
+    } catch {
+      return false;
+    }
+    if (executionMode !== "durable") return false;
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const chatSdk = (() => {
+      try {
+        return require("@trigger.dev/sdk/chat");
+      } catch {
+        return null;
+      }
+    })();
+    if (!chatSdk?.AgentChat) return false;
+
+    // Mint the thread up-front for new conversations (same as the durable
+    // path) — the session externalId IS the threadId, so it must exist first.
+    let threadId = data?.threadId as string | undefined;
+    if (!threadId) {
+      try {
+        const convo = (this.agentTaskService as any).conversationService;
+        const created = await convo?.getOrCreateThread?.(scope, agentId);
+        threadId = created?.id as string | undefined;
+      } catch {
+        return false;
+      }
+      if (!threadId) return false;
+    }
+
+    try {
+      const chatClient = new chatSdk.AgentChat({
+        agent: "platos.chat.session",
+        id: threadId,
+        clientData: {
+          agentId,
+          threadId,
+          scope: {
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+            userId: scope.userId,
+          },
+        },
+      });
+
+      const room = `thread:${threadId}`;
+      await client.join(room);
+      client.emit("agent_event", {
+        type: "meta",
+        thread_id: threadId,
+        threadId,
+        durable: true,
+        session: true,
+      });
+
+      const stream = await chatClient.sendMessage(data.message);
+
+      // Forward the durable .out stream to the room. Deliberately not awaited:
+      // the WS handler returns while the bridge pumps. One emit per event.
+      void (async () => {
+        try {
+          for await (const part of stream as AsyncIterable<any>) {
+            let evt: Record<string, unknown> | null = null;
+            if (part?.type === "text-delta") {
+              evt = { type: "token", text: part.delta ?? "" };
+            } else if (part?.type === "data-platos-event") {
+              evt = part.data as Record<string, unknown>;
+            } else if (part?.type === "error") {
+              evt = { type: "error", message: part.errorText ?? "turn failed" };
+            }
+            if (evt) {
+              this.server?.to(room).emit("agent_event", { ...evt, threadId });
+            }
+          }
+          this.server?.to(room).emit("agent_event", { type: "done", threadId });
+        } catch (err: any) {
+          this.server?.to(room).emit("agent_event", {
+            type: "error",
+            message: err?.message ?? String(err),
+            threadId,
+          });
+          this.server?.to(room).emit("agent_event", { type: "done", threadId });
+        }
+      })();
+
+      return true;
+    } catch {
+      // Session dispatch failed — fall through to durable-turn / direct.
+      return false;
+    }
+  }
+
   private async tryDispatchDurable(
     data: any,
     scope: RequestScope,
@@ -596,8 +750,7 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
     replyToMessageId: string | undefined,
     client: Socket,
   ): Promise<boolean> {
-    const threadId = data?.threadId as string | undefined;
-    if (!threadId) return false; // new-thread durable turns: direct for now
+    let threadId = data?.threadId as string | undefined;
 
     let executionMode = "direct";
     try {
@@ -626,6 +779,22 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
     })();
     const triggerReady = !!process.env.TRIGGER_SECRET_KEY && !!triggerSdk?.tasks?.trigger;
     if (!triggerReady) return false; // managed trigger not configured → direct
+
+    // New-thread durable turn: no threadId from the client (fresh chat). Mint
+    // the thread now so (a) we hand a concrete threadId to the run, (b) we can
+    // join the client to its room before the run streams, and (c) the client
+    // adopts it for subsequent turns via the meta event below. On failure, fall
+    // back to the direct path (which mints the thread itself).
+    if (!threadId) {
+      try {
+        const convo = (this.agentTaskService as any).conversationService;
+        const created = await convo?.getOrCreateThread?.(scope, agentId);
+        threadId = created?.id as string | undefined;
+      } catch {
+        return false;
+      }
+      if (!threadId) return false;
+    }
 
     try {
       const clientMessageId = (data as any).idempotencyKey as string | undefined;

--- a/apps/agent/src/trigger-tasks/chat-session.task.ts
+++ b/apps/agent/src/trigger-tasks/chat-session.task.ts
@@ -1,0 +1,205 @@
+import { chat, type ChatTaskWirePayload } from "@trigger.dev/sdk/ai";
+import { logger } from "@trigger.dev/sdk";
+
+/**
+ * Platos durable chat — Trigger Sessions re-platform, Option 1 (Platos proxies).
+ * Plan: docs/durable-chat-sessions-migration-plan.md
+ *
+ * The durable successor to `durable-turn.task.ts` ("Variant B" in its header),
+ * CORRECTED for the "3rd parties only ever touch Platos" constraint:
+ *
+ *   - This `chat.customAgent` owns the durable session (survives restarts,
+ *     redeploys, crashes; resumable `.out` stream).
+ *   - The turn itself still runs IN THE AGENT via
+ *     `POST /internal/chat/stream-turn` (SSE) — so config, BYOK keys, tools,
+ *     memory, cost ledger, scope enforcement, and message persistence are all
+ *     the EXISTING `executeStreamingTurn` code. Nothing is reimplemented here,
+ *     and no provider keys ever live in Trigger.
+ *   - Platos reads the session `.out` server-side and forwards chunks to the
+ *     chat client over its own socket (the proxy-bridge). The browser never
+ *     talks to Trigger.
+ *
+ * Turn flow: client msg → Platos gateway → session `.in` → this loop →
+ * agent SSE (AgentStreamEvents) → UIMessageChunks → `turn.complete()` →
+ * durable `.out` → Platos proxy → client.
+ *
+ * clientData (set by the gateway at session start, non-secret only):
+ *   { agentId, threadId, scope: { organizationId, projectId, environmentId, userId } }
+ */
+
+interface PlatosChatClientData {
+  agentId: string;
+  threadId: string;
+  scope: {
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    userId: string;
+  };
+}
+
+/** Minimal UIMessageChunk shapes we emit (AI SDK v7 wire vocabulary). */
+type UIChunk =
+  | { type: "start" }
+  | { type: "text-start"; id: string }
+  | { type: "text-delta"; id: string; delta: string }
+  | { type: "text-end"; id: string }
+  | { type: "data-platos-event"; data: Record<string, unknown> }
+  | { type: "error"; errorText: string }
+  | { type: "finish" };
+
+/** Parse an SSE body into the JSON payloads of its `data:` lines. */
+async function* parseSSE(body: ReadableStream<Uint8Array>): AsyncGenerator<any> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      // SSE frames are separated by a blank line.
+      for (;;) {
+        const sep = buf.indexOf("\n\n");
+        if (sep === -1) break;
+        const frame = buf.slice(0, sep);
+        buf = buf.slice(sep + 2);
+        for (const line of frame.split("\n")) {
+          if (!line.startsWith("data:")) continue;
+          const raw = line.slice(5).trim();
+          if (!raw) continue;
+          try {
+            yield JSON.parse(raw);
+          } catch {
+            // non-JSON data line (comment/heartbeat) — skip
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/**
+ * Convert the agent's AgentStreamEvent SSE into UIMessageChunks.
+ * `token` events become one text part; tool/meta/persistence events are
+ * forwarded as `data-platos-event` parts so the Platos proxy-bridge can
+ * translate them back into the client's existing `agent_event` frames.
+ */
+async function* toUIChunks(events: AsyncGenerator<any>): AsyncGenerator<UIChunk> {
+  const textId = "platos-turn-text";
+  let textOpen = false;
+  yield { type: "start" };
+  for await (const ev of events) {
+    const t = ev?.type;
+    if (t === "heartbeat") continue;
+    if (t === "token") {
+      if (!textOpen) {
+        textOpen = true;
+        yield { type: "text-start", id: textId };
+      }
+      yield { type: "text-delta", id: textId, delta: (ev.text as string) ?? "" };
+    } else if (t === "error") {
+      if (textOpen) {
+        textOpen = false;
+        yield { type: "text-end", id: textId };
+      }
+      yield { type: "error", errorText: (ev.message as string) ?? "turn failed" };
+    } else if (t === "done") {
+      break;
+    } else {
+      // tool_call / tool_result / meta / message_persisted / … — forward
+      // verbatim for the proxy-bridge (and future UIs) to interpret.
+      yield { type: "data-platos-event", data: ev as Record<string, unknown> };
+    }
+  }
+  if (textOpen) yield { type: "text-end", id: textId };
+  yield { type: "finish" };
+}
+
+/** Extract the newest user message's text from the accumulated ModelMessages. */
+function latestUserText(messages: Array<{ role: string; content: unknown }>): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m?.role !== "user") continue;
+    if (typeof m.content === "string") return m.content;
+    if (Array.isArray(m.content)) {
+      return m.content
+        .map((p: any) => (p?.type === "text" ? p.text : ""))
+        .filter(Boolean)
+        .join("\n");
+    }
+  }
+  return "";
+}
+
+export const platosChatSession = chat.customAgent({
+  id: "platos.chat.session",
+  run: async (payload: ChatTaskWirePayload, { signal }) => {
+    const session = chat.createSession(payload, {
+      signal,
+      idleTimeoutInSeconds: 60,
+      timeout: "1h",
+    });
+
+    const AGENT_API_URL =
+      process.env.PLATOS_AGENT_HTTP_URL || process.env.PLATOS_AGENT_API_URL || "http://localhost:3100";
+    const adminToken = process.env.PLATOS_ADMIN_TOKEN;
+
+    for await (const turn of session) {
+      const cd = turn.clientData as PlatosChatClientData | undefined;
+      if (!adminToken || !cd?.agentId || !cd?.scope) {
+        await turn.complete({
+          toUIMessageStream: () =>
+            (async function* (): AsyncGenerator<UIChunk> {
+              yield { type: "start" };
+              yield {
+                type: "error",
+                errorText: !adminToken
+                  ? "PLATOS_ADMIN_TOKEN not set on the Trigger worker"
+                  : "session clientData missing agentId/scope",
+              };
+              yield { type: "finish" };
+            })(),
+        });
+        continue;
+      }
+
+      const message = latestUserText(turn.messages as any);
+      logger.info("chat-session turn", {
+        chatId: turn.chatId,
+        turn: turn.number,
+        agentId: cd.agentId,
+        threadId: cd.threadId,
+        chars: message.length,
+      });
+
+      const res = await fetch(`${AGENT_API_URL}/api/v1/agent/internal/chat/stream-turn`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Platos-Admin-Token": adminToken },
+        body: JSON.stringify({
+          threadId: cd.threadId,
+          agentId: cd.agentId,
+          message,
+          scope: { ...cd.scope, agentId: cd.agentId, threadId: cd.threadId },
+        }),
+        signal: turn.signal,
+      });
+      if (!res.ok || !res.body) {
+        const detail = await res.text().catch(() => "");
+        await turn.complete({
+          toUIMessageStream: () =>
+            (async function* (): AsyncGenerator<UIChunk> {
+              yield { type: "start" };
+              yield { type: "error", errorText: `agent turn failed: ${res.status} ${detail.slice(0, 200)}` };
+              yield { type: "finish" };
+            })(),
+        });
+        continue;
+      }
+
+      await turn.complete({ toUIMessageStream: () => toUIChunks(parseSSE(res.body!)) });
+    }
+  },
+});

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
@@ -13,7 +13,7 @@ import {
   PlusIcon,
   TrashIcon,
 } from "@heroicons/react/20/solid";
-import { Form, useFetcher, useParams, type MetaFunction } from "@remix-run/react";
+import { Form, useActionData, useFetcher, useNavigation, useParams, type MetaFunction } from "@remix-run/react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { useMemo, useState } from "react";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
@@ -714,6 +714,16 @@ export default function AgentDetailPage() {
     agentEnableThreading,
     availableClusters,
   } = useTypedLoaderData<typeof loader>();
+  // Main config Form save feedback. The <Form method="post"> below submits via
+  // navigation (not a fetcher), so its result lands in useActionData and its
+  // in-flight state in useNavigation. Fetcher-based sub-forms (feature flags,
+  // context mapping) do NOT populate these, so this only reflects the main save.
+  const mainActionData = useActionData<{ success?: boolean; error?: string }>();
+  const mainNavigation = useNavigation();
+  // A main-form submit has no `intent` field (the intent-tagged branches are
+  // fetcher sub-forms), so this distinguishes it from those.
+  const isSavingConfig =
+    mainNavigation.state !== "idle" && !mainNavigation.formData?.get("intent");
   const [blocks, setBlocks] = useState(initialBlocks || []);
   const [toolsBlockMode, setToolsBlockMode] = useState<string>(
     (agent as any).toolsBlockConfig?.mode || "direct"
@@ -1388,9 +1398,23 @@ export default function AgentDetailPage() {
 
             <FormButtons
               confirmButton={
-                <Button type="submit" variant="primary/medium">
-                  Save Configuration
-                </Button>
+                <div className="flex items-center gap-3">
+                  <Button
+                    type="submit"
+                    variant="primary/medium"
+                    disabled={isSavingConfig}
+                  >
+                    {isSavingConfig ? "Saving…" : "Save Configuration"}
+                  </Button>
+                  {mainNavigation.state === "idle" && mainActionData?.success && (
+                    <span className="text-xs text-emerald-400">Saved.</span>
+                  )}
+                  {mainNavigation.state === "idle" && mainActionData?.error && (
+                    <span className="text-xs text-rose-400">
+                      {mainActionData.error}
+                    </span>
+                  )}
+                </div>
               }
             />
           </div>

--- a/apps/webapp/scripts/ws-smoke-session.mjs
+++ b/apps/webapp/scripts/ws-smoke-session.mjs
@@ -1,0 +1,74 @@
+// End-to-end WS smoke for the Trigger-Sessions durable chat path (Phase 5).
+// Connects to test.platos exactly like the dashboard chat (socket.io /agent
+// namespace), sends one message to a durable agent with NO threadId, and
+// expects: meta {durable:true, session:true} → token stream → done.
+//
+// Usage: PLATOS_SESSION_SECRET=... node scripts/ws-smoke-session.mjs
+import { io } from "socket.io-client";
+import crypto from "node:crypto";
+
+const secret = process.env.PLATOS_SESSION_SECRET;
+if (!secret) {
+  console.error("PLATOS_SESSION_SECRET required");
+  process.exit(1);
+}
+
+const scope = {
+  organizationId: "cmrci93gg0009pb0jjcekjh6o",
+  projectId: "cmrci97tt000cpb0jtcwm8h7s",
+  environmentId: "cmrci97ty000dpb0jq01pbdac",
+  userId: "cmrci21ns0004pb0jm1681sr5",
+};
+const AGENT_ID = "cmreyqssd0001s4018uqp4cd8"; // Ada (durable)
+
+const now = Math.floor(Date.now() / 1000);
+const payload = { ...scope, iss: "platos-platform", iat: now, exp: now + 3600 };
+const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const signingInput = `${b64({ alg: "HS256", typ: "JWT" })}.${b64(payload)}`;
+const sig = crypto.createHmac("sha256", secret).update(signingInput).digest("base64url");
+const token = `${signingInput}.${sig}`;
+
+const socket = io("wss://test.platos.dev/agent", {
+  path: "/agent-io/socket.io",
+  transports: ["websocket"],
+  auth: { token },
+});
+
+let sawSessionMeta = false;
+let text = "";
+let threadId = null;
+const bail = (msg, code = 1) => {
+  console.log(`\n[ws-smoke] ${msg}`);
+  socket.close();
+  process.exit(code);
+};
+const timer = setTimeout(() => bail("TIMEOUT after 150s — no done event", 1), 150_000);
+
+socket.on("connect", () => {
+  console.log("[ws-smoke] connected — sending message (no threadId, durable agent)");
+  socket.emit("message", {
+    message: "WS session smoke: in one short sentence, what is your core job?",
+    agentId: AGENT_ID,
+  });
+});
+socket.on("connect_error", (e) => bail(`connect_error: ${e.message}`));
+socket.on("error", (e) => console.log(`[ws-smoke] error frame: ${JSON.stringify(e).slice(0, 200)}`));
+socket.on("agent_event", (ev) => {
+  if (ev?.type === "meta") {
+    threadId = ev.threadId ?? ev.thread_id ?? threadId;
+    if (ev.session) sawSessionMeta = true;
+    console.log(`[ws-smoke] meta: durable=${ev.durable} session=${ev.session} thread=${threadId}`);
+  } else if (ev?.type === "token") {
+    text += ev.text ?? "";
+    process.stdout.write(ev.text ?? "");
+  } else if (ev?.type === "error") {
+    console.log(`\n[ws-smoke] agent error: ${ev.message}`);
+  } else if (ev?.type === "done") {
+    clearTimeout(timer);
+    console.log(`\n[ws-smoke] done. sessionMeta=${sawSessionMeta} textChars=${text.length}`);
+    if (sawSessionMeta && text.length > 5) bail("PASS", 0);
+    bail(`FAIL — sessionMeta=${sawSessionMeta} textChars=${text.length}`);
+  } else {
+    console.log(`[ws-smoke] event: ${JSON.stringify(ev).slice(0, 160)}`);
+  }
+});

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -412,6 +412,10 @@ services:
       TRIGGER_API_URL: "http://webapp:3030"
       TRIGGER_SECRET_KEY: "${TRIGGER_SECRET_KEY:-}"
       TRIGGER_INTERNAL_SECRET: "${TRIGGER_INTERNAL_SECRET:?required — openssl rand -hex 32}"
+      # Trigger Sessions durable chat (Option 1 — Platos proxies). When true,
+      # durable-mode agents route turns through the platos.chat.session worker
+      # + gateway proxy-bridge instead of the durable-turn task path.
+      PLATOS_CHAT_SESSIONS: "${PLATOS_CHAT_SESSIONS:-false}"
       PLATOS_WORKER_CONCURRENCY: "${PLATOS_WORKER_CONCURRENCY:-10}"
       PLATOS_BATCH_CONCURRENCY: "${PLATOS_BATCH_CONCURRENCY:-5}"
       PLATOS_PER_ORG_CONCURRENCY: "${PLATOS_PER_ORG_CONCURRENCY:-10}"

--- a/docs/durable-chat-sessions-migration-plan.md
+++ b/docs/durable-chat-sessions-migration-plan.md
@@ -1,0 +1,90 @@
+# Durable chat → Trigger Sessions migration plan
+
+**Status:** DECIDED 2026-07-16 → **Option B (full `chat.agent` Sessions re-platform)**. Accepts Trigger-Cloud dependence for durable chat (consistent with the durable-exec-on-Cloud direction); self-hosters fall back to direct mode. Execution is phased (skeleton → loop → tools → persistence → frontends) — see "Execution phases (Option B)" at the bottom.
+**Author:** session 2026-07-16
+**Trigger:** the durable-chat relay double-emits run events (RunsBridge `:136-137` fires two separate `.to().emit()`s to scope+thread rooms; a client in both rooms renders every event twice). Root cause is that we *hand-roll* the streaming transport. "The real fix" = stop hand-rolling it and use Trigger's native durable-chat stack.
+
+---
+
+## What we have now (Variant A — thin-shell relay)
+
+```
+WS client ──(socket.io "message")──▶ gateway.tryDispatchDurable
+   │                                     ├─ trigger platos.agent.durable-turn
+   │                                     ├─ client.join(thread room)
+   │                                     └─ RunsBridge.subscribe(runId)
+   │
+durable-turn.task ──POST /internal/durable-turn──▶ executeStreamingTurn (in-agent)
+                                                     ├─ Redis "overview:event" ──▶ gateway forwarder ──▶ thread room
+                                                     └─ RunsBridge run_update ──▶ scope room + thread room  ← DOUBLE EMIT BUG
+```
+Hand-rolled pieces: room registry, per-room auth, heartbeats, reconnect/resume, event framing, stop signal, run-status relay. Every one is a place to get a bug like the double-emit.
+
+## What Trigger v4.5.0 gives us (GA, and we're already on 4.5.0 + AI SDK v7 — verified importable)
+
+Two native paths, different depths:
+
+| | **Path A — Realtime Streams** | **Path B — `chat.agent` / Sessions** |
+|---|---|---|
+| Writer | `streams.define<UIMessageChunk>()` + `.pipe(result.toUIMessageStream())` inside a task | `run: ({messages,signal}) => streamText({...chat.toStreamTextOptions(), ...})` — auto-piped |
+| Reader | `useRealtimeStream(stream, runId, {accessToken})` | Vercel `useChat({transport})` + `useTriggerChatTransport` (`@trigger.dev/sdk/chat/react`) |
+| Scope | **run-scoped** (ephemeral, lives inside one run) | **session-scoped** (durable identity `chatId`, many runs, survives refresh/redeploy/crash) |
+| Auth | server-minted PAT scoped to runId | server-minted PAT scoped to `read/write:{sessions:chatId}` — the token *is* the room |
+| Tool/HITL events | manual (`.type === "tool-call"` …) | first-class `UIMessageChunk` parts + `tool-approval-request` chunks, rendered by `useChat` |
+| Transport | Electric SQL + HTTP streaming | S2 (`.in`/`.out`) + S3 snapshot + engine CRIU checkpoint |
+| **Self-hostable?** | **Yes** — `baseURL` points at own instance; Electric+HTTP are OSS | **UNDOCUMENTED** — depends on S2 (s2.dev, external) + S3; OSS-webapp availability unstated → **assume Cloud-dependent** |
+| Loop location | stays in-agent (task can pipe an in-agent stream via `target: runId`) | **moves into the Trigger worker** (`chat.agent`), or `chat.customAgent` with tool-callbacks |
+
+## The fork (this is the decision)
+
+**Option A — Native Realtime Streams, keep our loop + thread model.** Replace the RunsBridge/Redis/Socket.io *streaming relay* with a Trigger Realtime Stream per durable turn. Gateway mints a run-scoped PAT, hands `{runId, token}` to the client, client subscribes via `useRealtimeStream`. Kills the double-emit + retires the whole relay. **Self-hostable. Incremental. Low risk.** Does NOT deliver durable *sessions* (no cross-run resume, no survive-redeploy-mid-stream, no free HITL streaming). Frontend change is contained (durable turns switch transport; direct turns can stay on socket.io during transition).
+
+**Option B — Full `chat.agent` Sessions (the "real" durable chat).** Loop runs as a `chat.agent`/`chat.customAgent` task; durable cross-run sessions; resume-on-refresh/redeploy; native tool-approval streaming; `useChat` + `useTriggerChatTransport` frontend. This is the complete product. Costs: (1) **loop-in-worker** — either deploy the agent runtime into Trigger, or use `chat.customAgent` and call back for tools/memory/cost/scope (large plumbing); (2) **S2/S3 → likely Trigger-Cloud-dependent** for durable chat (self-hosters fall back to direct mode — consistent with our decided "durable-exec-on-Cloud" direction); (3) **frontend transport rewrite** across dashboard chat + `platos-embed` + `platos-react-widget` (all currently socket.io).
+
+**Recommended:** **A now, B as the north star.** Option A is the honest fix for *this* bug and the relay rot, keeps Platos self-hostable, and is a clean stepping stone. Commit to B as a deliberate, separately-scoped re-platform once we accept the Cloud-dependence + budget the frontend rewrite. (The `durable-turn.task.ts` header already anticipates exactly this as "Variant B".)
+
+## Open verification items before building B
+- Self-hosted S2/S3 provisioning for `chat.agent` — is it possible at all on the OSS webapp, or Cloud-only? (Decides whether B breaks self-host durable chat.)
+- Frontend blast radius: `useTriggerChatTransport` assumes Next/React server actions for token mint + session start — map onto Remix loaders/actions + the embed/widget SDKs.
+- How Platos's per-turn concerns (scope guard, BYOK provider keys, cost ledger, memory extraction, MCP tools, approvals) attach when the loop is a `chat.agent` task vs. our current in-agent `executeStreamingTurn`.
+
+## Phase A implementation sketch (if A is chosen)
+1. `apps/agent/src/streams.ts`: `export const turnStream = streams.define<UIMessageChunk>({ id: "agent-turn" })`.
+2. In `executeStreamingTurn` (or the durable-turn callback), `turnStream.pipe(result.toUIMessageStream(), { target: runId })` instead of publishing to Redis `overview:event`.
+3. Gateway: on durable dispatch, mint `auth.createPublicToken({ scopes:{ read:{ runs:[runId] } } })`, emit `{type:"meta", runId, streamToken}` to the client.
+4. Client (dashboard first): subscribe with `useRealtimeStream(turnStream, runId, {accessToken, baseURL})`; render `parts`.
+5. Delete the RunsBridge run_update relay for durable turns (the double-emit source) — or, if kept for non-durable run status, collapse `:136-137` into one chained `.to(scope).to(thread).emit()`.
+6. Keep direct-mode turns on socket.io until a later unification pass.
+
+---
+
+## Execution phases (Option B — CHOSEN)
+
+**Architecture (CORRECTED 2026-07-16 — Trigger is server-side ONLY; Platos proxies):** a 3rd party only ever touches **Platos**, never our Trigger. So the browser does NOT use `useTriggerChatTransport` (that connects the browser straight to Trigger's `/realtime/v1/sessions/:id/out` — pushes a Trigger dependency into the client, defeats the self-hostable purpose). Instead: the client stays on Platos's existing socket; Platos's server starts/continues the Trigger session, **reads the session `.out` stream server-side (`sessions.open(chatId).out.read()`) and forwards chunks over its own transport** — a clean single ordered stream (no double-emit). Trigger provides server-side durability (loop survives restart/redeploy); tenant keys are fetched per-session (never stored in Trigger); the operator needs a Trigger for durable mode, else direct-mode fallback.
+
+```
+Platos socket client  ◀──forward .out chunks──  Platos server (proxy/bridge)
+      │  "message" (as today)                         │  sessions.open(chatId).out.read()  (server-side)
+      ▼                                                ▲
+Platos gateway ── start/continue Trigger session ──────┘
+      │  basePayload { agentId, scope, chatId }   (NO secrets — not persisted to S3)
+      ▼
+chat.customAgent "platos.chat.session"  (Trigger worker)
+  for await (turn of session):
+    ├─ turn 0 continuation → GET history from Platos (/internal/chat/history)   [phase 4]
+    ├─ resolve config+BYOK key+tools from Platos (/internal/chat/resolve)       [phase 2/3]
+    ├─ streamText({ model, system, messages: turn.messages, tools })            [phase 2]
+    │     └─ each tool.execute → POST /internal/execute-tool (agent)            [phase 3]
+    ├─ turn.complete(result)  → streams to .out → useChat                       [phase 1]
+    └─ persist exchange + cost → POST /internal/chat/persist (agent)            [phase 4]
+```
+
+- **Phase 1 — walking skeleton (de-risk transport/deploy/auth).** Minimal `chat.customAgent` with a fixed model (together GLM-5.2). Deploy to Trigger. Prove a message streams end-to-end via the `AgentChat` server driver (no frontend yet). Confirms deploy + session + streaming + worker LLM-key path. ← STARTING HERE
+- **~~Phase 2 — port the model/config~~ → REUSE.** Under Option 1 (Platos proxies) the worker does NOT reimplement the loop. It calls the agent, which runs the *existing* `executeStreamingTurn` — config, BYOK key, model resolution all already done there. Worker just relays the resulting event stream into the session `.out`.
+- **~~Phase 3 — tools~~ → ALREADY DONE.** `executeStreamingTurn` already dispatches meta-tools + entity/MCP tools. No worker-side tool binding needed.
+- **~~Phase 4 — persistence + scope + cost~~ → ALREADY DONE.** `executeStreamingTurn` already persists `PlatosAgentMessage`, writes the cost ledger, enforces scope, and fires memory extraction. Nothing to re-add.
+- **Phase 2′ (the real work) — stream the turn into the session.** The `chat.customAgent` worker drives the durable session; per turn it calls an agent endpoint that runs `executeStreamingTurn` and **streams** its events (SSE); the worker writes them to `turn`/`session.out` (durable, resumable). History hydration on continuation uses `turn.setMessages` seeded from the agent (or the agent owns history and the worker passes only the new message).
+- **Phase 5 — Platos proxy-bridge (NOT browser→Trigger).** Platos server reads the Trigger session `.out` stream and forwards `UIMessageChunk`s over the *existing* socket to the client. Client stays on Platos's transport — no `useTriggerChatTransport`, no session-scoped PATs in the browser, no frontend transport rewrite (client may need minor framing tweaks to render UIMessageChunk parts). Replace the RunsBridge double-emit relay with this single-stream bridge.
+- **Phase 6 — cutover + cleanup.** Flip `executionMode=durable` to route through Sessions; delete `durable-turn.task` + the Redis/RunsBridge relay; fix/keep the direct path.
+
+**Open items:** worker LLM-key provisioning model (per-session pass vs Trigger env); Remix (not Next) transport wiring; self-hosted S2/S3 (durable chat = Cloud-only for now).


### PR DESCRIPTION
Re-platforms durable chat onto **Trigger Sessions** (`chat.customAgent`), Option 1: **Trigger stays 100% server-side, Platos proxies** — 3rd parties only ever touch Platos. Plan + research: `docs/durable-chat-sessions-migration-plan.md`.

## How it works
```
Platos socket client ◀── agent_event frames ── gateway proxy-bridge (AgentChat, server-side)
                                                    │ sendMessage → durable session .out
                                          platos.chat.session (chat.customAgent, Trigger worker)
                                                    │ POST /internal/chat/stream-turn (SSE, admin-gated)
                                          executeStreamingTurn — REUSED wholesale
                                          (config, BYOK, tools, memory, cost, persistence, scope)
```
- **No provider keys in Trigger** — the turn runs in-agent; keys never leave Platos.
- **Single emit per event** — the scope+thread double-emit bug class is structurally gone.
- **Flag-gated**: `PLATOS_CHAT_SESSIONS` (compose default `false`; ON on test.platos). Phase 6 cutover (default on + delete durable-turn task + RunsBridge relay) is a follow-up pending sign-off.

## Also bundled (durable-chat UX fixes shipped this session)
- New-thread durable dispatch — message #1 of a fresh chat now runs durably (gateway mints the thread before dispatch).
- Agent edit page Save Configuration feedback (Saving…/Saved./error).

## Verified live on test.platos
- AgentChat driver smoke: worker → agent SSE → durable `.out` → streamed reply (Ada on `sakana:fugu`).
- Browser-equivalent WS smoke: `meta{durable:true, session:true}` → 134 chars streamed → `done`.
- Typecheck clean; smoke scripts included (`apps/agent/scripts/smoke-chat-session.mjs`, `apps/webapp/scripts/ws-smoke-session.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)