### PR TITLE
security: H15 — scope PlatosToolDefinition per tenant [NEEDS MIGRATION REVIEW, not deployed]

### DIFF
--- a/apps/agent/src/mcp-platform/tools/orchestration.ts
+++ b/apps/agent/src/mcp-platform/tools/orchestration.ts
@@ -215,15 +215,27 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
         const callbackUrl = effectiveMcpUrls[0] ?? "/mcp";
         for (const toolName of initialTools) {
           try {
-            // Upsert the central tool definition first (unique by name).
-            const existing = await prisma.platosToolDefinition.findUnique({
-              where: { name: toolName },
+            // Upsert the central tool definition first. SECURITY (audit H15) —
+            // scope by (org, project, name): PlatosToolDefinition is now
+            // per-tenant (was globally unique by name). An unscoped lookup here
+            // would attach this provision's mapping to whatever tenant already
+            // owns that name, and post-migration `findUnique({name})` throws
+            // (name is no longer a unique key) — silently swallowed into
+            // toolWarnings, so stubs would stop being created.
+            const existing = await prisma.platosToolDefinition.findFirst({
+              where: {
+                name: toolName,
+                organizationId: scope.organizationId,
+                projectId: scope.projectId,
+              },
             });
             const toolDef = existing
               ? existing
               : await prisma.platosToolDefinition.create({
                   data: {
                     name: toolName,
+                    organizationId: scope.organizationId,
+                    projectId: scope.projectId,
                     description: `[stub] ${toolName} — schema pending tool-sync handshake.`,
                     paramSchema: { type: "object", additionalProperties: true } as any,
                     schemaHash: "stub",

--- a/apps/agent/src/tool-gateway/tool-registry.service.ts
+++ b/apps/agent/src/tool-gateway/tool-registry.service.ts
@@ -227,9 +227,19 @@ export class ToolRegistryService implements OnModuleInit {
       const resolvedCategory =
         tool.category || inferEntityToolCategory(tool.name, params.sourceEntityId);
 
-      // Upsert into central registry
-      let existing = await this.prisma.platosToolDefinition.findUnique({
-        where: { name: tool.name },
+      // Upsert into central registry.
+      // SECURITY (audit H15) — scope the lookup + create to (org, project,
+      // name). Previously the row was keyed by `name` alone (global @unique),
+      // so an org registering a common tool name overwrote another org's shared
+      // row and re-indexed the shared toolId in the process-wide BM25 index —
+      // cross-tenant schema-overwrite + ranking poison. Each tenant now owns
+      // its own row.
+      let existing = await this.prisma.platosToolDefinition.findFirst({
+        where: {
+          name: tool.name,
+          organizationId: params.organizationId,
+          projectId: params.projectId,
+        },
       });
 
       if (existing) {
@@ -252,6 +262,8 @@ export class ToolRegistryService implements OnModuleInit {
         existing = await this.prisma.platosToolDefinition.create({
           data: {
             name: tool.name,
+            organizationId: params.organizationId,
+            projectId: params.projectId,
             description: tool.description,
             paramSchema: tool.paramSchema,
             category: resolvedCategory,

--- a/docs/security-audit-2026-07-16.md
+++ b/docs/security-audit-2026-07-16.md
@@ -307,6 +307,12 @@ Ordered by (blocker status × blast radius × implementation cost). Each notes b
 > **Residuals (deferred to Phase 4):** H11 DNS-rebind TOCTOU is not closed (validate-by-hostname, no IP-pin — needs hardening inside `fetchWithValidatedRedirects`); privileged headers still follow a redirect to any **public** host (SSRF-to-internal closed, exfil-to-arbitrary-public open). Duplicate `toolName` rows (uniqueness is `(entityPk, toolId)`) could let list (Map last-wins) and call (`findFirst` first-wins) pick different rows — low-severity, needs an `orderBy` or a name-level uniqueness constraint.
 
 12. **H15** — tenant-scope `PlatosToolDefinition` (or at least the BM25 index). *Blast: cross-tenant tool-row overwrite + ranking poison. **Product decision:** schema migration timing (`@@unique` change is a migration).*
+
+> **STATUS — H15 IMPLEMENTED, in flagged PR #48, NOT deployed to test.platos (schema migration — your apply decision).**
+> `PlatosToolDefinition` gained nullable `organizationId`/`projectId`; the global `name @unique` became `@@unique([organizationId, projectId, name])`. `registerTools` and the `entities_provision` stub path both scope their lookup/create to `(org, project, name)` (scope comes from the authenticated entity's service-secret-verified `conn`, never the tool payload). Migration `20260717010000_platos_tool_definition_scope` is additive (nullable columns; existing rows → `(NULL,NULL,name)`, no conflict). **test.platos has 0 tool rows** → safe to apply as-is; populated self-host DBs need a backfill **before entities reconnect** (the first scoped re-register orphans the legacy mapping) + orphan cleanup after — SQL + sequence documented in the migration file. Typecheck-verified on the VPS (prisma generate + nest build); Fable-verified (caught + fixed the missed `entities_provision` writer).
+>
+> **Residual (informational, deferred):** the BM25 corpus statistics (`totalDocs`/IDF/`avgDocLength`) remain process-global, so another tenant registering tools can shift *ranking order* (not content — `bm25.search` hard-filters candidate ids by scope before scoring; no cross-scope name/description/schema can surface). `getIndexStats` also exposes a global doc count. Cosmetic; per-scope corpus stats are a possible future hardening.
+
 13. **M2, M3, M5, M8** — claims-whitelist mint, OAuth-token key separation, WS responder binding, ReDoS guard. *No product decisions.*
 
 > **STATUS — Phase 3 cluster 2 (M2, M3, M5, M8) SHIPPED (2026-07-17), deployed to test.platos, Fable-verified.**

--- a/internal-packages/database/prisma/migrations/20260717010000_platos_tool_definition_scope/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260717010000_platos_tool_definition_scope/migration.sql
@@ -1,0 +1,40 @@
+-- SECURITY (audit 2026-07-16, finding H15): scope PlatosToolDefinition per
+-- tenant. `name` was globally @unique, so one org registering a common tool
+-- name (`search`, `send_email`) overwrote the shared row's
+-- description/paramSchema/bm25Tokens and re-indexed the shared toolId in the
+-- process-wide BM25 index — poisoning another org's ranking + leaking its
+-- schema. The registry lookup/create is now scoped to (organizationId,
+-- projectId, name); this migration makes the storage layer match.
+--
+-- ADDITIVE + SAFE TO APPLY AS-IS: the new columns are NULLABLE, so every
+-- existing row (at most one per name, since name was globally unique) becomes
+-- (NULL, NULL, name) and does NOT violate the new composite unique. New tool
+-- registrations write real (organizationId, projectId, name) rows.
+--
+-- ⚠️ EXISTING DATA (self-host / populated DBs) — backfill BEFORE relying on
+-- per-tenant isolation for tools registered prior to this migration:
+--   * Rows referenced by exactly ONE (org, project) can be backfilled in place
+--     from PlatosEntityToolMapping -> PlatosConnectedEntity scope, e.g.:
+--       UPDATE "PlatosToolDefinition" td
+--       SET "organizationId" = s.org, "projectId" = s.proj
+--       FROM (
+--         SELECT m."toolId",
+--                min(e."organizationId") org, min(e."projectId") proj,
+--                count(distinct e."organizationId"||':'||e."projectId") n
+--         FROM "PlatosEntityToolMapping" m
+--         JOIN "PlatosConnectedEntity" e ON e.id = m."entityId"
+--         GROUP BY m."toolId"
+--       ) s
+--       WHERE td.id = s."toolId" AND s.n = 1;
+--   * Rows genuinely SHARED across scopes (the vulnerable case) must be SPLIT:
+--     one row per scope, repointing each scope's PlatosEntityToolMapping to its
+--     new row. This is a deliberate data decision — do NOT automate it blindly.
+-- On test.platos this table is empty (0 rows), so no backfill is required there.
+
+ALTER TABLE "PlatosToolDefinition" ADD COLUMN "organizationId" TEXT;
+ALTER TABLE "PlatosToolDefinition" ADD COLUMN "projectId" TEXT;
+
+-- Replace the global name-unique with a tenant-scoped composite unique.
+DROP INDEX "PlatosToolDefinition_name_key";
+CREATE UNIQUE INDEX "PlatosToolDefinition_organizationId_projectId_name_key" ON "PlatosToolDefinition"("organizationId", "projectId", "name");
+CREATE INDEX "PlatosToolDefinition_organizationId_projectId_idx" ON "PlatosToolDefinition"("organizationId", "projectId");

--- a/internal-packages/database/prisma/migrations/20260717010000_platos_tool_definition_scope/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260717010000_platos_tool_definition_scope/migration.sql
@@ -11,8 +11,16 @@
 -- (NULL, NULL, name) and does NOT violate the new composite unique. New tool
 -- registrations write real (organizationId, projectId, name) rows.
 --
--- ⚠️ EXISTING DATA (self-host / populated DBs) — backfill BEFORE relying on
--- per-tenant isolation for tools registered prior to this migration:
+-- ⚠️ EXISTING DATA (self-host / populated DBs) — backfill BEFORE ENTITIES
+-- RECONNECT after this deploy (not merely "before relying on isolation"): the
+-- first WS reconnect runs registerTools with real (org, project), which MISSES
+-- the legacy (NULL, NULL, name) row and CREATEs a new scoped row, orphaning the
+-- old PlatosEntityToolMapping. That orphan can then win the rebuildIndex cache
+-- race after a restart and serve the (possibly pre-migration-poisoned) legacy
+-- definition + stale callbackUrl. After backfilling, delete
+-- PlatosEntityToolMapping rows still pointing at (NULL, NULL) tool rows once
+-- every entity has re-registered, then delete those orphan tool rows.
+-- Backfill the tool rows before that window:
 --   * Rows referenced by exactly ONE (org, project) can be backfilled in place
 --     from PlatosEntityToolMapping -> PlatosConnectedEntity scope, e.g.:
 --       UPDATE "PlatosToolDefinition" td

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -3671,7 +3671,16 @@ model PlatosEntityMcpConfig {
 /// entities, projects, and orgs. BM25 tokens are computed once here.
 model PlatosToolDefinition {
   id          String   @id @default(cuid())
-  name        String   @unique
+  // SECURITY (audit H15) — tenant scope. `name` was globally @unique, so one
+  // org registering a common tool name (`search`, `send_email`) overwrote the
+  // shared row's description/paramSchema/bm25Tokens and re-indexed it, poisoning
+  // another org's ranking + inheriting its schema. Scope the row per tenant.
+  // Nullable for an additive migration: legacy rows (one per name, since name
+  // was globally unique) become (NULL, NULL, name) — no constraint conflict —
+  // and are backfilled/split before enforcing NOT NULL.
+  organizationId String?
+  projectId      String?
+  name        String
   description String   @db.Text
   paramSchema Json // full JSON Schema for parameters
   category    String? // functional grouping: "calendar", "email", "tasks", etc.
@@ -3683,6 +3692,8 @@ model PlatosToolDefinition {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([organizationId, projectId, name])
+  @@index([organizationId, projectId])
   @@index([category])
 }
 


### PR DESCRIPTION
Finding **H15** (2026-07-16 audit). **⚠️ Contains a schema migration — deliberately NOT deployed to test.platos; needs your review + apply decision.**

## Problem
`PlatosToolDefinition.name` was globally `@unique` with no scope columns. `registerTools` looked it up by name alone and, on a `schemaHash` mismatch, overwrote `description`/`paramSchema`/`bm25Tokens` and re-indexed the shared `toolId` in the process-wide BM25 index. Org B registering a common tool name (`search`, `send_email`) → poisons Org A's `find_tools` ranking and, after any `rebuildIndex()`, Org A inherits Org B's schema/description.

## Fix
- **schema.prisma**: nullable `organizationId`/`projectId`, drop `name @unique`, add `@@unique([organizationId, projectId, name])` + index.
- **tool-registry.service.ts** `registerTools`: scope the lookup to `findFirst({name, organizationId, projectId})` and set org/project on create (both already in `params`). Each tenant owns its own row; `find_tools` already filters candidates by scope.
- **migration** `20260717010000_platos_tool_definition_scope`: additive + safe — new columns nullable, so existing rows become `(NULL, NULL, name)` with no constraint conflict.

## ⚠️ Why not deployed / what you must decide
This repo runs `prisma migrate deploy` on stack-up (`migrations-init`). The migration is **safe on an empty table** — **test.platos has 0 `PlatosToolDefinition` rows** (verified), so no backfill is needed there. But **populated self-host DBs** need a backfill BEFORE relying on per-tenant isolation for pre-existing tools:
- Rows referenced by exactly one `(org, project)` → backfill in place from the entity mapping's scope (SQL in the migration file).
- Rows genuinely **shared** across scopes (the vulnerable case) → must be **split** one-row-per-scope, repointing each scope's `PlatosEntityToolMapping`. This is a deliberate data decision — don't automate blindly.

**To land:** review, decide backfill for any populated env, then apply via the normal migrate-deploy flow. On test.platos it's safe to apply as-is.

## Verification
- Typecheck: VPS `nest build` (prisma generate + tsc) — see checks.
- Fable-verified (code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)