### PR TITLE
ci: --ignore-scripts so re2 native build does not break CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts: skip native addon builds (re2). CI needs only types
+        # (typecheck) and the testcontainer suite; neither loads re2, and its
+        # node-gyp build fails on the hosted runner (node-gyp@13 + undici@8).
+        # The agent Docker build (which DOES need re2) builds it separately.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Generate Prisma client
         # @platos/database re-exports the generated client; several packages'
@@ -82,7 +86,11 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        # --ignore-scripts: skip native addon builds (re2). CI needs only types
+        # (typecheck) and the testcontainer suite; neither loads re2, and its
+        # node-gyp build fails on the hosted runner (node-gyp@13 + undici@8).
+        # The agent Docker build (which DOES need re2) builds it separately.
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Generate Prisma client
         # @internal/testcontainers + the test both import @platos/database,


### PR DESCRIPTION
Adding `re2` to `pnpm.onlyBuiltDependencies` (required so the agent Docker build compiles `re2.node`) made every `pnpm install` try to build it — breaking the CI typecheck + cross-scope-isolation jobs (node-gyp@13 fails vs undici@8 on the hosted runner). Those jobs only need types + the testcontainer suite; neither loads re2. `--ignore-scripts` on their installs skips the native build. Agent Docker build is unaffected (separate install, has the toolchain). Webapp build failure in the prior push was an unrelated runner disk issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)