### PR TITLE
fix(memory): scope memory recall to the agent unless clustered

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -1877,6 +1877,12 @@ export class AgentService {
                   kind,
                   limit,
                   agentVisibleOnly: true,
+                  // Memory is agent-scoped unless the agent is clustered
+                  // (cluster branch above shares across members). Without
+                  // this, one agent recalls another's memories — observed
+                  // live: Mark (fitness) surfaced Ada's (SDR) Pulsegrid
+                  // outreach context for the same user.
+                  ...(scope.agentId ? { agentId: scope.agentId } : {}),
                 });
             return {
               query,
@@ -1947,6 +1953,9 @@ export class AgentService {
             kind,
             limit,
             offset,
+            // Same agent-scoping rule as `recall`: cluster members share,
+            // standalone agents see only their own memories.
+            ...(agentConfig?.clusteringId || !scope.agentId ? {} : { agentId: scope.agentId }),
           });
           return {
             total: rows.length,
@@ -4912,6 +4921,7 @@ export class AgentService {
     ) {
       try {
         let policyEnabled = true;
+        let injectClusteringId: string | null = null;
         if (scope.agentId) {
           const agentRow = await this.prisma.platosAgent.findFirst({
             where: {
@@ -4920,10 +4930,11 @@ export class AgentService {
               projectId: scope.projectId,
               environmentId: scope.environmentId,
             },
-            select: { extractionPolicy: true },
+            select: { extractionPolicy: true, clusteringId: true },
           });
           const policy = resolveExtractionPolicy(agentRow?.extractionPolicy ?? null);
           policyEnabled = policy.enabled;
+          injectClusteringId = (agentRow as any)?.clusteringId ?? null;
         }
         if (policyEnabled) {
           const budget = Math.max(100, env.PLATOS_MEMORY_INJECT_BUDGET_TOKENS ?? 800);
@@ -4948,6 +4959,12 @@ export class AgentService {
                 minScore: 0.35,
                 // Defaults exclude "private"; pass agent-visible + hidden.
                 visibilityIn: ["agent_visible", "hidden"],
+                // Agent-scoped injection: memory crosses agents ONLY inside a
+                // cluster. Without this filter, every agent in the scope saw
+                // every other agent's user memories — observed live: Mark
+                // (fitness coach) opened with Ada's (SDR) Pulsegrid/cold-email
+                // background the hour memory-extraction came back online.
+                ...(scope.agentId && !injectClusteringId ? { agentId: scope.agentId } : {}),
               },
             ),
             new Promise<never>((_, reject) =>

--- a/apps/webapp/scripts/ws-verify-memscope.mjs
+++ b/apps/webapp/scripts/ws-verify-memscope.mjs
@@ -1,0 +1,29 @@
+import { io } from "socket.io-client";
+import crypto from "node:crypto";
+const secret = process.env.PLATOS_SESSION_SECRET;
+const scope = {
+  organizationId: "cmrci93gg0009pb0jjcekjh6o",
+  projectId: "cmrci97tt000cpb0jtcwm8h7s",
+  environmentId: "cmrci97ty000dpb0jq01pbdac",
+  userId: "cmrci21ns0004pb0jm1681sr5",
+};
+const MARK = "cmrd8he3n0003sd01gda2cpgg";
+const now = Math.floor(Date.now() / 1000);
+const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
+const si = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({ ...scope, iss: "platos-platform", iat: now, exp: now + 3600 })}`;
+const token = `${si}.${crypto.createHmac("sha256", secret).update(si).digest("base64url")}`;
+const socket = io("wss://test.platos.dev/agent", { path: "/agent-io/socket.io", transports: ["websocket"], auth: { token } });
+let text = "";
+const bail = (m, c = 1) => { console.log(`\n[verify] ${m}`); socket.close(); process.exit(c); };
+setTimeout(() => bail("TIMEOUT"), 180_000);
+socket.on("connect", () => socket.emit("message", {
+  message: "Before we start: tell me honestly, what background context or memories do you have about me or my projects?",
+  agentId: MARK,
+}));
+socket.on("agent_event", (ev) => {
+  if (ev?.type === "token") { text += ev.text ?? ""; process.stdout.write(ev.text ?? ""); }
+  else if (ev?.type === "done") {
+    const leaked = /pulsegrid|outreach|cold.?email|sdr|prospect/i.test(text);
+    bail(leaked ? "FAIL — Ada context still leaking" : "PASS — no cross-agent context", leaked ? 1 : 0);
+  }
+});


### PR DESCRIPTION
Cross-agent memory leak — every agent in a scope saw every other agent's user memories (injection + recall + list_memories read paths had no agentId filter; storage was always correctly attributed). Surfaced the hour memory-extraction came back online: Mark (fitness) opened with Ada's (SDR) Pulsegrid background.

**Rule:** memory crosses agents ONLY within an agent cluster (existing cluster branch unchanged).

Verified live on test.platos: fresh Mark chat asked for its background context → no Ada vocabulary (reproduced before the fix).

Follow-ups filed in commit message: cluster-search breadth, extraction dedup, KG-recall audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)