### PR TITLE
fix(memory): cluster search scoped to members + extraction watermark

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -1869,7 +1869,8 @@ export class AgentService {
             // agents' memories (agentId filter omitted). Single-agent: normal search.
             const hits = agentConfig?.clusteringId
               ? await (this.memoryService as any).semanticSearchForCluster(
-                  scopeTuple, query, memoryUserId, { limit }
+                  scopeTuple, query, memoryUserId,
+                  { limit, clusteringId: agentConfig.clusteringId },
                 )
               : await this.memoryService.semanticSearch(scopeTuple, {
                   query,
@@ -2059,6 +2060,7 @@ export class AgentService {
         }
         try {
           const out = await this.memoryExtraction.extractFromThread(scopeTuple, {
+            force: true, // explicit memory_extract ask bypasses the watermark
             threadId,
             policyOverride,
           });

--- a/apps/agent/src/mcp-platform/tools/platos-control.ts
+++ b/apps/agent/src/mcp-platform/tools/platos-control.ts
@@ -310,6 +310,7 @@ export function buildPlatosControlToolHandlers(deps: {
         const policyOverride = params["policyOverride"] as Record<string, unknown> | undefined;
         try {
           const out = await memoryExtraction.extractFromThread(tuple(scope), {
+            force: true, // manual extract-now bypasses the no-new-activity watermark
             threadId,
             ...(policyOverride !== undefined
               ? { policyOverride: policyOverride as any }

--- a/apps/agent/src/memory/memory-extraction.service.ts
+++ b/apps/agent/src/memory/memory-extraction.service.ts
@@ -4,6 +4,7 @@ import { anthropic, createAnthropic } from "@ai-sdk/anthropic";
 import { openai, createOpenAI } from "@ai-sdk/openai";
 import { google, createGoogleGenerativeAI } from "@ai-sdk/google";
 import { PRISMA_TOKEN } from "../shared/database.provider";
+import { REDIS_TOKEN } from "../shared/redis.provider";
 import { ScopedEnvService } from "../providers/scoped-env.service";
 import { MemoryService, type ScopeTuple, type MemoryKind } from "./memory.service";
 import { KnowledgeGraphService } from "./knowledge-graph.service";
@@ -89,6 +90,8 @@ export interface ExtractFromThreadInput {
   threadId: string;
   /** Optional per-call policy override — mostly for the manual endpoint. */
   policyOverride?: Partial<ExtractionPolicy>;
+  /** Bypass the no-new-activity watermark (manual extract-now kicks). */
+  force?: boolean;
 }
 
 export interface ExtractFromThreadOutput {
@@ -132,6 +135,7 @@ export class MemoryExtractionService {
     @Optional() private readonly scopedEnv?: ScopedEnvService,
     @Optional() private readonly crypto?: MessageCryptoService,
     @Optional() private readonly costService?: CostService,
+    @Optional() @Inject(REDIS_TOKEN) private readonly redis?: any,
   ) {}
 
   async extractFromThread(
@@ -147,7 +151,7 @@ export class MemoryExtractionService {
         projectId: scope.projectId,
         environmentId: scope.environmentId,
       },
-      select: { id: true, agentId: true, userId: true, platosEndUserId: true },
+      select: { id: true, agentId: true, userId: true, platosEndUserId: true, updatedAt: true },
     });
     if (!thread) {
       return { memoriesCreated: 0, entitiesCreated: 0, relationshipsCreated: 0, skipped: 0, reason: "thread-not-found" };
@@ -179,6 +183,29 @@ export class MemoryExtractionService {
       return { memoriesCreated: 0, entitiesCreated: 0, relationshipsCreated: 0, skipped: 0, reason: "extraction-disabled" };
     }
 
+    // Watermark — skip threads with no activity since the last extraction.
+    // Without this, every hourly sweep re-judged the same window and wrote
+    // near-duplicate memories (observed live: identical facts at 10:00,
+    // 11:00, and 12:00 from one thread). Keyed on thread.updatedAt (bumps
+    // on new messages); manual kicks pass `force` to bypass.
+    const wmKey = `memx:wm:${input.threadId}`;
+    const threadStamp = (thread as any).updatedAt ? new Date((thread as any).updatedAt).toISOString() : null;
+    if (!input.force && this.redis && threadStamp) {
+      try {
+        const wm = await this.redis.get(wmKey);
+        if (wm && wm >= threadStamp) {
+          return { memoriesCreated: 0, entitiesCreated: 0, relationshipsCreated: 0, skipped: 0, reason: "no-new-activity" };
+        }
+      } catch {
+        // Redis hiccup — proceed without the watermark.
+      }
+    }
+    const setWatermark = () => {
+      if (this.redis && threadStamp) {
+        this.redis.set(wmKey, threadStamp, "EX", 60 * 60 * 24 * 14).catch(() => undefined);
+      }
+    };
+
     // Pull the last N messages (N = max(minMessagesBeforeRun * 2, 40) up to 80
     // to give the judge enough context without runaway token cost).
     const windowSize = Math.max(Math.min(policy.minMessagesBeforeRun * 2, 80), 20);
@@ -206,6 +233,8 @@ export class MemoryExtractionService {
       take: windowSize,
     });
     if (messages.length < policy.minMessagesBeforeRun) {
+      // Mark covered — new messages bump thread.updatedAt past the watermark.
+      setWatermark();
       return {
         memoriesCreated: 0,
         entitiesCreated: 0,
@@ -345,6 +374,10 @@ export class MemoryExtractionService {
         );
       }
     }
+
+    // Transcript fully evaluated — stamp the watermark so unchanged threads
+    // are skipped by subsequent sweeps.
+    setWatermark();
 
     return {
       memoriesCreated,

--- a/apps/agent/src/memory/memory.service.ts
+++ b/apps/agent/src/memory/memory.service.ts
@@ -111,6 +111,11 @@ export interface SemanticSearchInput {
    */
   visibilityIn?: MemoryVisibility[];
   /**
+   * Restrict to a set of agents (cluster-member search). Wins alongside
+   * the scope+user filters; mutually exclusive with `agentId` in practice.
+   */
+  agentIds?: string[];
+  /**
    * MCPF-W2 — when `true`, semantic search includes archived rows. Default
    * `false` — archived rows are filtered out so the agent never recalls
    * them. Restore via `MemoryService.restore`.
@@ -596,6 +601,10 @@ export class MemoryService {
         wheres.push(`"agentId" = $${nextIdx++}`);
       }
     }
+    if (input.agentIds && input.agentIds.length > 0) {
+      params.push(input.agentIds);
+      wheres.push(`"agentId" = ANY($${nextIdx++}::text[])`);
+    }
     if (input.agentVisibleOnly) {
       wheres.push(`"agentVisible" = TRUE`);
     }
@@ -657,14 +666,30 @@ export class MemoryService {
     scope: ScopeTuple,
     query: string,
     userId: string,
-    options?: { limit?: number; minScore?: number },
+    options?: { limit?: number; minScore?: number; clusteringId?: string | null },
   ): Promise<MemorySearchHit[]> {
+    // Cluster share means the cluster's MEMBERS — not every agent in the
+    // scope. Resolve the member ids and filter to them; without a
+    // clusteringId (legacy callers) fall back to the old scope-wide search.
+    let agentIds: string[] | undefined;
+    if (options?.clusteringId) {
+      const members: Array<{ id: string }> = await this.prisma.platosAgent.findMany({
+        where: {
+          organizationId: scope.organizationId,
+          projectId: scope.projectId,
+          environmentId: scope.environmentId,
+          clusteringId: options.clusteringId,
+        },
+        select: { id: true },
+      });
+      agentIds = members.map((m) => m.id);
+    }
     return this.semanticSearch(scope, {
       query,
       userId,
       limit: options?.limit ?? 10,
       minScore: options?.minScore,
-      // agentId intentionally omitted → searches across all agents in scope
+      ...(agentIds && agentIds.length > 0 ? { agentIds } : {}),
     });
   }
 


### PR DESCRIPTION
Follow-ups to #42:
- **Cluster share = cluster MEMBERS only** — `semanticSearchForCluster` resolves member agentIds and filters `agentId = ANY(...)` (was: all agents in scope).
- **Extraction watermark** — unchanged threads are skipped by the hourly sweep (Redis `memx:wm:<threadId>` on `thread.updatedAt`); manual kicks bypass with `force`. Kills the duplicate-memory writes observed today.

Deployed + healthy on test.platos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)