### PR TITLE
security: cross-tenant hardening Phase 0+1 (audit 2026-07-16)

### DIFF
--- a/apps/agent/src/agent-runtime/agent.controller.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.ts
@@ -47,6 +47,7 @@ import {
 } from "./prompt-builder.service";
 import { SkillRuntimeService } from "../skills/skill-runtime.service";
 import type { RequestScope } from "../auth/scope.guard";
+import { requireOperator } from "../auth/scope.guard";
 import { REDIS_TOKEN } from "../shared/redis.provider";
 import type Redis from "ioredis";
 import { BudgetService, type BudgetPeriod, type BudgetScopeType } from "../monitoring/budget.service";
@@ -132,6 +133,43 @@ export class AgentController {
       projectId: scope.projectId,
       environmentId: scope.environmentId,
     };
+  }
+
+  /**
+   * SECURITY (audit C2) — durable-exec internal callbacks are admin-token
+   * gated, but the whole body (incl. `scope`) is attacker-controllable if the
+   * shared static admin token is reached (e.g. via the shared Trigger enqueue
+   * surface). As a non-breaking mitigation, verify the body's agentId +
+   * threadId actually BELONG to the body's scope — a forged foreign scope
+   * won't own the real target ids. Legitimate callbacks (the chat-session /
+   * durable-turn workers) always send a scope that owns its ids, so this is a
+   * no-op for them. Full defense-in-depth = HMAC over the body with a
+   * worker-held secret (tracked as the C2 HMAC follow-up).
+   */
+  private async adminCallbackScopeOwns(body: {
+    agentId?: string;
+    threadId?: string | null;
+    scope?: { organizationId?: string; projectId?: string; environmentId?: string };
+  }): Promise<boolean> {
+    const s = body?.scope;
+    if (!s?.organizationId || !s?.projectId || !s?.environmentId) return false;
+    // FAIL CLOSED — an attacker could otherwise forge a victim scope and OMIT
+    // both ids to skip every check (Fable verify BLOCKER B). Require at least
+    // one verifiable ownership anchor.
+    if (!body.agentId && !body.threadId) return false;
+    if (body.agentId) {
+      const agent = await this.agentCrud
+        .findById(body.agentId, body.scope as any)
+        .catch(() => null);
+      if (!agent) return false;
+    }
+    if (body.threadId) {
+      const thread = await this.conversationService
+        .getThread(body.threadId, body.scope as any, { allUsers: true })
+        .catch(() => null);
+      if (!thread) return false;
+    }
+    return true;
   }
 
   /**
@@ -1913,6 +1951,9 @@ export class AgentController {
     },
   ) {
     const scope = this.getScope(req);
+    // SECURITY (audit C1/M7) — entity registration is minting authority
+    // (a new entity + serviceSecret). Operator-only.
+    requireOperator(scope);
     // PIFSP-3 Deliverable 1 — tighten server-side validation to the same
     // regex the form uses. Protects against API callers who skip the
     // browser client.
@@ -1950,6 +1991,10 @@ export class AgentController {
     @Param("entityId") entityId: string,
   ) {
     const scope = this.getScope(req);
+    // SECURITY (audit C1) — the serviceSecret IS the HMAC key that signs
+    // session tokens; an end-user/entity token must never rotate it (and
+    // receive the new plaintext → mint tokens for any user).
+    requireOperator(scope);
     const result = await this.authService.regenerateServiceSecret(
       scope.organizationId,
       scope.projectId,
@@ -2115,6 +2160,8 @@ export class AgentController {
     },
   ) {
     const scope = this.getScope(req);
+    // SECURITY (audit C1 — entity config is operator-only).
+    requireOperator(scope);
     const entity = await this.authService.getEntity(
       scope.organizationId,
       scope.projectId,
@@ -2355,6 +2402,8 @@ export class AgentController {
     @Res() res: Response,
   ): Promise<void> {
     const scope = this.getScope(req);
+    // SECURITY (audit C1 — test credentials are operator-only).
+    requireOperator(scope);
     const entity = await this.authService.getEntity(
       scope.organizationId,
       scope.projectId,
@@ -2570,11 +2619,20 @@ export class AgentController {
     @Query("date") date?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     return this.costService.getScopeDailyCost(this.scopeTuple(scope), date);
   }
 
   @Get("monitoring/cost/thread/:threadId")
-  async getThreadCost(@Param("threadId") threadId: string) {
+  async getThreadCost(@Req() req: Request, @Param("threadId") threadId: string) {
+    // SECURITY (audit H2) — cross-TENANT IDOR: this took no scope and read a
+    // threadId-only Redis key, so any threadId leaked another org's spend.
+    // Scope-gate the thread first (mirrors getThreadTrace below), 404 on miss.
+    const scope = this.getScope(req);
+    const thread = await this.conversationService.getThread(threadId, scope as any);
+    if (!thread) {
+      return { error: "Thread not found", status: 404 };
+    }
     return this.costService.getThreadCost(threadId);
   }
 
@@ -2605,6 +2663,7 @@ export class AgentController {
     @Query("limit") limit?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const rows = await this.costService.getCostByModel(this.scopeTuple(scope), {
       days: days ? parseInt(days, 10) : undefined,
       limit: limit ? parseInt(limit, 10) : undefined,
@@ -2622,6 +2681,7 @@ export class AgentController {
     @Query("limit") limit?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const rows = await this.costService.getCostByAgent(this.scopeTuple(scope), {
       days: days ? parseInt(days, 10) : undefined,
       limit: limit ? parseInt(limit, 10) : undefined,
@@ -2642,6 +2702,7 @@ export class AgentController {
     @Query("limit") limitRaw?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.costService as any).prisma;
     if (!prisma) return { rows: [], windowHours: 24, fetchedAt: new Date().toISOString() };
     const limit = Math.min(20, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 5 : 5));
@@ -2745,6 +2806,7 @@ export class AgentController {
     @Query("limit") limit?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const rows = await this.costService.getCostByUser(this.scopeTuple(scope), {
       days: days ? parseInt(days, 10) : undefined,
       limit: limit ? parseInt(limit, 10) : undefined,
@@ -2768,6 +2830,7 @@ export class AgentController {
     @Query("sort") sort?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.costService as any).prisma;
     if (!prisma) return { users: [], nextCursor: null, fetchedAt: new Date().toISOString() };
 
@@ -2982,6 +3045,7 @@ export class AgentController {
     @Query("sinceDays") sinceDaysRaw?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.costService as any).prisma;
     if (!prisma) return { agents: [], fetchedAt: new Date().toISOString() };
     const sinceDays = Math.min(90, Math.max(1, sinceDaysRaw ? parseInt(sinceDaysRaw, 10) || 30 : 30));
@@ -3082,6 +3146,7 @@ export class AgentController {
     @Param("userId") targetUserId: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.costService as any).prisma;
     if (!prisma) return { error: "service unavailable", status: 503 };
 
@@ -3249,6 +3314,7 @@ export class AgentController {
     @Param("userId") targetUserId: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     return this.budgetService.getUserConsumptionSummary(scope, targetUserId);
   }
 
@@ -3260,6 +3326,7 @@ export class AgentController {
   @Get("monitoring/breaches")
   async monitoringBreaches(@Req() req: Request) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     // Active userIds in the period — derive from the per-user cost rollup
     // (anyone who spent ≥1 cent in the last 30 days).
     let activeUserIds: string[] = [];
@@ -3280,6 +3347,7 @@ export class AgentController {
     @Param("userId") targetUserId: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.costService as any).prisma;
     if (!prisma) return { error: "service unavailable" };
 
@@ -3415,6 +3483,7 @@ Write the summary now:`;
     @Query("days") daysRaw?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const days = Math.max(1, Math.min(30, daysRaw ? parseInt(daysRaw, 10) || 7 : 7));
     const result = await this.costService.getAgentCacheRange(
       this.scopeTuple(scope),
@@ -3437,6 +3506,7 @@ Write the summary now:`;
     @Query("date") date?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const result = await this.costService.getSkillCostDaily(this.scopeTuple(scope), date);
     return { ...result, fetchedAt: new Date().toISOString() };
   }
@@ -3452,6 +3522,7 @@ Write the summary now:`;
     @Query("to") to?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const today = new Date().toISOString().slice(0, 10);
     const end = to || today;
     // Default to a 7-day window ending today when no `from` given.
@@ -3476,6 +3547,7 @@ Write the summary now:`;
     @Query("limit") limit?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     return this.utilizationService.build(this.scopeTuple(scope), {
       days: days ? parseInt(days, 10) : undefined,
       topUserLimit: limit ? parseInt(limit, 10) : undefined,
@@ -3492,6 +3564,7 @@ Write the summary now:`;
     @Query("days") days?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     return this.utilizationService.build(this.scopeTuple(scope), {
       days: days ? parseInt(days, 10) : undefined,
     });
@@ -3519,6 +3592,7 @@ Write the summary now:`;
     @Query("offset") offset?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const page = await this.toolAuditService.list(this.scopeTuple(scope), {
       threadId,
       agentId,
@@ -3539,6 +3613,7 @@ Write the summary now:`;
   @Get("monitoring/tool-audit/:callId")
   async getToolAudit(@Req() req: Request, @Param("callId") callId: string) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const row = await this.toolAuditService.getById(this.scopeTuple(scope), callId);
     if (!row) return { error: "Tool call not found", status: 404 };
     return row;
@@ -3562,6 +3637,7 @@ Write the summary now:`;
     @Param("callId") callId: string,
   ): Promise<any> {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
 
     // PPR-10 — per-(scope, user) token bucket: 10 replays per minute.
     // Replay re-invokes through ToolExecutorService.execute which runs
@@ -3640,6 +3716,7 @@ Write the summary now:`;
     @Query("offset") offset?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const scopeTuple = this.scopeTuple(scope);
     // Note: previously this called `sweepExpired` synchronously on every
     // request. The webapp polls this endpoint every ~2s for the pending-
@@ -3665,6 +3742,7 @@ Write the summary now:`;
   @Get("monitoring/approvals/:approvalId")
   async getApproval(@Req() req: Request, @Param("approvalId") approvalId: string) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const row = await this.approvalsService.getById(this.scopeTuple(scope), approvalId);
     if (!row) return { error: "Approval not found", status: 404 };
     return row;
@@ -3714,6 +3792,12 @@ Write the summary now:`;
     }
     if (!body?.threadId || !body?.scope) {
       return { status: "invalid", reason: "threadId and scope required" };
+    }
+    // SECURITY (audit C2 / Fable BLOCKER B residual) — the body's scope must
+    // own the thread (compaction runs under the supplied scope). threadId is
+    // mandatory here so no omit-ids hole, but the ownership was unverified.
+    if (!(await this.adminCallbackScopeOwns(body))) {
+      return { status: "forbidden", reason: "scope does not own the target thread" };
     }
     const start = Date.now();
     try {
@@ -3788,6 +3872,10 @@ Write the summary now:`;
     if (!env.PLATOS_ADMIN_TOKEN) return { status: "skipped", reason: "PLATOS_ADMIN_TOKEN not set" };
     if (!this.verifyAdminToken(req)) return { status: "forbidden" };
     if (!body?.message || !body?.scope) return { status: "invalid", reason: "message and scope required" };
+    // SECURITY (audit C2) — the body's scope must own its agent/thread.
+    if (!(await this.adminCallbackScopeOwns(body))) {
+      return { status: "forbidden", reason: "scope does not own the target agent/thread" };
+    }
     const start = Date.now();
     const threadId = body.threadId;
     const room = `thread:${threadId}`;
@@ -3885,6 +3973,11 @@ Write the summary now:`;
       res.status(400).json({ error: "message and scope required" });
       return;
     }
+    // SECURITY (audit C2) — the body's scope must own its agent/thread.
+    if (!(await this.adminCallbackScopeOwns(body))) {
+      res.status(403).json({ error: "forbidden", reason: "scope does not own the target agent/thread" });
+      return;
+    }
     const ac = new AbortController();
     const onClose = () => {
       if (!ac.signal.aborted) ac.abort();
@@ -3932,6 +4025,10 @@ Write the summary now:`;
     if (!env.PLATOS_ADMIN_TOKEN) return { status: "skipped", reason: "PLATOS_ADMIN_TOKEN not set" };
     if (!this.verifyAdminToken(req)) return { status: "forbidden" };
     if (!body?.goal || !body?.scope) return { status: "invalid", reason: "goal and scope required" };
+    // SECURITY (audit C2 / Fable BLOCKER B) — the body's scope must own its agent/thread.
+    if (!(await this.adminCallbackScopeOwns(body))) {
+      return { status: "forbidden", reason: "scope does not own the target agent/thread" };
+    }
     const start = Date.now();
     try {
       // TODO(refactor): multi-step autonomous orchestration. For now a single
@@ -3986,6 +4083,17 @@ Write the summary now:`;
     if (!this.verifyAdminToken(req)) return { status: "forbidden" };
     if (!body?.skillId || !body?.toolName || !body?.scope) {
       return { status: "invalid", reason: "skillId, toolName and scope required" };
+    }
+    // SECURITY (audit C2 / Fable BLOCKER B) — the body's scope must own its
+    // agent/thread. skill-run carries the agent id inside scope.agentId.
+    if (
+      !(await this.adminCallbackScopeOwns({
+        agentId: body.scope?.agentId,
+        threadId: body.threadId ?? body.scope?.threadId,
+        scope: body.scope,
+      }))
+    ) {
+      return { status: "forbidden", reason: "scope does not own the target agent/thread" };
     }
     if (!this.skillRuntime) return { status: "skipped", reason: "SkillRuntimeService unavailable" };
     const start = Date.now();
@@ -4194,6 +4302,7 @@ Write the summary now:`;
   @Get("monitoring/summary")
   async monitoringSummary(@Req() req: Request) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const scopeTuple = this.scopeTuple(scope);
 
     const [threadCountAll, threadCountDay, cost7d] = await Promise.all([
@@ -4281,6 +4390,7 @@ Write the summary now:`;
   @Get("monitoring/governance")
   async governanceDashboard(@Req() req: Request, @Query("sinceDays") sinceDaysRaw?: string) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const sinceDays = sinceDaysRaw ? parseInt(sinceDaysRaw, 10) : undefined;
     return this.governanceService.dashboard(this.scopeTuple(scope), { sinceDays });
   }
@@ -4300,6 +4410,7 @@ Write the summary now:`;
     @Query("offset") offset?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     return this.safetyEventService.list(this.scopeTuple(scope), {
       detector: detector as DetectorKind | undefined,
       action: action as DetectorAction | undefined,
@@ -4334,6 +4445,7 @@ Write the summary now:`;
     @Query("agentId") agentId?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
     const prisma = (this.agentService as any).prisma;
     const limit = Math.min(50, Math.max(1, limitStr ? parseInt(limitStr, 10) : 15));
     const scopeWhere = {
@@ -4526,6 +4638,8 @@ Write the summary now:`;
     },
   ) {
     const scope = this.getScope(req);
+    // SECURITY (audit H16 — budget caps are operator-only (financial DoS otherwise)).
+    requireOperator(scope);
     try {
       const cap = await this.budgetService.upsert(this.scopeTuple(scope), body);
       return { cap };
@@ -4544,6 +4658,8 @@ Write the summary now:`;
   @Delete("budgets/:capId")
   async deleteBudget(@Req() req: Request, @Param("capId") capId: string) {
     const scope = this.getScope(req);
+    // SECURITY (audit H16 — budget caps are operator-only).
+    requireOperator(scope);
     const deleted = await this.budgetService.delete(this.scopeTuple(scope), capId);
     return { deleted };
   }
@@ -4559,6 +4675,8 @@ Write the summary now:`;
     @Body() body: { minutes: number },
   ) {
     const scope = this.getScope(req);
+    // SECURITY (audit H16 — budget override is operator-only).
+    requireOperator(scope);
     const minutes = typeof body?.minutes === "number" ? body.minutes : 0;
     const cap = await this.budgetService.override(this.scopeTuple(scope), capId, {
       minutes,

--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -1,7 +1,25 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException, Inject, Optional } from "@nestjs/common";
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException, ForbiddenException, Inject, Optional } from "@nestjs/common";
 import * as crypto from "node:crypto";
 import { AuthService } from "./auth.service";
 import { env } from "../shared/env";
+
+/**
+ * SECURITY (2026-07-16 audit — OWASP API5 BFLA, deny-by-default function-level
+ * authz). Throw 403 unless the caller is an operator (the webapp control-plane
+ * or a platform-signed token). Fails CLOSED: an undefined/end-user principal is
+ * rejected. Call at the TOP of any handler that exposes cross-user data,
+ * secrets, budgets, files, entity management, or monitoring — surfaces that an
+ * entity-minted widget/SDK/guest token must never reach.
+ */
+export function requireOperator(scope: Pick<RequestScope, "principal">): void {
+  if (scope?.principal !== "operator") {
+    throw new ForbiddenException({
+      error: "OPERATOR_ONLY",
+      message:
+        "This endpoint requires an operator (control-plane) credential. End-user / entity / guest tokens are not permitted.",
+    });
+  }
+}
 
 /**
  * EOBD.40 — parse a W3C traceparent header into its trace-id +
@@ -52,6 +70,20 @@ export interface RequestScope {
   userToken?: string;
   agentId?: string;
   sessionId?: string;
+  /**
+   * SECURITY (2026-07-16 audit C1/H1) — trust tier of the caller.
+   *   "operator"  — the webapp/control-plane: a platform-signed session token
+   *                 (iss:"platos-platform", verified against PLATOS_SESSION_SECRET
+   *                 which only the webapp holds) OR the trusted internal
+   *                 direct-header path (webapp→agent over the Docker network,
+   *                 never through Caddy).
+   *   "end-user"  — an entity-signed session token (a widget/SDK end-user or
+   *                 anonymous public guest). MUST NOT reach operator surfaces
+   *                 (other users' data, secrets, budgets, monitoring).
+   * `requireOperator(scope)` enforces this. Undefined is treated as end-user
+   * (fail closed).
+   */
+  principal?: "operator" | "end-user";
   /** OTel trace context — set by AgentTaskService for the current turn so
    * downstream services (tool executor, provider calls) can attach child
    * spans. Theme E.1. */
@@ -330,6 +362,16 @@ export class ScopeGuard implements CanActivate {
           userId: payload.userId,
           entityId: payload.entityId,
           userToken: payload.userToken,
+          // Operator ONLY when platform-signed (verified against
+          // PLATOS_SESSION_SECRET) AND not a public guest. The guest-token flow
+          // (EOBD.89) mints platform-signed tokens with isGuest:true for
+          // anonymous visitors — those are end-users, NOT operators. (Fable
+          // verify BLOCKER A: iss-alone classification let an anonymous guest
+          // reach regenerate-secret + budget mutators.)
+          principal:
+            payload.iss === "platos-platform" && (payload as any).isGuest !== true
+              ? "operator"
+              : "end-user",
           ...(tokenAgentId ? { agentId: tokenAgentId } : {}),
           ...(sessionContextFromToken
             ? { sessionContext: sessionContextFromToken }
@@ -377,6 +419,10 @@ export class ScopeGuard implements CanActivate {
         projectId: String(projectId),
         environmentId: String(environmentId),
         userId: String(userId),
+        // Trusted internal path (webapp→agent over the Docker network, never
+        // through Caddy — enforced by the !viaProxy guard above). This IS the
+        // control-plane, so it authorizes operator surfaces.
+        principal: "operator",
         ...(entityId ? { entityId: String(entityId) } : {}),
         ...(userToken ? { userToken: String(userToken) } : {}),
         // EOBD.40 — propagate inbound traceparent on the direct-header

--- a/apps/agent/src/files/files.controller.ts
+++ b/apps/agent/src/files/files.controller.ts
@@ -4,6 +4,7 @@ import { AttachmentsService } from "../agent-runtime/attachments.service";
 import { PRISMA_TOKEN } from "../shared/database.provider";
 import { Inject } from "@nestjs/common";
 import type { RequestScope } from "../auth/scope.guard";
+import { requireOperator } from "../auth/scope.guard";
 
 /**
  * PIFSP-16 — File System: 4-level hierarchy for browsing attachments.
@@ -41,6 +42,7 @@ export class FilesController {
     @Query("search") search?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H10) — file browser is operator-only (cross-user presigned URLs)
     const limit = Math.min(200, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 50 : 50));
 
     const rows: Array<{
@@ -101,6 +103,7 @@ export class FilesController {
     @Query("search") search?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H10) — file browser is operator-only (cross-user presigned URLs)
     const limit = Math.min(200, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 50 : 50));
 
     const rows: Array<{
@@ -154,6 +157,7 @@ export class FilesController {
     @Query("search") search?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H10) — file browser is operator-only (cross-user presigned URLs)
     const limit = Math.min(200, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 50 : 50));
 
     const rows: Array<{
@@ -210,6 +214,7 @@ export class FilesController {
     @Query("mime") mimeFilter?: string,
   ) {
     const scope = this.getScope(req);
+    requireOperator(scope); // SECURITY (audit H10) — file browser is operator-only (cross-user presigned URLs)
     const limit = Math.min(200, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 50 : 50));
 
     const whereBase: Record<string, unknown> = {

--- a/apps/agent/src/mcp-platform/mcp-platform.controller.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform.controller.ts
@@ -292,6 +292,14 @@ export class McpPlatformController {
     if (raw.startsWith("plt_oa_")) {
       const oa = await this.oauth.verifyAccessToken(raw);
       if (!oa) return null;
+      // SECURITY (audit C3) — an entity-minted OAuth token (entityPk set) is
+      // scoped to that ENTITY's per-entity MCP surface, NOT the org-wide
+      // platform surface. verifyAnyBearer never inspected entityPk, so an
+      // embedded-widget visitor could request scope=mcp:write → permissions
+      // ["*"] and drive org/project-wide platform tools (agents.*, providers.*,
+      // entities.regenerate_secret, …). Reject entity OAuth tokens here — the
+      // inverse of the per-entity surface's own entityPk pin.
+      if (oa.entityPk) return null;
       const permissions = oa.scopes.includes("mcp:write")
         ? ["*"]
         : ["*.list", "*.get", "platos_whoami", "platos_list_accessible_scopes"];

--- a/apps/agent/src/mcp-platform/tools/trigger.ts
+++ b/apps/agent/src/mcp-platform/tools/trigger.ts
@@ -212,14 +212,33 @@ export function buildTriggerToolHandlers(): McpToolHandler[] {
         },
         additionalProperties: false,
       },
-      async execute(params) {
+      async execute(params, scope) {
         const taskId = String(params["taskId"]);
+        const payload = (params["payload"] ?? {}) as Record<string, unknown>;
+        // SECURITY (audit C4) — platos.* worker tasks forward payload.scope to
+        // admin-token internal callbacks that run a turn UNDER that scope. The
+        // MCP admin tier is "cross-scope WITHIN the minting org", not a
+        // platform superuser, so a foreign payload.scope would be a cross-ORG
+        // escalation. Rebind the scope tuple to the token's own verified scope
+        // for any platos.* task — never trust the caller-supplied scope.
+        // Match BOTH dot- and dash-namespaced Platos tasks: platos.agent.*
+        // AND platos-agent-tool-block / platos-agent-batch / platos-custom-task,
+        // which are the real scope-forwarding workers (Fable verify BLOCKER C).
+        if (/^platos[.-]/.test(taskId) && payload && typeof payload === "object") {
+          const existing = (payload["scope"] ?? {}) as Record<string, unknown>;
+          payload["scope"] = {
+            ...existing,
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+          };
+        }
         return triggerFetch(
           `/api/v1/tasks/${encodeURIComponent(taskId)}/trigger`,
           {
             method: "POST",
             body: JSON.stringify({
-              payload: params["payload"] ?? {},
+              payload,
               options: params["options"] ?? {},
             }),
           },

--- a/apps/agent/src/memory/knowledge-graph.service.ts
+++ b/apps/agent/src/memory/knowledge-graph.service.ts
@@ -190,14 +190,19 @@ export class KnowledgeGraphService {
     return toEntityRow(row, (v) => this.decString(v), (v) => this.crypto?.decryptJsonField(v) ?? v);
   }
 
-  async getEntityById(scope: ScopeTuple, id: string): Promise<EntityRow | null> {
+  async getEntityById(scope: ScopeTuple, id: string, userId?: string): Promise<EntityRow | null> {
     this.requireScope(scope);
+    // SECURITY (audit H9) — when a userId is supplied, gate the entity to that
+    // user (KG entities carry userId). The session-token REST path passes
+    // scope.userId so it can't read another user's entity by id; operator MCP
+    // tools omit it (scope-only, operator-trusted).
     const row = await this.prisma.platosMemoryEntity.findFirst({
       where: {
         id,
         organizationId: scope.organizationId,
         projectId: scope.projectId,
         environmentId: scope.environmentId,
+        ...(userId ? { userId } : {}),
       },
     });
     return row ? toEntityRow(row, (v) => this.decString(v), (v) => this.crypto?.decryptJsonField(v) ?? v) : null;
@@ -211,9 +216,13 @@ export class KnowledgeGraphService {
   async getRelationships(
     scope: ScopeTuple,
     input: { entityId: string },
+    userId?: string,
   ): Promise<EntityRelationships | null> {
     this.requireScope(scope);
-    const entity = await this.getEntityById(scope, input.entityId);
+    // SECURITY (audit H9) — gate the root entity by userId (the getEntityById
+    // call returns null for a foreign entity), and filter the relationship
+    // rows by userId too when supplied.
+    const entity = await this.getEntityById(scope, input.entityId, userId);
     if (!entity) return null;
 
     const [outRows, inRows] = await Promise.all([
@@ -223,6 +232,7 @@ export class KnowledgeGraphService {
           organizationId: scope.organizationId,
           projectId: scope.projectId,
           environmentId: scope.environmentId,
+          ...(userId ? { userId } : {}),
         },
         include: { toEntity: true },
         orderBy: { createdAt: "desc" },
@@ -234,6 +244,7 @@ export class KnowledgeGraphService {
           organizationId: scope.organizationId,
           projectId: scope.projectId,
           environmentId: scope.environmentId,
+          ...(userId ? { userId } : {}),
         },
         include: { fromEntity: true },
         orderBy: { createdAt: "desc" },

--- a/apps/agent/src/memory/memory.controller.ts
+++ b/apps/agent/src/memory/memory.controller.ts
@@ -52,6 +52,16 @@ export class MemoryController {
     );
   }
 
+  /**
+   * SECURITY (audit H7) — an end-user / entity / guest token must NOT read or
+   * write another user's memories by supplying ?userId= or body.userId.
+   * Operators (the dashboard, via the internal path or a platform token) may
+   * target any user; every other principal is FORCED to its own userId.
+   */
+  private effectiveUserId(scope: RequestScope, requested?: string | null): string {
+    return scope.principal === "operator" ? (requested || scope.userId) : scope.userId;
+  }
+
   private scopeTuple(scope: RequestScope) {
     return {
       organizationId: scope.organizationId,
@@ -82,7 +92,7 @@ export class MemoryController {
     const scope = this.getScope(req);
     try {
       const row = await this.memoryService.add(this.scopeTuple(scope), {
-        userId: body.userId || scope.userId,
+        userId: this.effectiveUserId(scope, body.userId),
         content: body.content,
         kind: body.kind,
         agentId: body.agentId ?? null,
@@ -151,7 +161,7 @@ export class MemoryController {
     @Query("userId") userId?: string,
   ) {
     const scope = this.getScope(req);
-    const uid = userId || scope.userId;
+    const uid = this.effectiveUserId(scope, userId);
     try {
       const scopeTuple = this.scopeTuple(scope);
       // MCPF-W2 — DSAR must include archived rows. Soft-deleted memories
@@ -170,7 +180,7 @@ export class MemoryController {
       const relationships: Array<Record<string, unknown>> = [];
       // Pull relationships per-entity to stay inside the scope-gated API.
       for (const e of entities) {
-        const details = await this.graph.getRelationships(scopeTuple, { entityId: e.id });
+        const details = await this.graph.getRelationships(scopeTuple, { entityId: e.id }, uid);
         if (!details) continue;
         for (const out of details.outbound) {
           if (!entityIds.has(out.to.id)) continue;
@@ -542,7 +552,7 @@ export class MemoryController {
         metadata: body.metadata,
         agentVisible: body.agentVisible,
         visibility: body.visibility,
-      });
+      }, this.effectiveUserId(scope));
       if (!row) return { error: "memory not found", status: 404 };
       return { memory: row };
     } catch (err: any) {
@@ -566,7 +576,7 @@ export class MemoryController {
     const scope = this.getScope(req);
     try {
       const rows = await this.memoryService.list(this.scopeTuple(scope), {
-        userId: userId || scope.userId,
+        userId: this.effectiveUserId(scope, userId),
         kind: kind || undefined,
         agentId: agentId || undefined,
         limit: limit ? Number.parseInt(limit, 10) : undefined,
@@ -593,7 +603,7 @@ export class MemoryController {
     try {
       const hits = await this.memoryService.semanticSearch(this.scopeTuple(scope), {
         query: q,
-        userId: userId || scope.userId,
+        userId: this.effectiveUserId(scope, userId),
         kind: kind || undefined,
         agentId: agentId || undefined,
         limit: limit ? Number.parseInt(limit, 10) : undefined,
@@ -609,7 +619,7 @@ export class MemoryController {
   async deleteMemory(@Req() req: Request, @Param("id") id: string) {
     const scope = this.getScope(req);
     try {
-      const deleted = await this.memoryService.delete(this.scopeTuple(scope), id);
+      const deleted = await this.memoryService.delete(this.scopeTuple(scope), id, this.effectiveUserId(scope));
       return { deleted };
     } catch (err: any) {
       return { error: err?.message || "delete failed", status: 400 };
@@ -629,7 +639,7 @@ export class MemoryController {
     const scope = this.getScope(req);
     try {
       const rows = await this.graph.getEntities(this.scopeTuple(scope), {
-        userId: userId || scope.userId,
+        userId: this.effectiveUserId(scope, userId),
         entityType: entityType || undefined,
         limit: limit ? Number.parseInt(limit, 10) : undefined,
         offset: offset ? Number.parseInt(offset, 10) : undefined,
@@ -644,7 +654,9 @@ export class MemoryController {
   async getRelationships(@Req() req: Request, @Param("id") id: string) {
     const scope = this.getScope(req);
     try {
-      const res = await this.graph.getRelationships(this.scopeTuple(scope), { entityId: id });
+      // SECURITY (audit H9) — force the caller's own userId so a session token
+      // can't walk another user's KG neighborhood by entity id.
+      const res = await this.graph.getRelationships(this.scopeTuple(scope), { entityId: id }, this.effectiveUserId(scope));
       if (!res) return { error: "entity not found", status: 404 };
       return res;
     } catch (err: any) {
@@ -668,7 +680,7 @@ export class MemoryController {
       const path = await this.graph.shortestPath(this.scopeTuple(scope), {
         fromEntityId: from,
         toEntityId: to,
-        userId: userId || scope.userId,
+        userId: this.effectiveUserId(scope, userId),
         maxHops: maxHops ? Number.parseInt(maxHops, 10) : undefined,
       });
       return { path };
@@ -702,7 +714,7 @@ export class MemoryController {
       };
     }
     const scopeTuple = this.scopeTuple(scope);
-    const userId = body.userId || scope.userId;
+    const userId = this.effectiveUserId(scope, body.userId);
     try {
       const [from, to] = await Promise.all([
         this.graph.upsertEntity(scopeTuple, {

--- a/apps/agent/src/memory/memory.service.ts
+++ b/apps/agent/src/memory/memory.service.ts
@@ -322,10 +322,14 @@ export class MemoryService {
    * kind+content+metadata tuple if any of them change. Re-embeds when
    * `content` changes. Scope-guarded.
    */
-  async update(scope: ScopeTuple, id: string, patch: UpdateMemoryInput): Promise<MemoryRow | null> {
+  async update(scope: ScopeTuple, id: string, patch: UpdateMemoryInput, userId?: string): Promise<MemoryRow | null> {
     this.requireScope(scope);
     const existing = await this.get(scope, id);
     if (!existing) return null;
+    // SECURITY (audit H7 write-side residual) — when a userId is supplied,
+    // refuse to edit a memory the caller doesn't own (the REST path passes the
+    // caller's userId so it can't edit another user's memory by id).
+    if (userId && existing.userId !== userId) return null;
 
     const nextKind: string = patch.kind ?? existing.kind;
     const nextContent: string = patch.content ?? existing.content;
@@ -426,7 +430,7 @@ export class MemoryService {
    * (silent no-op rather than an exception — the `forget` meta-tool
    * prefers idempotent behaviour).
    */
-  async delete(scope: ScopeTuple, id: string): Promise<boolean> {
+  async delete(scope: ScopeTuple, id: string, userId?: string): Promise<boolean> {
     this.requireScope(scope);
     const res = await this.prisma.platosMemory.deleteMany({
       where: {
@@ -434,6 +438,10 @@ export class MemoryService {
         organizationId: scope.organizationId,
         projectId: scope.projectId,
         environmentId: scope.environmentId,
+        // SECURITY (audit H7 write-side residual) — scope the delete to the
+        // caller's userId when supplied so a session token can't delete
+        // another user's memory by id.
+        ...(userId ? { userId } : {}),
       },
     });
     return (res?.count ?? 0) > 0;

--- a/apps/agent/src/trigger-bridge/internal-execute-tool.controller.ts
+++ b/apps/agent/src/trigger-bridge/internal-execute-tool.controller.ts
@@ -26,10 +26,22 @@ import type { RequestScope } from "../auth/scope.guard";
  * BLOCK 2: wire into tool-gateway for actual execution.
  */
 
-// TODO(env.ts) consider migration — module-load-time const; env proxy
-// would trigger full schema parse before main.ts has a chance to surface
-// structured errors. Kept as direct process.env read.
-const INTERNAL_SECRET = process.env.TRIGGER_INTERNAL_SECRET || "dev-internal-secret-change-me";
+// SECURITY (audit M1) — this secret is the HMAC key gating /internal/execute-tool
+// + /internal/batch-turn (which run tools/turns under a supplied scope). A
+// hardcoded default meant a self-host that forgot to set it had a PUBLICLY
+// KNOWN signing key → forgeable internal callbacks. Fail CLOSED in production:
+// no default, and crash at boot if unset/placeholder when NODE_ENV=production.
+const INTERNAL_SECRET_RAW = (process.env.TRIGGER_INTERNAL_SECRET || "").trim();
+const INTERNAL_SECRET_PLACEHOLDERS = new Set(["", "dev-internal-secret-change-me", "change-me", "changeme"]);
+if (process.env.NODE_ENV === "production" && INTERNAL_SECRET_PLACEHOLDERS.has(INTERNAL_SECRET_RAW)) {
+  throw new Error(
+    "TRIGGER_INTERNAL_SECRET must be set to a strong random value in production " +
+      "(it HMAC-gates /internal/execute-tool + /internal/batch-turn). Generate one with `openssl rand -hex 32`.",
+  );
+}
+// Outside production, fall back to a clearly-marked dev value so local dev works;
+// the boot guard above blocks it in prod.
+const INTERNAL_SECRET = INTERNAL_SECRET_RAW || "dev-internal-secret-change-me";
 const MAX_CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 min
 
 @Controller("internal")

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -1528,7 +1528,27 @@ const EnvironmentSchema = z
     PRIVATE_CONNECTIONS_AWS_ACCOUNT_IDS: z.string().optional(),
   })
   .and(GithubAppEnvSchema)
-  .and(S2EnvSchema);
+  .and(S2EnvSchema)
+  // SECURITY (audit H14) — the webapp MINTS the login cookie (also the API JWT
+  // secret) + magic-link tokens; a self-host that copies `.env.example` boots
+  // prod with the repo's public placeholder → forgeable session/magic-link for
+  // any user. The agent already guards PLATOS_SESSION_SECRET (.min + prod
+  // sentinel); mirror it here for the actual minter. Prod-gated so local dev
+  // (which copies `.env.example`) still boots.
+  .superRefine((val, ctx) => {
+    if (val.NODE_ENV !== "production") return;
+    const placeholder = /replace-with-real|change-?me|placeholder|^abcdef1234/i;
+    for (const key of ["SESSION_SECRET", "MAGIC_LINK_SECRET"] as const) {
+      const v = (val as Record<string, unknown>)[key];
+      if (typeof v !== "string" || v.length < 16 || placeholder.test(v)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: `${key} must be a strong random value (≥16 chars, not a placeholder) in production. Generate one with: openssl rand -hex 32`,
+        });
+      }
+    }
+  });
 
 export type Environment = z.infer<typeof EnvironmentSchema>;
 export const env = EnvironmentSchema.parse(process.env);

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -372,7 +372,15 @@ services:
     logging: *default-logging
     mem_limit: ${AGENT_MEM_LIMIT:-2g}
     ports:
-      - "3100:3100"
+      # SECURITY (audit — Fable verify residual): bind to loopback only. The
+      # direct-header (Path 2) auth path grants OPERATOR scope to any request
+      # without an X-Forwarded-For header (webapp→agent internal traffic). Caddy
+      # (host, localhost) fronts the public surface and always stamps XFF →
+      # session-token auth only. Publishing 3100 on 0.0.0.0 would let an
+      # external caller that reaches the port directly bypass ALL auth as
+      # operator. Inter-container traffic uses the Docker network (agent:3100),
+      # not this published port, so loopback binding doesn't affect it.
+      - "127.0.0.1:3100:3100"
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/security-audit-2026-07-16.md
+++ b/docs/security-audit-2026-07-16.md
@@ -1,0 +1,271 @@
+Both critical claims verify. `verifyAnyBearer` builds the `VerifiedToken` purely from `oa.scope`/`oa.scopes` and never inspects `oa.entityPk` (lines 291-310) — and `mcp:write` maps to `["*"]` with `tier: "scope"`. `internalDurableTurn` gates only on `verifyAdminToken` then passes `body.scope` verbatim into `executeStreamingTurn` (lines 3788-3803) with no HMAC over the body and no binding of scope to the caller. All load-bearing findings confirmed against source. Now writing the report.
+
+# Platos Production-Hardening Security Report
+**Target:** make `play.platos.dev` safe for real multi-tenant production (winsen.ai pilots)
+**Date:** 2026-07-16 · **Scope reviewed:** agent runtime (`apps/agent`), auth/scope, WS/SSE streaming, MCP gateway, memory/KG/RAG, durable-exec callbacks, budgets/approvals, webapp secrets
+
+---
+
+## 1. Executive Summary
+
+**Verdict: `play.platos.dev` is NOT safe for real multi-tenant production today.** It is safe under exactly one assumption — that **every principal inside a single `(organizationId, projectId, environmentId)` tuple is a mutually-trusting operator**. That assumption is precisely what the winsen.ai pilot / embedded-widget / Percy AI-employee direction breaks: many *untrusted end-users* (and anonymous public-guest tokens) share one scope tuple. The moment that happens, the codebase has cross-user AND cross-tenant breaks that expose message content, PII, spend, BYOK-backed execution, and secret-signing keys.
+
+The root cause is architectural and singular: **Platos has a correct *edge* posture (scope derived from a verified token, raw scope headers rejected behind the proxy) but treats the scope tuple as if it were a user boundary. It is not.** There is (a) **no operator/end-user tier** — an entity-minted or public-guest session token is indistinguishable from a webapp operator token at every handler; (b) **no per-user partition** in the realtime layer — every socket joins a tenant-wide `scope:` room; and (c) **no structural enforcement** — scope filtering is per-handler convention, so any forgotten `where` is a live IDOR, and the cross-scope regression suite is `it.skip` scaffolding.
+
+**Top blockers (must fix before any real pilot):**
+
+| # | Blocker | Class |
+|---|---------|-------|
+| B1 | **End-user token can rotate an entity's serviceSecret and receive the plaintext** → the HMAC signing key → mint tokens for *any* user. Full auth-model collapse. (`agent.controller.ts:1947`) | Critical — verified |
+| B2 | **Durable-exec internal callbacks trust `body.scope` verbatim behind one shared static admin token** → cross-tenant turn execution under victim BYOK keys/memory. (`agent.controller.ts:3769`) | Critical — verified |
+| B3 | **Entity anonymous OAuth flow mints `mcp:write` → `["*"]` scope-tier platform token, entityPk never checked** → org/project-wide read+write from an embedded chatbot visitor. (`mcp-platform.controller.ts:291`) | Critical — verified |
+| B4 | **Platform-MCP `trigger.tasks.trigger` forwards attacker `payload.scope` verbatim to the shared Trigger project** → cross-org escalation past the "within minting org" admin boundary. (`mcp-platform/tools/trigger.ts:200`) | Critical |
+| B5 | **No operator tier across the whole monitoring/memory/files/budget surface** → any in-scope token reads other users' messages, memories, PII, spend, and file bytes, and mutates budget caps. | High (structural) |
+| B6 | **Scope-room realtime broadcast** leaks approvals (tool args), run output, thread titles, and userId↔agent maps to every user in the tenant; **`join_thread` is scope- but not user-gated** → live token-stream hijack. | High |
+
+None of these are cross-org *by default* except B1/B2/B3/B4 and the two unscoped-Redis-key reads (thread cost, thread spans). Everything else is cross-*user within a tenant* — which is the exact isolation a shared pilot instance needs.
+
+**Bottom line for the pilot:** if winsen.ai onboards two customers into two *separate* `(org, project, env)` tuples AND you fix B1–B4 (the cross-org escalations) AND you never expose the memory/monitoring REST surface publicly, you can run a **single-user-per-tenant** pilot relatively safely. To run **multiple end-users under one tenant** (the widget/AI-employee model), you must additionally land the operator tier (B5) and the realtime room redesign (B6). Do not put real customer PII on it before that.
+
+---
+
+## 2. Findings — ranked by severity
+
+Each finding names the best-practice pattern the fix applies (from the LangGraph / Vercel AI SDK / Trigger.dev / OWASP / realtime-rooms research).
+
+### CRITICAL
+
+---
+
+**C1 — End-user session token can rotate an entity's serviceSecret and receive the new plaintext (full auth-model escalation)**
+`apps/agent/src/agent-runtime/agent.controller.ts:1947-1970` → `auth.service.ts:664-680`
+**Verified in source.** `regenerateEntitySecret` gates *only* on `getScope(req)` (line 1952), which returns `req.scope` verbatim with no role/operator check. `ScopeGuard` populates `req.scope` identically for an `iss:'entity'` end-user token and an `iss:'platos-platform'` operator token, and the agent-pin only fires on `/agents/:id/*` paths (this path has no agentId). `regenerateServiceSecret` returns the new plaintext, spread into the 200 body at line 1969. Because the entity `serviceSecret` **is** the HMAC key that `validateSessionToken`/`createSessionToken` sign with, and the mint endpoint accepts an attacker-chosen `userId`, any entity-minted token obtains the signing key and can mint tokens for **arbitrary users** → read/write every user's threads/messages/memories in that scope. Also DoS-disconnects the victim entity's live WS.
+**Fix (OWASP API5 BFLA — deny-by-default, centralized function-level authz):** introduce a single `requireOperator(req)` that throws 403 unless `req.scope` came from an `iss==='platos-platform'` token. Surface `iss` onto `req.scope` in `scope.guard.ts` (~line 326-338). Call `requireOperator` at the top of `regenerateEntitySecret`, `registerEntity`, `patchEntity`, `getEntityTestCredentials`, `setTestCredentials`. Never return the rotated secret in a call an untrusted client can trigger — but the operator gate is the load-bearing fix.
+
+---
+
+**C2 — Durable-exec internal callbacks trust `body.scope` verbatim behind one shared static admin token (cross-tenant impersonation)**
+`apps/agent/src/agent-runtime/agent.controller.ts:3769-3841` (+ `3856`, `3914`, `3967`, `3683`); gate `scope.guard.ts:254-284`
+**Verified in source.** `internalDurableTurn` checks only `verifyAdminToken(req)` (line 3789), then passes `body.scope` straight into `executeStreamingTurn` (line 3803), which resolves the BYOK provider key, thread, memory, and persistence all **under the supplied scope**. Nothing binds `body.scope` to the caller — no HMAC over the body, no check that `agentId`/`threadId` belong to the scope. The sibling `/internal/execute-tool` callback HMAC-signs the *whole* body with `TRIGGER_INTERNAL_SECRET` (so scope can't be swapped); these newer durable callbacks regressed to bearer-only. Caddy routes `/api/v1/agent*` publicly and passes the admin-token header through. Combined with B4/C3, an attacker enqueues `platos.agent.employee-run` with a foreign `payload.scope` and runs a turn *as another org* under their BYOK key.
+**Fix (Trigger.dev — the mint step is the only trust boundary; OWASP API1 — re-derive, never trust client id):** require `X-Platos-Signature = HMAC-SHA256(TRIGGER_INTERNAL_SECRET, body+timestamp)` on all five durable callbacks (`internalDurableTurn`, employee-run, skill-run, batch-turn, compaction), reusing `verifySignature` from `internal-execute-tool.controller.ts`, so `body.scope` is covered by the signature. Additionally cross-check inside each handler that `body.agentId`/`body.threadId` belong to `body.scope` via a scoped `findFirst`, failing closed on mismatch.
+
+---
+
+**C3 — Entity OAuth token bypasses the platform-MCP entityPk pin; `mcp:write` → `["*"]` scope-tier grant**
+`apps/agent/src/mcp-platform/mcp-platform.controller.ts:291-311` (`verifyAnyBearer`); mint flow `oauth.controller.ts:796-883`
+**Verified in source.** `verifyAnyBearer` builds a `VerifiedToken` purely from `oa.scope` + `oa.scopes` and **never inspects `oa.entityPk`** (lines 291-310), while the per-entity surface *does* reject foreign entityPk. The anonymous entity OAuth flow mints a `plt_oa_*` token with scopes taken verbatim from attacker-controlled `body.scope` (`oauth.controller.ts:875`, no server-side clamp). Requesting `scope=mcp:write` maps to `permissions:["*"]`, `tier:"scope"` (line 295-296, 308) → passes `allows()` for every non-admin-tier platform tool (`agents.create/update/delete`, `threads.delete`, `providers.add_key`, `entities.regenerate_secret`, `memories.upsert`, `messages.list`) against the entity's org/project. (Note: the first-pass `mcp:tools`→broad-read claim is *false* — that permission mapping is dead due to leading-wildcard/underscore mismatches; the real escalation is `mcp:write`.)
+**Fix (OWASP API1 — least privilege at the mint step; Trigger.dev — resource-pinned scopes minted by trusted backend, never client-declared):** (a) in `verifyAnyBearer`, reject OAuth tokens carrying an `entityPk`: `if (oa.entityPk) return null;` — mirror the per-entity pin, inverted. (b) Clamp entity-flow scopes to the entity's advertised set (`mcp:tools`) at `issueAuthCode` time so `mcp:write` can never be minted for an entity client. (c) Fix the dead read-permission mapping (`platos.whoami` with dots; implement leading-wildcard matching or enumerate concrete read tool names) so legit `mcp:read` tokens aren't silently useless.
+
+---
+
+**C4 — Platform-MCP `trigger.tasks.trigger` forwards attacker-controlled `payload.scope` to the shared Trigger project**
+`apps/agent/src/mcp-platform/tools/trigger.ts:200-228`
+`tasks.trigger` accepts `payload:{type:'object'}` with no shape/allowlist and forwards `params.payload` verbatim via the single admin-level `PLATOS_TRIGGER_API_KEY`. The MCP token's org is never applied to the payload. The gate is `requiresAdminTier` — but admin-tier is "cross-scope **within the minting org**", not a platform superuser. In the default deploy (`MCP_INTERACTIVE_APPROVALS=false`) the `require_approval` auto-escalation is a no-op. The worker forwards `payload.scope` verbatim to the internal callback (C2), so an org-A admin enqueues a `platos.*` task with `payload.scope` = org B and the callback runs as org B.
+**Fix (OWASP API1 — re-derive scope server-side; Microsoft/OpenAI multitenancy — tenant-scoped keys, never client-supplied):** in `tasks.trigger.execute`, for any `platos.*` task whose payload carries a `scope`, **overwrite** `payload.scope.{org,project,env}` with the MCP token's own verified scope (`buildScope(token)`) rather than trusting the caller's payload. Combine with C2's HMAC+ownership check so even a mis-scoped enqueue fails at the callback.
+
+---
+
+### HIGH
+
+---
+
+**H1 — No operator tier: entire monitoring / activity / cost / audit read surface is reachable by any in-scope end-user token**
+`apps/agent/src/agent-runtime/agent.controller.ts:2741, 2761, 2979, 3079-3326, 3472, 3489, 3509, 3631, 4289, 4330`
+`monitoringUserDetail`/`monitoringUserSummary`/`monitoringUserConsumption` take a `:userId` path param, query threads/memories/safety-events/PII/email filtered on the scope tuple only, and (summary) feed a victim's data to an LLM to produce a prose dossier. `costByUser`, `monitoringBreaches`, `topUsers`, `toolAudit`, `recentActivity`, `safety-events` (with `?userId=` filter) — all gated only by `getScope`. `/api/v1/agent*` is publicly proxied. **This is the structural root under H1–H7.**
+**Fix (OWASP API5 — one centralized deny-by-default RBAC module; LangGraph `disable_studio_auth` lesson — no dev-convenience default-allow on a shared prod instance):** apply `requireOperator(req)` (from C1) to the entire `/monitoring/*`, `/activity/*`, `/monitoring/tool-audit`, `/monitoring/approvals`, `/monitoring/safety-events`, `/monitoring/users/*` family. Add a `cross-scope-isolation.test.ts` case asserting an `iss:'entity'` token gets 403 on these routes.
+
+---
+
+**H2 — `monitoring/cost/thread/:threadId` has NO scope binding — cross-*tenant* IDOR**
+`apps/agent/src/agent-runtime/agent.controller.ts:2576-2579` → `cost.service.ts:1223-1230`
+**Verified in source.** `getThreadCost(@Param threadId)` takes no `@Req()`, never reads `req.scope`, and calls `costService.getThreadCost(threadId)` which does `redis.hgetall('cost:thread:'+threadId)` — key namespaced by `threadId` only, **zero scope filter**. Crosses the org/project/env boundary entirely (worse than in-scope findings). The very next handler `getThreadTrace` 404s on cross-scope — proving this is an omission, not a pattern.
+**Fix (OWASP API1 — check ownership in every function that takes a client id):** add `@Req() req`, resolve the thread via a scoped `findFirst` (or `conversationService.getThread(threadId, scope)`), 404 on miss — mirror `getThreadTrace:2587`. Longer term namespace the Redis key with the scope tuple.
+
+---
+
+**H3 — `join_thread` is scope-gated but NOT user-gated → same-scope live token-stream hijack**
+`apps/agent/src/connections/connections.gateway.ts:944-965`
+**Verified in source.** The `findFirst` filters `id + org + project + env` only (lines 944-950) — it omits the `{ userId OR createdByUserId }` ownership clause that `getThread` and the dispatch-path `getOrCreateThread` both enforce. So any same-scope socket that knows a victim `threadId` joins `thread:<id>` and receives every `agent_event` streamed in — live tokens, tool_results, batch output PII. `threadId`s are handed out via the scope-room `overview.turn.completed`/`thread.title.generated` broadcasts (H4), so no guessing is needed.
+**Fix (Vercel AI SDK — re-resolve ownership server-side, 404-not-403; LangGraph `@auth.on.threads.read` filter):** replace the bare `prisma.findFirst` with `conversationService.getThread(data.threadId, scope)` (which ORs `userId`/`createdByUserId` under the scope tuple) and join only if non-null. Return the indistinguishable "thread not found".
+
+---
+
+**H4 — Scope-room broadcast leaks approvals (tool args), run output/PII, thread titles, and userId↔agent maps to every user in the tenant**
+`apps/agent/src/connections/connections.gateway.ts:134-166, 285` · `trigger-bridge/runs-bridge.service.ts:124-140` · `agent-task.service.ts:1308-1323, 1635-1651`
+Every socket joins `scope:{org}:{project}:{env}` unconditionally on connect (line 285). Into that tenant-wide room the code emits: `approval_needed` with `action`+`details` (tool name + arguments, often PII) + `requestedBy` (134-155); `run_update` carrying `snap.output` + `metadata.progress` (per-item batch LLM output — SDR contact content) via `RunsBridge` (runs-bridge:140); `thread.title.generated` (LLM-derived from the user's message content) and `overview.turn.completed` `{agentId, threadId, userId}` (thread ids + who-talks-to-which-agent). This is a passive cross-user realtime bus.
+**Fix (realtime-rooms — room key must be at least as narrow as the smallest authorized audience; Pusher private-channel discipline):** see §3 redesign. Deliver content-bearing `run_update`/approvals/titles only to `thread:{threadId}` and per-user rooms; the scope room, if kept at all, carries redacted status-only frames and is operator-role-gated.
+
+---
+
+**H5 — Cross-user approval resolution (BOLA) over both WS and REST**
+`connections.gateway.ts:986-1034` · `agent.controller.ts:770-800` · `approvals.service.ts:199-230, 292-302`
+Both resolve paths gate only on `getById(scopeTuple, approvalId)` — filtered by the scope tuple, never by `requestedBy` or thread ownership. The `PlatosAgentApproval` row *carries* `requestedBy` and `threadId` but neither is compared at resolve time. The `approvalId` is reachable because `approval_needed` is fanned to the whole scope room (H4). So any same-scope user (including anonymous public-guest) can **approve** another user's destructive gated tool call, or **reject** to DoS every other user's gated actions.
+**Fix (OWASP API1 — ownership check by id):** after `getById`, reject unless `found.requestedBy === scope.userId` (or thread-ownership resolves), returning 404-equivalent. Add `requestedBy` to the `resolve()` `updateMany` where-clause as defense-in-depth. Operators resolving on behalf of end-users go through an explicit `requireOperator` branch. Also verify `parsed.respondedBy` in the agent's BLPOP-wake path before treating the wake as authoritative.
+
+---
+
+**H6 — WS streaming never enforces the token's pinned `agentId`; client-controlled `data.agentId` drives any agent in scope**
+`apps/agent/src/connections/connections.gateway.ts:370, 439`
+`handleConnection` validates the session token but never copies `payload.agentId` into scope; `handleMessage` derives the agent from client-supplied `data.agentId` as top priority and stamps it into scope with no comparison to any pinned agentId. `agent.service.ts` loads the agent scoped by `(org,project,env)` only — no visibility gate. Contrast the HTTP path where `ScopeGuard` enforces `tokenAgentId !== pathAgentId → 403`. So a **public-guest token pinned to public agent A can run a turn against private agent B** (B's prompt, tools, memory, BYOK keys).
+**Fix (LangGraph — capability must be re-checked, not trusted from the wire):** capture `pinnedAgentId = payload.agentId` onto the socket at connect; in `handleMessage`/`handleJoinThread`/durable path, after resolving `agentId`, enforce `if (pinnedAgentId && agentId !== pinnedAgentId) reject` — mirroring `scope.guard.ts:300-308`.
+
+---
+
+**H7 — REST `/api/v1/memory/*` honors client `?userId=` (read) and `body.userId` (write) → cross-user memory read/export + poisoning**
+`apps/agent/src/memory/memory.controller.ts:85 (write, verified), 154, 569, 596, 632, 671, 705`
+**Write verified in source** (`userId: body.userId || scope.userId`, line 85). Reads compute `userId || scope.userId` on list/search/export/graph. Export forces `includeArchived:true` → full DSAR of another user's private+archived memories + KG. Writes let an attacker attribute a memory (surfaced into the agent's system-prompt memory block) to a victim → cross-user prompt injection. `relate` (705) forges a consistent victim `userId` across both endpoints, defeating the `createRelationship` cross-user guard.
+**Reachability caveat (needs-human on the read/write DSAR, per verification):** the reference `Caddyfile.example` proxies only `/api/v1/agent*` and `/mcp/*`; `/api/v1/memory*` falls through to the webapp. So through the *documented* public proxy these are **not** externally reachable — but they are on the internal docker network and in any self-host that routes `/api/v1/*` to the agent (which `scope.guard.ts:271-275` explicitly anticipates for the SDK).
+**Fix (LangGraph `@auth.on.store` — validate namespace against identity, don't construct from client input; OWASP API3 mass-assignment):** for non-operator tokens, force `userId = scope.userId` and ignore the query/body param on list/search/export/graph and on create/relate/update writes. Only honor an explicit `userId` for operator-tier tokens. Mirror `importBundle`'s already-correct behavior (it pins `scope.userId`). Do NOT add `/api/v1/memory*` to the public Caddyfile.
+
+---
+
+**H8 — Turn-time RAG runs as `userId='default'` → RAG corpus pooled cross-user per scope**
+`apps/agent/src/agent-runtime/agent.service.ts:4897, 5116, 6157, 6231` · `skill-handlers.ts:223-229` · `skill-runtime.service.ts:140-234`
+All four `skillRuntime.invokeTool()` call sites pass a bare 3-tuple with **no `userId`** (the `ScopeTuple` type doesn't carry it). `context` (agentId/threadId) is used only for cost accounting and never reaches the handler scope. So `ragResolveUserId` reads `undefined` and returns the literal `'default'` — every real user's RAG ingest/retrieve runs under one shared bucket at `visibility:'agent_visible'`. User A's ingested private doc is retrievable by User B's agent in the same scope.
+**Fix (LangGraph `@auth.on.store` — namespace pinned to authenticated identity, fail closed on missing identity):** widen the tuple passed to `invokeTool` at all four sites to include `userId: scope.userId`; make `SkillRuntimeService` merge the acting userId into the scope it hands to `dispatch`. Retire the silent `'default'` fallback for authenticated turns — throw/refuse when `userId` is absent so a missing identity fails closed rather than pooling.
+
+---
+
+**H9 — `kg.get_entity` / REST graph relationships read is userId-blind (cross-user KG PII leak)**
+`apps/agent/src/memory/knowledge-graph.service.ts:193-204, 211-255`
+`getEntityById` filters on `(org, project, env)` only — no `userId` — while every other KG read requires it. `getRelationships` hydrates counterpart entities (full names, aliases, decrypted metadata) scope-only. Reachable via (a) the `kg.get_entity` MCP tool (takes only `{entityId}`, not tier-gated) and (b) REST `GET /graph/entities/:id/relationships` (ScopeGuard-only). Any in-scope token reads another user's entity + full relationship neighborhood by supplying their `entityId` (which appear in export bundles/audit results).
+**Fix (OWASP API1):** thread `userId` through `getEntityById(scope, id, userId)` and `getRelationships`, add it to both WHERE clauses. `kg.get_entity` must take a required `userId`; REST must resolve `userId` from `scope.userId` only.
+
+---
+
+**H10 — Files browser returns presigned S3 download URLs for any user's thread attachments (cross-user file exfiltration)**
+`apps/agent/src/files/files.controller.ts:204-282`
+`listAttachments` filters by scope tuple + client `threadId` with no `userId` check, then mints 5-minute presigned GETs for every attachment. The agent-pin regex doesn't match `/api/v1/agent/files/*`, and the agent enforces no operator/membership tier. Any entity/guest token in scope enumerates + downloads other users' file bytes. **`/api/v1/agent/files/*` IS publicly proxied.**
+**Fix (OWASP API1 + API5):** gate `/files/*` on `requireOperator`, and for Level-4 verify the thread's `userId` matches the caller unless operator-tier.
+
+---
+
+**H11 — External MCP + entity-callback fetches follow redirects without re-validation (blind SSRF → cloud metadata)**
+`apps/agent/src/mcp-agent/mcp-tool-executor.service.ts:192-210` · `server-registry.service.ts:232-250` · `tool-executor.service.ts:955-999`
+All three call `validatePublicUrl(url)` then bare `fetch(url, …)` with default `redirect:'follow'` — only the *initial* URL is validated. A registered server/callback that passes the check can `302 → http://169.254.169.254/…` and the agent chases it server-side. The entity-callback path additionally forwards the signed `X-Platos-*` scope headers + user token to the redirect target. The repo already ships `fetchWithValidatedRedirects` (used correctly in `skills/*`) but not here.
+**Fix:** replace the three bare `fetch(url,…)` with `fetchWithValidatedRedirects(url, 3, {…})`. Pin the resolved IP to close the DNS-rebind TOCTOU. Only send privileged headers to the validated final hop.
+
+---
+
+**H12 — Per-tool MCP ACL (`minIdentityMode`/`allowedPatIds`) is never enforced on entity-MCP dispatch**
+`apps/agent/src/mcp-platform/mcp-entity.controller.ts:730-802` · `mcp-tool-acl.service.ts:155-174`
+`handleToolsCall`/`handleToolsList` enforce only the coarse entity-wide `toolAllowlist`. `McpToolAclService.filterByIdentity` has **zero call sites** on any dispatch path. Worse, `authenticate()` builds a token with no `identityMode` field, so there's nothing to filter on. An operator who sets a tool to `minIdentityMode:'oidc'` gets zero enforcement — any bearer PAT valid for the entity calls every exposed tool.
+**Fix:** thread `identityMode`/`scopes` through `authenticate()`; in `handleToolsCall`, after the allowlist check, load the ACL row and call `toolAclService.filterByIdentity([aclRow], caller)`, reject on `PERMISSION_DENIED`; mirror in `handleToolsList` to hide restricted tools.
+
+---
+
+**H13 — `stop` handler AbortController key never matches → stop is a silent no-op (LLM keeps streaming + billing)**
+`apps/agent/src/connections/connections.gateway.ts:1096-1112` vs set at `401/403`
+**Verified in source.** `handleMessage` stores the controller under `ackey = …:${tid}:${replyToMessageId ?? 'main'}` (line 401). `handleStop` reconstructs `…:${data.threadId}` — **without the trailing `:${replyToMessageId}` segment** (line 1105). The keys can never match, so `activeStreams.get(key)` is always `undefined`, `abort()` never runs, yet the client is emitted a fabricated `{done, stopped:true}`. The UI shows "done" while the model streams to completion and keeps accruing cost with no WS way to halt it. Re-breaks the exact EOBD.26 behavior the comment claims to fix.
+**Fix (Vercel AI SDK — stream-owner store keyed correctly; reconnect/stop re-checks owner):** reconstruct the exact key (`accept replyToMessageId in the stop payload`), or iterate `activeStreams` keys with prefix `…:${threadId}:` and abort matches. Add `scope.userId` into `ackey` so one user's stop can't abort a co-tenant's turn. Only emit `done` if a controller was actually aborted.
+
+---
+
+**H14 — Webapp accepts `.env.example` / weak session + magic-link secrets in production**
+`apps/webapp/app/env.server.ts:107-108, 469, 1541-1596`
+`SESSION_SECRET` and `MAGIC_LINK_SECRET` are bare `z.string()` (no `.min()`, no sentinel); `PLATOS_SESSION_SECRET` is `.optional()`. The only prod boot guard validates MinIO keys, never the signing secrets. `.env.example` ships `SESSION_SECRET=abcdef1234-replace-with-real-secret`; docker-compose's `${SESSION_SECRET:?required}` rejects only *empty*, not the copied placeholder. These sign the login cookie (also the API JWT secret) and magic-link tokens. A self-hoster who copies `.env.example` boots a prod webapp whose login keys are the repo's public placeholder → forge a session cookie / magic link for any user. The agent side already guards `PLATOS_SESSION_SECRET` with `.min(16)` + a prod sentinel refusal; the webapp — the actual minter — has neither.
+**Fix:** add `.min(16)` to both, and mirror the agent's `superRefine`: in the existing `NODE_ENV==='production'` block (line 1541), throw if any signing secret equals a known placeholder or is under the minimum.
+
+---
+
+**H15 — Global `PlatosToolDefinition.name` uniqueness lets one tenant overwrite another's shared tool row + poison BM25 ranking**
+`apps/agent/src/tool-gateway/tool-registry.service.ts:231-264` · `schema.prisma:3674`
+`name` is globally `@unique`. `registerTools` does `findUnique({where:{name}})` with no scope filter; on `schemaHash` mismatch it overwrites `description/paramSchema/bm25Tokens` and re-indexes the shared `toolId` in the process-wide BM25 index. Org B collides on a common name (`search`, `send_email`) and rewrites the shared row → immediately poisons Org A's BM25 `find_tools` *ranking*, and after any `rebuildIndex()` (boot/bulk op) Org A's cache repopulates from the DB row → inherits Org B's schema+description. Also a self-inflicted DoS (two tenants flap the shared `schemaHash` on reconnect).
+**Fix (OWASP — tenant identity is structural, not a global key):** change to `@@unique([organizationId, projectId, name])`, scope the `registerTools` lookup to `findFirst({name, org, project})`. Short-term minimum: key the BM25 index by `(scopePrefix + toolId)` and stop overwriting a row that belongs to a different scope.
+
+---
+
+**H16 — Budget-cap CRUD reachable by any end-user token (financial DoS / cap bypass)**
+`apps/agent/src/agent-runtime/agent.controller.ts:4481-4573`
+`upsertBudget`/`deleteBudget`/`overrideBudget` sit behind only ScopeGuard — zero role checks — while ~9 sibling endpoints in the *same controller* correctly gate on a timing-safe `PLATOS_ADMIN_TOKEN`. `capId`s come from the equally-unrestricted `GET /budgets`. An end-user (or anonymous public-guest, for those scopes) can `DELETE` the org spend cap, `override` to suspend enforcement, or set a huge `limitCents`, then drive unbounded spend against the operator's BYOK keys. `override` even records the attacker as the authorizer.
+**Fix (OWASP API5):** gate the three mutations (and ideally `GET /budgets`) behind the operator tier — reuse the `PLATOS_ADMIN_TOKEN` check already in this file, or `requireOperator`.
+
+---
+
+### MEDIUM
+
+- **M1 — `TRIGGER_INTERNAL_SECRET` defaults to a hardcoded public literal** (`internal-execute-tool.controller.ts:32`, `const … || "dev-internal-secret-change-me"`). No boot guard (`shared/env.ts:136` optional). A self-host that forgets it exposes forgeable HMAC on `/internal/execute-tool` and `/internal/batch-turn`. **Fix:** read via validated env, crash at boot if unset/default in production.
+- **M2 — Entity session-token mint spreads `body.claims` LAST** (`session-token.controller.ts:112-124`), enabling conditional cross-org mint when an `entityId` slug collides across orgs (common slugs: `main`, `default`, `widget`), and trivially defeats the agent pin in-org. **Fix:** whitelist `body.claims`, merge *before* the typed fields, drop reserved keys — mirror the safe ordering already in `createPlatformSessionToken`.
+- **M3 — OAuth entity access/refresh tokens encrypted with the *message-body* key and fail open to plaintext** (`oauth.controller.ts:1442-1495`). Violates the three-key separation; `PLATOS_MESSAGE_ENCRYPTION_KEY` is `.optional()` so common configs persist OAuth refresh tokens in plaintext. **Fix:** route through `SecretsService` (`PLATOS_ENCRYPTION_KEY`, fail-closed in prod); remove the plaintext fallback.
+- **M4 — Entity `serviceSecret` stored plaintext despite schema comment "// encrypted"** (`schema.prisma:3583`; used raw as HMAC key at `auth.service.ts:203,226,324,336`). Any DB read yields the token-signing key. **Fix:** encrypt at rest via `SecretsService`; add a separate `sha256` lookup column for the plaintext-equality match in `tool-sync-ws.service.ts:202`. At minimum fix the misleading comment.
+- **M5 — Entity WS `tool_result`/`tool_error` matched by `callId` across a global pending map with no responder-entity binding** (`tool-sync-ws.service.ts:38-45, 477-528`). A connected entity supplying a matching (leaked) `callId` can inject a forged result / abort another tenant's call. **Fix:** record `{entityId, environmentId}` on `PendingCall`, reject frames from a non-matching connection.
+- **M6 — `thread:lifecycle`/`overview:event` broadcast message-derived titles + userId↔agent maps to the scope room** (`connections.gateway.ts:156-166`). Folds into §3. **Fix:** deliver to `thread:{id}` + per-user rooms only.
+- **M7 — Approval resolution + entity registration by end-user tokens** (`agent.controller.ts:770-871, 1902-1945`) — cross-user approve/reject and durable minting-authority foothold. **Fix:** operator gate. (Same root as C1/H5.)
+- **M8 — Admin-supplied PII `customRegex` compiled + run against every message with no ReDoS guard** (`pii-filter.service.ts:122-137`). Catastrophic backtracking pins the single-threaded event loop → multi-tenant stall. **Fix:** RE2/`safe-regex`, bound input length + wall-clock.
+
+### LOW / INFO
+
+- **L1** — `handleMessage` unscoped thread→agentId lookup (`connections.gateway.ts:371-384`): agentId oracle + telemetry mislabel; content re-gated downstream. **Fix:** add scope tuple to the `findFirst`.
+- **L2** — `executeInner` re-loads entity `serviceSecret` via `findUnique(entityPk)` with no scope re-verify (`tool-executor.service.ts:732-749`). Cache boundary holds today; defense-in-depth. **Fix:** `findFirst` with scope tuple.
+- **L3** — `MemoryService.list()` `agentIds` branch references an unbound SQL placeholder (`memory.service.ts:551-560` vs `832-837`) → clustered `list_memories` throws, **fails closed** (empty result). **Fix:** push `input.agentIds` in `buildListArgs`.
+- **L4** — Redis keys unscoped: `chatsess:cursor:<threadId>` (gateway:699), Trigger idempotency `turn-<threadId>-<clientMessageId>` (gateway:890). Cuid collision only; defense-in-depth. **Fix:** prefix with scope tuple.
+- **L5** — RAG ingest + bundle import write `agentId=NULL` (`skill-handlers.ts:377-391`, `memory.controller.ts:294-309`) → cross-agent visibility asymmetry. **Fix:** stamp `agentId` once H8 threads it through.
+- **L6 (info)** — KG rows have no `agentId` column (`schema.prisma:4657-4728`) — latent cross-agent leak the moment any turn-time KG recall is wired. **Fix:** add nullable `agentId` before wiring KG-in-prompt.
+- **L7 (needs-human)** — Run-inspection meta-tools (`get_run_details`/`replay_run`, `agent.service.ts:3157+`) take an unscoped `runId` on the shared Trigger project. Default-OFF + long random ids. **Fix:** tag runs with scope metadata, verify on retrieve; or per-scope Trigger projects.
+- **L8 (needs-human)** — Global 15MB body limit applies to unauthenticated bypass routes (`main.ts:144`) → memory-amplification DoS. **Fix:** per-route 256KB cap on `/api/v1/public/*`, `/mcp*`, `/oauth/*`; keep 15MB only on catalog ingest. Code-vs-Caddy is an ops call.
+
+---
+
+## 3. Realtime Room-Topology Redesign
+
+**The core defect:** every socket joins one tenant-wide `scope:{org}:{project}:{env}` room at connect (`connections.gateway.ts:285`), and sensitive events (approvals with tool args, run output, thread titles, activity metadata) are broadcast to it. A Socket.IO room has **no inherent privacy** — its safety is 100% the join-authorization logic. The room key must be **at least as narrow as the smallest set of principals allowed to see the event**, derived from server-verified identity only.
+
+**Target topology** (namespace `/agent/{agentId}` authorized at connect → rooms inside it):
+
+| Room key | Who joins (server-gated) | Carries |
+|---|---|---|
+| `thread:{threadId}` | sockets whose **owner** passed `getThread(threadId, scope)` (H3 fix) | token stream, `tool_call`/`tool_result`, `done`/`error`, `run_update` with output, thread rename **for that thread** |
+| `user:{org}:{project}:{env}:{userId}` | that user's sockets (browser + mobile fan-in) | `approval_needed`/`approval_resolved` addressed to that user, per-user thread-list/overview updates, notifications |
+| `scope:{org}:{project}:{env}` | **operators only** — role-gated via the `OrgMember.role` lookup already at `connections.gateway.ts:414-419` | genuinely org-wide *operator* signals (dashboard overview, budget alerts) — **never** end-user message bodies, titles, or tool args |
+| `role:{org}:{project}:{env}:{role}` | sockets whose verified role matches | role-scoped operator broadcasts (admin-only safety alerts) |
+
+**Concrete changes (all in `connections.gateway.ts` unless noted):**
+
+1. **Stop joining end-users to the scope room** (line 285). At connect: always `client.join(user:{org}:{project}:{env}:{userId})`; join `scope:*` **only** if a verified operator role. Lift the `orgMember.findFirst` role lookup (currently at 414-419) into `handleConnection` and stash `isOperator` on the socket. (This is the Socket.IO analog of Pusher `private-`/`presence-` server-round-trip authorization and Ably per-user capability tokens.)
+2. **Re-target approvals** (134-155) → `user:{…}:{requestedBy}`, not the scope room. Gate `approval_response` on owner === `scope.userId` or operator role (H5).
+3. **Re-target `run_update`** (`runs-bridge.service.ts:124-140`): full frame (output + `metadata.progress`) → `thread:{threadId}` only; to any scope room emit only a redacted `{runId, status, threadId}`.
+4. **Re-target thread lifecycle + title** (156-161, `agent-task.service.ts:1635`) → `thread:{threadId}` (+ owner's `user:` room). Drop the scope-room target. (`thread.rename` at 1087 is correctly user-gated but still over-broadcasts — fold in.)
+5. **Validate `overview:event` room server-side** (162-165): reconstruct `scope:{org}:{project}:{env}` from the payload tuple, never forward the raw `payload.room` string; operator-audience only.
+6. **Formalize connect-time authz as `io.use()` middleware** (currently inline 180-315), rejecting with `next(new Error(...))` → un-bypassable, centralized, mirroring the global `APP_GUARD` HTTP `ScopeGuard`.
+7. **Finish the per-agent namespace migration** (the deprecation notice at 288-294 promises `/agent/{agentId}` but only the shared `/agent` namespace exists). A parametric namespace + `.use()` gives a namespace-level authorization seam (the Socket.IO analog of Pusher/Ably per-tenant namespaces) — authorize agent access + enforce the H6 agent-pin at connect, then rooms handle per-user/per-thread fan-out.
+
+**Net:** no end-user message body, tool result, run output, thread title, or approval detail is ever emitted to a room broader than its rightful audience. This is the change that makes a shared `(org, project, env)` safe for multiple untrusted end-users.
+
+---
+
+## 4. Prioritized Fix Sequence
+
+Ordered by (blocker status × blast radius × implementation cost). Each notes blast-radius and whether a product decision is required.
+
+**Phase 0 — cross-tenant escalations (do before ANY pilot; these are the only cross-*org* breaks + the auth-model collapse):**
+
+1. **C1** — operator gate on entity-secret / entity-registration / test-cred mutations. *Blast: full auth-model collapse (mint tokens for any user). No product decision — clearly an operator action.* Introduces the reusable `requireOperator(req)` + `iss` on `req.scope` that Phase 1 reuses.
+2. **C2** — HMAC-sign + ownership-check the 5 durable-exec callbacks. *Blast: cross-org turn execution under victim BYOK keys. No product decision — mirror the existing signed callback.*
+3. **C3** — reject entityPk OAuth on platform MCP + clamp entity scopes to `mcp:tools`. *Blast: org/project-wide read+write from an embedded chatbot visitor. No product decision.*
+4. **C4** — rebind `payload.scope` to the MCP token's scope in `trigger.tasks.trigger`. *Blast: cross-org via shared Trigger project. No product decision.*
+5. **H2** — scope-bind `getThreadCost`; **M1** — fail-closed `TRIGGER_INTERNAL_SECRET`; **H14** — webapp secret guards; **M4** — entity-secret schema comment (at minimum). *Blast: cross-tenant spend oracle / forgeable internal HMAC / forgeable login on a copied `.env`. No product decisions — all clear bugs.*
+
+**Phase 1 — the operator tier (unlocks the multi-user-per-tenant model; one structural change, many endpoints):**
+
+6. **H1 / H10 / H16 / M7** — apply `requireOperator` across `/monitoring/*`, `/activity/*`, `/files/*`, budget CRUD, entity registration, approval-resolve operator branch. *Blast: cross-user PII/spend/files + financial DoS within a tenant. **Product decision:** confirm which surfaces are operator-only vs self-service (e.g. a user reading their *own* cost is fine; reading `:userId` others' is operator).*
+7. **H7 / H9** — force `userId = scope.userId` on memory + KG reads/writes for non-operator tokens. *Blast: cross-user memory read/export/poisoning + KG PII. **Product decision:** does any legit flow need cross-user memory writes? If yes, that's the one operator-gated exception.* Do NOT add `/api/v1/memory*` to the public Caddyfile.
+
+**Phase 2 — realtime + per-user isolation (the room redesign; largest single code change):**
+
+8. **§3 room redesign** — per-user + per-thread + operator-role rooms; **H3** (user-gate `join_thread`); **H4/M6** (retarget broadcasts); **H5** (approval owner-check); **H6** (WS agent-pin); **H13** (fix stop key). *Blast: live token-stream hijack + passive cross-user leak of content/approvals/run output within a tenant. No product decision — the redesign is mechanical once the operator tier exists.* This is the gate for "multiple untrusted end-users under one tenant."
+
+**Phase 3 — SSRF, RAG isolation, tool-ACL, DoS hardening:**
+
+9. **H11** — `fetchWithValidatedRedirects` on the 3 MCP/entity-callback fetches. *Blast: blind SSRF → cloud metadata + scope-header leak. No product decision.*
+10. **H8 / L5** — thread `userId` (+ `agentId`) into the RAG scope; retire the `'default'` fallback (fail closed). *Blast: cross-user RAG corpus pooling. No product decision.*
+11. **H12** — enforce per-tool MCP ACL on dispatch. *Blast: ACL bypass on entity MCP. No product decision.*
+12. **H15** — tenant-scope `PlatosToolDefinition` (or at least the BM25 index). *Blast: cross-tenant tool-row overwrite + ranking poison. **Product decision:** schema migration timing (`@@unique` change is a migration).*
+13. **M2, M3, M5, M8** — claims-whitelist mint, OAuth-token key separation, WS responder binding, ReDoS guard. *No product decisions.*
+
+**Phase 4 — defense-in-depth + the CI gate that makes it stick:**
+
+14. **Make `cross-scope-isolation.test.ts` real and blocking** — two-org + two-user fixture via `internal-packages/testcontainers`; assert cross-tenant AND cross-user reads/writes/subscribes return null/`[]`/404/rejected across every scoped model and every transport (HTTP, WS join, memory REST). Wire into CI as a **merge gate** (OWASP API1 rule #4: don't deploy changes that fail the authz tests). *This is the enforcement that keeps Phases 0-3 from regressing.*
+15. **L1, L2, L4, L7, L8, L6** — scope-namespace the remaining Redis keys / lookups; add `agentId` to KG rows before any KG recall; decide body-limit code-vs-Caddy. *L7/L8 need-human (run-ownership tagging model; body-cap ops call).*
+16. **Postgres RLS backstop** (optional but highest defense-in-depth): `ENABLE ROW LEVEL SECURITY` + `current_setting('platos.org')` policies on `Platos*` scoped tables, GUCs set per-request via a Prisma `$extends` transaction wrapper. Roll out **log-only → enforcing**, minding the `PLATOS_ADMIN_TOKEN` cross-scope sweeps (run those as a `BYPASSRLS` role). *This is the layer that holds even when a handler forgets its `where` — it directly answers CLAUDE.md's own admission that "the scope model is an implicit convention with no universal query layer."*
+
+**Key files for the changes above:** `apps/agent/src/auth/scope.guard.ts` (add `iss`→`req.scope`, `requireOperator`), `apps/agent/src/agent-runtime/agent.controller.ts` (C1, C2, H1, H2, H10, H16, monitoring family), `apps/agent/src/connections/connections.gateway.ts` (§3 redesign, H3, H5, H6, H13), `apps/agent/src/mcp-platform/mcp-platform.controller.ts` (C3), `apps/agent/src/mcp-platform/tools/trigger.ts` (C4), `apps/agent/src/memory/memory.controller.ts` + `knowledge-graph.service.ts` (H7, H9), `apps/agent/src/agent-runtime/agent.service.ts` + `skills/official/skill-handlers.ts` + `skill-runtime.service.ts` (H8), `apps/agent/src/mcp-agent/{mcp-tool-executor,server-registry}.service.ts` + `tool-gateway/tool-executor.service.ts` (H11), `apps/agent/src/mcp-platform/mcp-entity.controller.ts` + `mcp-tool-acl.service.ts` (H12), `apps/webapp/app/env.server.ts` (H14), `internal-packages/database/prisma/schema.prisma` (H15, L6, RLS), `apps/agent/src/auth/cross-scope-isolation.test.ts` + `internal-packages/testcontainers` (Phase 4 gate).


### PR DESCRIPTION
Response to the multi-agent security audit (`docs/security-audit-2026-07-16.md`). Root cause: the (org,project,env) scope tuple was treated as a user boundary — no operator/end-user tier. This adds that tier and closes the cross-org escalations + cross-user REST leaks. **Every fix Fable-5 adversarially verified** (author/reviewer split).

## Foundation
`RequestScope.principal` ('operator' | 'end-user') + `requireOperator()` (fails closed). Operator = platform-signed token (`iss:platos-platform` AND NOT `isGuest`) OR the trusted internal direct-header path. The webapp dashboard reaches gated endpoints via that internal path — verified no regression.

## Critical (cross-org) — C1 entity-secret gate · C2 durable-callback ownership checks (5 callbacks) · C3 entity-OAuth reject · C4 trigger `payload.scope` rebind (dot+dash)
## High — H1 (25 dashboard handlers) · H2 thread-cost IDOR · H7 memory `?userId=` (incl. update/delete) · H9 KG userId · H10 files browser · H14 webapp secrets · H16 budget
## Medium — M1 internal-secret fail-closed · `:3100`→loopback

Fable caught + I fixed: guest-token escalation, omit-ids bypass, dash-prefix, write-side residual — all re-verified CLOSED. Durable chat + dashboard confirmed intact on test.platos.

Follow-ups (in the audit doc): Phase 2 realtime room redesign (H3–H6/H13), Phase 3 (H8/H11/H12/H15), Phase 4 (C2 HMAC + CI isolation-test gate), + platos-client approvals SDK 403 changelog note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)