### PR TITLE
fix(security): cross-tenant IDOR in session dispatch + complete memory agent-scoping

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -1457,6 +1457,40 @@ export class AgentService {
    * Non-streaming callers (e.g. `run()`) may pass `undefined` — artifact
    * events are silently dropped in that path since there's no consumer.
    */
+  /**
+   * Resolve the agent-scoping filter for memory READS (recall / list /
+   * injection). The product rule: an agent sees only its OWN memories unless
+   * it is clustered, in which case it sees its cluster MEMBERS' memories.
+   *   - no agentId (agent-less session) → {} (no agent identity to scope to)
+   *   - standalone agent               → { agentId }
+   *   - clustered agent                → { agentIds: [members…] }
+   * Returned object is spread straight into the MemoryService read input.
+   */
+  private async memoryAgentFilter(
+    agentId: string | undefined,
+    clusteringId: string | null | undefined,
+    scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
+  ): Promise<{ agentId?: string; agentIds?: string[] }> {
+    if (!agentId) return {};
+    if (!clusteringId) return { agentId };
+    try {
+      const members: Array<{ id: string }> = await this.prisma.platosAgent.findMany({
+        where: {
+          organizationId: scope.organizationId,
+          projectId: scope.projectId,
+          environmentId: scope.environmentId,
+          clusteringId,
+        },
+        select: { id: true },
+      });
+      const ids = members.map((m) => m.id);
+      return ids.length > 0 ? { agentIds: ids } : { agentId };
+    } catch {
+      // On lookup failure, fail CLOSED to the single agent (never scope-wide).
+      return { agentId };
+    }
+  }
+
   private buildMetaTools(
     scope: RequestScope,
     agentConfig?: AgentConfig,
@@ -1954,9 +1988,8 @@ export class AgentService {
             kind,
             limit,
             offset,
-            // Same agent-scoping rule as `recall`: cluster members share,
-            // standalone agents see only their own memories.
-            ...(agentConfig?.clusteringId || !scope.agentId ? {} : { agentId: scope.agentId }),
+            // Own agent, or cluster MEMBERS when clustered (never scope-wide).
+            ...(await this.memoryAgentFilter(scope.agentId, agentConfig?.clusteringId, scope)),
           });
           return {
             total: rows.length,
@@ -4961,12 +4994,12 @@ export class AgentService {
                 minScore: 0.35,
                 // Defaults exclude "private"; pass agent-visible + hidden.
                 visibilityIn: ["agent_visible", "hidden"],
-                // Agent-scoped injection: memory crosses agents ONLY inside a
-                // cluster. Without this filter, every agent in the scope saw
-                // every other agent's user memories — observed live: Mark
-                // (fitness coach) opened with Ada's (SDR) Pulsegrid/cold-email
-                // background the hour memory-extraction came back online.
-                ...(scope.agentId && !injectClusteringId ? { agentId: scope.agentId } : {}),
+                // Agent-scoped injection: own agent, or cluster MEMBERS when
+                // clustered — never scope-wide. (Original leak: Mark the
+                // fitness coach opened with Ada the SDR's Pulsegrid/cold-email
+                // background. Clustered agents previously still leaked
+                // scope-wide here; now member-resolved.)
+                ...(await this.memoryAgentFilter(scope.agentId, injectClusteringId, scope)),
               },
             ),
             new Promise<never>((_, reject) =>

--- a/apps/agent/src/connections/connections.gateway.ts
+++ b/apps/agent/src/connections/connections.gateway.ts
@@ -666,19 +666,23 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
     })();
     if (!chatSdk?.AgentChat) return false;
 
-    // Mint the thread up-front for new conversations (same as the durable
-    // path) — the session externalId IS the threadId, so it must exist first.
-    let threadId = data?.threadId as string | undefined;
-    if (!threadId) {
-      try {
-        const convo = (this.agentTaskService as any).conversationService;
-        const created = await convo?.getOrCreateThread?.(scope, agentId);
-        threadId = created?.id as string | undefined;
-      } catch {
-        return false;
-      }
-      if (!threadId) return false;
+    // SECURITY (cross-tenant IDOR) — ALWAYS resolve the threadId through
+    // getOrCreateThread, which scope+owner-gates it (getThread filters by the
+    // full scope tuple AND userId/createdByUserId). Never trust a client-
+    // supplied threadId directly: without this, a caller could pass a victim's
+    // threadId and get joined to `thread:<victimId>` — reading the victim's
+    // streamed turns and injecting into their live UI. A non-owned threadId
+    // resolves to a freshly minted (owned) thread instead. The session
+    // externalId IS this resolved threadId, so it must exist first anyway.
+    let threadId: string | undefined;
+    try {
+      const convo = (this.agentTaskService as any).conversationService;
+      const resolved = await convo?.getOrCreateThread?.(scope, agentId, data?.threadId);
+      threadId = resolved?.id as string | undefined;
+    } catch {
+      return false;
     }
+    if (!threadId) return false;
 
     try {
       // FRESH AgentChat per message (deliberate — do NOT cache): with the
@@ -845,21 +849,20 @@ export class ConnectionsGateway implements OnGatewayConnection, OnGatewayDisconn
     const triggerReady = !!process.env.TRIGGER_SECRET_KEY && !!triggerSdk?.tasks?.trigger;
     if (!triggerReady) return false; // managed trigger not configured → direct
 
-    // New-thread durable turn: no threadId from the client (fresh chat). Mint
-    // the thread now so (a) we hand a concrete threadId to the run, (b) we can
-    // join the client to its room before the run streams, and (c) the client
-    // adopts it for subsequent turns via the meta event below. On failure, fall
-    // back to the direct path (which mints the thread itself).
-    if (!threadId) {
-      try {
-        const convo = (this.agentTaskService as any).conversationService;
-        const created = await convo?.getOrCreateThread?.(scope, agentId);
-        threadId = created?.id as string | undefined;
-      } catch {
-        return false;
-      }
-      if (!threadId) return false;
+    // SECURITY (cross-tenant IDOR — same as tryDispatchSession) — ALWAYS
+    // resolve through getOrCreateThread so a client-supplied threadId is
+    // scope+owner-gated before we join the room / bridge the run. A foreign
+    // threadId resolves to a freshly minted owned thread rather than joining
+    // `thread:<victimId>`. Also gives us a concrete id to hand the run and for
+    // the client to adopt via the meta event below.
+    try {
+      const convo = (this.agentTaskService as any).conversationService;
+      const resolved = await convo?.getOrCreateThread?.(scope, agentId, data?.threadId);
+      threadId = resolved?.id as string | undefined;
+    } catch {
+      return false;
     }
+    if (!threadId) return false;
 
     try {
       const clientMessageId = (data as any).idempotencyKey as string | undefined;

--- a/apps/agent/src/memory/memory.service.ts
+++ b/apps/agent/src/memory/memory.service.ts
@@ -127,6 +127,8 @@ export interface ListMemoriesInput {
   userId: string;
   kind?: MemoryKind | string;
   agentId?: string | null;
+  /** Restrict to a set of agents (cluster-member listing). */
+  agentIds?: string[];
   limit?: number;
   offset?: number;
   /**
@@ -546,6 +548,16 @@ export class MemoryService {
          ${includeArchived ? "" : `AND "archivedAt" IS NULL`}
          ${input.kind ? `AND "kind" = $5` : ""}
          ${input.agentId !== undefined ? `AND "agentId" ${input.agentId === null ? "IS NULL" : `= $${input.kind ? 6 : 5}`}` : ""}
+         ${
+           input.agentIds && input.agentIds.length > 0
+             ? `AND "agentId" = ANY($${
+                 4 +
+                 (input.kind ? 1 : 0) +
+                 (input.agentId !== undefined && input.agentId !== null ? 1 : 0) +
+                 1
+               }::text[])`
+             : ""
+         }
        ORDER BY "lastAccessedAt" DESC NULLS LAST, "createdAt" DESC
        LIMIT ${limit} OFFSET ${offset}`,
       ...buildListArgs(scope, input),

--- a/docs/audit-cross-agent-tenancy-2026-07-16.md
+++ b/docs/audit-cross-agent-tenancy-2026-07-16.md
@@ -1,0 +1,37 @@
+# Cross-agent / cross-tenant audit — 2026-07-16
+
+Triggered by a live leak: **Mark** (fitness agent) opened a chat with **Ada's** (SDR) Pulsegrid/cold-email context for the same user. Three parallel auditors swept (1) memory/KG read+write paths, (2) every other turn-time ingredient + broadcast surfaces, (3) the day's new Trigger-Sessions code. Rule under test: *a turn's context contains only its own agent's data, plus cluster-shared data when agents share a `clusteringId`.*
+
+## FIXED this session
+
+| # | Finding | Sev | Fix |
+|---|---------|-----|-----|
+| A | **Memory recall/injection/list had no agentId filter** — every agent read every agent's user memories (the Mark/Ada leak). | High | PR #42: pass `agentId: scope.agentId` at all three read sites. |
+| B | **Clustered agents still searched scope-wide** — the #42 fix *dropped* the filter for clustered agents instead of resolving cluster members; `semanticSearchForCluster` also searched all agents in scope. | High | PR #43 + this PR: `memoryAgentFilter()` resolves cluster MEMBERS → `agentIds` filter; `list`/`semanticSearch` gained `agentIds`; fails **closed** to the single agent on error. |
+| C | **Socket.IO dispatch IDOR** — `tryDispatchSession`/`tryDispatchDurable` joined `thread:<client-supplied-threadId>` with no ownership check (unlike `handleJoinThread`). A caller with a durable agent in their own scope could pass a victim's threadId → read the victim's streamed turns AND inject into their live UI; also attach to the victim's durable session `.out`. | High | This PR: both paths now resolve every threadId through the scope+owner-gated `getOrCreateThread`; a non-owned threadId mints a fresh owned thread instead of joining the victim room. |
+| D | **Extraction wrote duplicate memories** every hourly sweep (same facts at 10/11/12:00). | Med | PR #43: per-thread watermark (`memx:wm:<threadId>` on `thread.updatedAt`); manual kicks pass `force`. |
+
+## PRE-EXISTING — flagged, NOT yet fixed (need your call; larger/older surfaces)
+
+| # | Finding | Sev | Recommended fix |
+|---|---------|-----|-----------------|
+| E | **REST `/api/v1/memory/*` `?userId=` override** — `GET /`, `/search`, `/export`, `/graph/*` take `userId` from a query param and any entity/session token reaches them (the agent-pin only guards `/agents/:id/*`). A session-token holder reads **any other user's** memories + full export (incl. archived + private). | **High** (cross-user, externally reachable) | Ignore client `userId` on session-token auth (force `scope.userId`); only honor `?userId=` for operator/admin-tier tokens. Add a default `agentId` filter too. |
+| F | **`monitoring/users/:userId*` endpoints** — profile/memory content + LLM summaries for any `:userId`, session-token reachable, no membership tier. | **High** | Gate behind an operator/admin tier, not the plain scope guard. |
+| G | **Scope-room broadcast** — every client joins `scope:{org}:{proj}:{env}`; `run_update` events (incl. BGO/batch `output`) and `approval_needed`/`approval_resolved` (incl. `action`+`details`) fan out to **all** clients in the scope, no user/agent gate. | **High** (client-delivery leak) | Narrow the broadcast: route run/approval events to a `user:` or `thread:` room, not the scope room; or gate membership. Structural — needs a design pass. |
+| H | **`join_thread` scope-gated, not user-gated** — any same-scope client with a known threadId joins the thread room + receives its live stream (batch `output` may carry per-item PII). | Med | Add the `userId`/`createdByUserId` check to `handleJoinThread` (the dispatch paths now do this via getOrCreateThread; join_thread should match). |
+| I | **Run-inspection meta-tools** (`get_run_details`/`replay_run`/`wait_for_runs`/`list_runs`) enforce no scope/owner check on `runId`; `list_bgos`/`list_runs` filter project+env only. | Med (default-OFF per agent) | Scope-check the runId against the caller's tuple before returning `output`/replaying. |
+| J | **`agentId: NULL` writes** — REST `POST /memory`, MCP `memories.upsert`, RAG ingest, and export→import round-trips create/strip to null-agent rows: invisible to strict recall (silent loss) yet visible to any remaining scope-wide fallback. | Med | Stamp the caller's agentId on write; preserve agentId across export/import. |
+| K | **KG has no `agentId` column** (`PlatosMemoryEntity`/`Relationship`). No turn-time KG *read* exists today (safe), but any future KG-in-prompt injection is an automatic cross-agent leak with nothing to filter on. | Note / landmine | Add `agentId` to KG rows before wiring any KG recall. |
+| L | **Trigger session `externalId` = bare threadId**, globally keyed, no scope binding; Redis cursor key `chatsess:cursor:<threadId>` unscoped. Mitigated by fix C (threadId now owner-resolved) but defense-in-depth wants scope-namespacing. | Low (post-C) | Namespace session externalId + cursor key with the scope tuple. |
+
+## BY DESIGN (documented, not bugs)
+
+- **Conversation history, compaction summaries, artifacts** are keyed by `threadId`, not `agentId`. Agent-switch-mid-thread is a feature, so these are cross-agent *within a shared thread* by design. "Agent isolation" is really "thread isolation" for these three. Threads remain user-gated.
+- **MCP `memories.*` / `kg.*` / `gdpr.export`** are operator surfaces (scope-tier tokens, gdpr approval-gated). Caveat: an operator can bind the platform MCP to an agent, handing it scope-wide memory reads — worth a docs warning.
+- Profile cache, config/prompt Redis caches, dynamicBlocks/promptVars/sessionContext, scoped-env: all correctly agent- or scope-keyed. Safe.
+- `WorkingMemoryService` is `threadId`-only keyed but has **no callers** (dead wiring) — safe today, latent if ever injected.
+
+## Top pre-existing to fix next (recommended order)
+1. **E + F** — REST `?userId=` / `monitoring/users` cross-user (externally reachable, High).
+2. **G + H** — scope-room broadcast + `join_thread` gating (High/Med, structural).
+3. **J** — agentId-null writes (data-integrity + the strict-filter blind spot).


### PR DESCRIPTION
3-auditor cross-agent/cross-tenant sweep (triggered by the Mark-sees-Ada's-memories leak). Full report: `docs/audit-cross-agent-tenancy-2026-07-16.md`.

**Fixed here (both High, both today's code / incomplete prior fix):**
- **IDOR** — `tryDispatchSession`/`tryDispatchDurable` joined `thread:<client-threadId>` with no ownership check → cross-tenant read + inject on a victim's live chat. Now every threadId is resolved through the scope+owner-gated `getOrCreateThread`. Multi-turn verified intact.
- **Clustered memory** — the #42/#43 fix searched scope-wide for clustered agents; now member-resolved via `memoryAgentFilter()`, fails closed to the single agent.

**Pre-existing findings** (REST `?userId=`, monitoring/users tier, scope-room broadcast, join_thread gating, agentId-null writes, KG no agentId) are catalogued in the audit doc with severities — not changed here; recommend fixing E+F (external cross-user reads) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)