### PR TITLE
security: L6 — KG agentId isolation column [migration, not deployed]

### DIFF
--- a/apps/agent/src/memory/knowledge-graph.service.ts
+++ b/apps/agent/src/memory/knowledge-graph.service.ts
@@ -57,6 +57,10 @@ export interface ShortestPathInput {
 
 export interface UpsertEntityInput {
   userId: string;
+  /// L6 — acting agent (null for operator/non-agent-pinned callers). Stamped
+  /// on CREATE only; entities are shared per (scope,userId,entityKey) so an
+  /// existing node keeps its first-writer agentId.
+  agentId?: string | null;
   entityKey: string;
   entityType?: string;
   label?: string;
@@ -163,6 +167,7 @@ export class KnowledgeGraphService {
         projectId: scope.projectId,
         environmentId: scope.environmentId,
         userId: input.userId,
+        agentId: input.agentId ?? null,
         entityKey: input.entityKey,
         entityType: input.entityType || "other",
         // EOBD.22 — encrypt label + metadata at rest (label is typically
@@ -398,6 +403,8 @@ export class KnowledgeGraphService {
     scope: ScopeTuple,
     input: {
       userId: string;
+      /// L6 — acting agent (null for operator/non-agent-pinned callers).
+      agentId?: string | null;
       fromEntityId: string;
       toEntityId: string;
       relationshipType: string;
@@ -431,6 +438,7 @@ export class KnowledgeGraphService {
         projectId: scope.projectId,
         environmentId: scope.environmentId,
         userId: input.userId,
+        agentId: input.agentId ?? null,
         fromEntityId: input.fromEntityId,
         toEntityId: input.toEntityId,
         relationshipType: input.relationshipType,

--- a/apps/agent/src/memory/memory.controller.ts
+++ b/apps/agent/src/memory/memory.controller.ts
@@ -291,6 +291,7 @@ export class MemoryController {
         }
         const ent = await this.graph.upsertEntity(scopeTuple, {
           userId,
+          agentId: scope.agentId ?? null,
           entityKey: key,
           entityType: String((e as any).entityType || "other"),
           label: String((e as any).label || key),
@@ -346,6 +347,7 @@ export class MemoryController {
         try {
           await this.graph.createRelationship(scopeTuple, {
             userId,
+            agentId: scope.agentId ?? null,
             fromEntityId: fromId,
             toEntityId: toId,
             relationshipType: relType,
@@ -725,12 +727,14 @@ export class MemoryController {
       const [from, to] = await Promise.all([
         this.graph.upsertEntity(scopeTuple, {
           userId,
+          agentId: scope.agentId ?? null,
           entityKey: body.fromEntityKey,
           entityType: body.fromEntityType || "other",
           label: body.fromLabel || body.fromEntityKey,
         }),
         this.graph.upsertEntity(scopeTuple, {
           userId,
+          agentId: scope.agentId ?? null,
           entityKey: body.toEntityKey,
           entityType: body.toEntityType || "other",
           label: body.toLabel || body.toEntityKey,
@@ -738,6 +742,7 @@ export class MemoryController {
       ]);
       const rel = await this.graph.createRelationship(scopeTuple, {
         userId,
+        agentId: scope.agentId ?? null,
         fromEntityId: from.id,
         toEntityId: to.id,
         relationshipType: body.relationshipType,

--- a/internal-packages/database/prisma/migrations/20260717020000_platos_kg_agent_scope/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260717020000_platos_kg_agent_scope/migration.sql
@@ -1,0 +1,27 @@
+-- L6 (security audit 2026-07-16) — knowledge-graph agent isolation.
+--
+-- The KG entity + relationship tables scope on
+-- (organizationId, projectId, environmentId, userId) but carry NO agentId,
+-- unlike PlatosMemory (which gained it in the L5 wave). Today this is a
+-- LATENT leak: the turn-time `relate` meta-tool and the extractor WRITE
+-- these tables, but no turn-time path READS them yet. Add the nullable
+-- isolation column BEFORE any KG-in-prompt recall is wired, so the column
+-- exists before it is relied upon.
+--
+-- Nullable + additive: existing rows get agentId = NULL (identical to the
+-- semantics of pre-L5 PlatosMemory rows). No backfill required; no existing
+-- query changes (every current read filters on scope + userId only).
+-- Mirrors 20260717010000_platos_tool_definition_scope (additive scope cols).
+
+ALTER TABLE "PlatosMemoryEntity" ADD COLUMN IF NOT EXISTS "agentId" TEXT;
+ALTER TABLE "PlatosMemoryRelationship" ADD COLUMN IF NOT EXISTS "agentId" TEXT;
+
+-- Agent-scoped read index. Matches the @@index maps added to schema.prisma
+-- so a future `(scope, userId, agentId)` KG recall is index-backed. agentId
+-- is nullable — a b-tree index stores NULLs fine and NULL rows stay
+-- reachable via the existing scope_user indexes.
+CREATE INDEX IF NOT EXISTS "platos_mem_entity_scope_agent_idx"
+  ON "PlatosMemoryEntity" ("organizationId", "projectId", "environmentId", "userId", "agentId");
+
+CREATE INDEX IF NOT EXISTS "platos_mem_rel_scope_agent_idx"
+  ON "PlatosMemoryRelationship" ("organizationId", "projectId", "environmentId", "userId", "agentId");

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -4675,6 +4675,14 @@ model PlatosMemoryEntity {
 
   userId String
 
+  /// L6 (audit 2026-07-16) — nullable acting-agent stamp. NULL for rows
+  /// written before this column existed, or by non-agent-pinned tokens
+  /// (operator MCP). Mirrors PlatosMemory.agentId so a future turn-time KG
+  /// recall can filter (scope, userId, agentId) without leaking across agents.
+  /// Entities are shared per (scope, userId, entityKey), so this records the
+  /// FIRST agent that materialised the node (stamped on create, not update).
+  agentId String?
+
   /// Stable external identifier chosen by the agent/operator
   /// (e.g. "user_123", "project_rocket", "company_acme"). Used as the
   /// upsert key for `relate()` so repeated calls are idempotent.
@@ -4694,6 +4702,7 @@ model PlatosMemoryEntity {
 
   @@unique([organizationId, projectId, environmentId, userId, entityKey], map: "platos_mem_entity_scope_key_unq")
   @@index([organizationId, projectId, environmentId, userId], map: "platos_mem_entity_scope_user_idx")
+  @@index([organizationId, projectId, environmentId, userId, agentId], map: "platos_mem_entity_scope_agent_idx")
   @@index([organizationId, projectId, environmentId, entityType], map: "platos_mem_entity_scope_type_idx")
 }
 
@@ -4712,6 +4721,11 @@ model PlatosMemoryRelationship {
   environment    RuntimeEnvironment @relation(fields: [environmentId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   userId String
+
+  /// L6 (audit 2026-07-16) — nullable acting-agent stamp, denormalised from
+  /// the write scope (parallels the denormalised userId column above). NULL
+  /// for pre-existing rows / non-agent-pinned tokens.
+  agentId String?
 
   fromEntityId String
   fromEntity   PlatosMemoryEntity @relation("PlatosMemoryRelationshipFrom", fields: [fromEntityId], references: [id], onDelete: Cascade)
@@ -4733,6 +4747,7 @@ model PlatosMemoryRelationship {
   createdAt DateTime @default(now())
 
   @@index([organizationId, projectId, environmentId, userId], map: "platos_mem_rel_scope_user_idx")
+  @@index([organizationId, projectId, environmentId, userId, agentId], map: "platos_mem_rel_scope_agent_idx")
   @@index([fromEntityId], map: "platos_mem_rel_from_idx")
   @@index([toEntityId], map: "platos_mem_rel_to_idx")
   @@index([organizationId, projectId, environmentId, relationshipType], map: "platos_mem_rel_scope_type_idx")


### PR DESCRIPTION
Finding **L6** (2026-07-16 audit). **⚠️ Contains a schema migration — not deployed; apply alongside H15 (#48) when ready.**

## Problem
The KG tables (`PlatosMemoryEntity`, `PlatosMemoryRelationship`) scope on `(org, project, env, userId)` but carry **no `agentId`**, unlike `PlatosMemory`. Latent cross-agent leak: the turn-time `relate` meta-tool + the extractor **write** these tables, but nothing **reads** them turn-time yet. Add the isolation column *before* KG-in-prompt recall is wired.

## Fix
- **schema**: nullable `agentId` on both KG models + a `(scope, userId, agentId)` index each. Additive; existing rows → NULL (same as pre-L5 `PlatosMemory`). No backfill, no existing-query change.
- **migration** `20260717020000_platos_kg_agent_scope`: `ADD COLUMN IF NOT EXISTS` ×2 + `CREATE INDEX IF NOT EXISTS` ×2.
- **service**: `upsertEntity` stamps `agentId` on CREATE only (nodes are shared per `(scope,userId,entityKey)` — record the first writer); `createRelationship` denormalises it; the `memory.controller` KG import/relate paths pass `scope.agentId ?? null`.

**When recall is later wired**, the reader must treat NULL as "visible to the owning user across agents" (not a specific-agent match), or legacy rows vanish from recall.

Typecheck-verified on the VPS. Not deployed to test.platos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)