### PR TITLE
feat(connect-v3): Phase B — Slack Agents & AI Apps surface

### DIFF
--- a/apps/agent/src/agent-runtime/channel-apps.controller.ts
+++ b/apps/agent/src/agent-runtime/channel-apps.controller.ts
@@ -48,6 +48,19 @@ import { validateAgentRouting } from "./channel-routing";
  * install-time bot tokens live on the installation rows and are likewise
  * redacted (`hasBotToken`). `clientId` is a public identifier and IS returned.
  * POST returns `installUrl` — the "Add to Slack" href.
+ *
+ * RECOMMENDED Slack `scopes` for the "Agents & AI Apps" surface (send in the
+ * create/update body):
+ *   - `assistant:write`   — assistant.threads.setTitle / setStatus /
+ *                           setSuggestedPrompts on the assistant thread.
+ *   - `im:history`        — read the user's messages in the assistant DM thread.
+ *   - `chat:write`        — post replies (also clears the thinking status).
+ *   - `app_mentions:read` — mention-bot fallback surface.
+ * Per Slack's 2026-03-05 change `setStatus` also accepts `chat:write`, but the
+ * other `assistant.threads.*` methods still require `assistant:write` — request
+ * BOTH. The app must additionally enable the "Agents & AI Apps" toggle in its
+ * Slack config so the split-view panel + assistant_thread_started events are
+ * delivered.
  */
 
 const APP_PROVIDERS = new Set(["slack"]);

--- a/apps/agent/src/channels/channel-app-events.controller.ts
+++ b/apps/agent/src/channels/channel-app-events.controller.ts
@@ -175,6 +175,14 @@ export class ChannelAppEventsController {
     }
 
     // ── ACK fast, then route + run the turn DETACHED ──────────────────────
+    // Every non-url_verification, non-lifecycle event is admitted here and
+    // handed WHOLE to runtime.handleAppEvent — there is NO inner-type allowlist
+    // in this controller. That is deliberate: the "Agents & AI Apps" surface
+    // events (assistant_thread_started / assistant_thread_context_changed,
+    // Phase B) ride the SAME per-app events URL and MUST reach the runtime,
+    // which decides what to do per inner type. Do NOT add a type filter here —
+    // it would silently drop the assistant surface. Dedupe + ACK above are
+    // type-agnostic and stay identical.
     res.status(200).json({ ok: true });
     void (async () => {
       try {

--- a/apps/agent/src/channels/channel-runtime.service.ts
+++ b/apps/agent/src/channels/channel-runtime.service.ts
@@ -11,6 +11,12 @@ import { ConversationService } from "../memory/conversation.service";
 import { AgentTaskService } from "../agent-runtime/agent-task.service";
 import { env } from "../shared/env";
 import type { RequestScope } from "../auth/scope.guard";
+import {
+  buildAssistantPrompts,
+  setAssistantStatus,
+  setAssistantSuggestedPrompts,
+  setAssistantTitle,
+} from "./slack-assistant.api";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Chat SDK (v4.34) — RUNTIME + BRIDGE slice.
@@ -881,9 +887,31 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
     if (installation?.status && installation.status !== "active") return;
 
     // Never react to bot-authored messages (our own replies, other bots) —
-    // the hard stop against reply loops, mirroring the v2 bridge.
+    // the hard stop against reply loops, mirroring the v2 bridge. Assistant
+    // threads echo the bot's OWN posts back as message.im events; those carry
+    // `bot_id` (this guard) AND a `bot_message` subtype (parseSlackAppEvent
+    // drops any subtype) AND user==botUserId (the self-echo check below), so
+    // the reply loop is closed by three independent guards on the message path.
     const event = envelope?.event;
     if (event?.bot_id) return;
+
+    // ── "Agents & AI Apps" surface events (Phase B) ───────────────────────
+    // The events controller admits these on the SAME per-app events URL; they
+    // are NOT message events, so parseSlackAppEvent would drop them — branch
+    // here first. Both are best-effort decoration; neither runs a turn.
+    const eventType = typeof event?.type === "string" ? event.type : "";
+    if (eventType === "assistant_thread_started") {
+      await this.handleAssistantThreadStarted(app, installation, event);
+      return;
+    }
+    if (eventType === "assistant_thread_context_changed") {
+      // v1 stores no per-thread context (it is informational; the thread row is
+      // already pinned). Debug-log only — no persistent update.
+      this.logger.debug(
+        `[channel-apps] assistant_thread_context_changed app=${appId} installation=${installationId}`,
+      );
+      return;
+    }
 
     const parsed = this.parseSlackAppEvent(envelope);
     if (!parsed) return;
@@ -965,6 +993,27 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
       return;
     }
 
+    // ── Assistant-surface "is thinking…" status (best-effort) ─────────────
+    // A message.im WITHIN an assistant thread has a thread_ts (parsed into
+    // replyThreadTs) and a DM channel (starts with "D"). Set the ephemeral
+    // status before the turn; the reply's chat.postMessage clears it
+    // automatically. A plain DM (no thread_ts) is NOT an assistant thread and
+    // keeps its existing behavior (no status). Never fails the turn.
+    const isAssistantThread =
+      parsed.channel.startsWith("D") && !!parsed.replyThreadTs;
+    if (isAssistantThread) {
+      try {
+        await setAssistantStatus(
+          botToken,
+          parsed.channel,
+          parsed.replyThreadTs as string,
+          "is thinking…",
+        );
+      } catch {
+        /* best-effort — never blocks the turn */
+      }
+    }
+
     // ── Turn → reply (already detached by the controller) ─────────────────
     const turnScope = {
       ...conversationScope,
@@ -990,6 +1039,20 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
           parsed.replyThreadTs,
           reply,
         );
+      } else if (isAssistantThread) {
+        // Empty/tool-only turn: nothing gets posted, so the "is thinking…"
+        // status would stick forever (Slack only clears it when the app posts
+        // or explicitly clears it). An empty status string clears it.
+        try {
+          await setAssistantStatus(
+            botToken,
+            parsed.channel,
+            parsed.replyThreadTs as string,
+            "",
+          );
+        } catch {
+          /* best-effort */
+        }
       }
     } catch {
       this.logger.error(
@@ -1005,6 +1068,197 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
       } catch {
         /* best-effort */
       }
+    }
+  }
+
+  /**
+   * Handle an `assistant_thread_started` event for the "Agents & AI Apps"
+   * surface. DETACHED, best-effort decoration — it runs NO turn:
+   *   (a) PIN a PlatosChannelAppThread row for this (installation, thread) NOW
+   *       — keyed `slack:<D-channel>:<thread_ts>`, IDENTICAL to the key the
+   *       first user message.im computes — so the first message reuses the same
+   *       Platos thread + agent instead of racing a fresh one.
+   *   (b) setSuggestedPrompts — up to 4 prompts derived from the bound agent's
+   *       description (generic defaults today; see buildAssistantPrompts) under
+   *       the heading "Ask <agent name>".
+   *   (c) setTitle — the agent's display name.
+   * Routing note: an assistant thread is a 1:1 DM split view with no message
+   * text and no channel to route on, so the pinned agent is the default
+   * (install override → app default); text-prefix / channel routing rules do
+   * not apply to this surface. Context (team/channel the user navigated from)
+   * is informational; v1 persists none (no schema change) — see the
+   * assistant_thread_context_changed debug-only branch in handleAppEvent.
+   */
+  private async handleAssistantThreadStarted(
+    app: any,
+    installation: any,
+    event: any,
+  ): Promise<void> {
+    const appId = String(app?.id ?? "");
+    const installationId = String(installation?.id ?? "");
+    const parsed = this.parseAssistantThreadEvent(event);
+    if (!parsed) return;
+    // Defensive self-skip (the opener is a human, never our bot).
+    if (installation.botUserId && parsed.user === String(installation.botUserId)) {
+      return;
+    }
+
+    // Need the bot token to decorate the thread; fail-closed on decrypt.
+    let botToken: string;
+    try {
+      botToken = this.getAppBotToken(app, installation);
+    } catch {
+      this.logger.error(
+        `[channel-apps] bot token unavailable (assistant_thread_started) app=${appId} installation=${installationId}`,
+      );
+      return;
+    }
+
+    // Default agent: install override → app default. None ⇒ nothing to bind.
+    const defaultAgentId =
+      (typeof installation.agentId === "string" && installation.agentId) ||
+      (typeof app.defaultAgentId === "string" && app.defaultAgentId) ||
+      "";
+    if (!defaultAgentId) {
+      this.logger.warn(
+        `[channel-apps] no agent bound (assistant_thread_started) app=${appId} installation=${installationId}`,
+      );
+      return;
+    }
+    const agentRouting = installation.agentRouting ?? app.agentRouting ?? null;
+
+    this.logger.log(
+      `[channel-apps] assistant_thread_started app=${appId} installation=${installationId}`,
+    );
+
+    // ── Identity + scope (app OWNER's scope), mirroring the message path ───
+    const team = String(installation.teamId ?? installation.enterpriseId ?? "");
+    const handle = team ? `${team}:${parsed.user}` : parsed.user;
+    const claims = [{ channel: "slack", handle, verified: true }];
+    const authorScope: RequestScope = {
+      organizationId: String(app.organizationId),
+      projectId: String(app.projectId),
+      environmentId: String(app.environmentId),
+      userId: `slack:${handle}`,
+      userIdentities: claims,
+    };
+    const conversationScope: RequestScope = {
+      ...authorScope,
+      userId: this.appConversationUserId(installationId, parsed.channelThreadKey),
+    };
+
+    // (a) PIN the thread row NOW (empty text ⇒ default agent) so the first user
+    //     message reuses it. Best-effort — a failure just means the first
+    //     message creates the row instead; still decorate with the default agent.
+    let agentId = defaultAgentId;
+    try {
+      const resolved = await this.resolveAppThreadBinding(
+        installationId,
+        defaultAgentId,
+        agentRouting,
+        authorScope,
+        conversationScope,
+        parsed.channelThreadKey,
+        "",
+      );
+      agentId = resolved.agentId;
+    } catch {
+      this.logger.error(
+        `[channel-apps] thread pin failed (assistant_thread_started) app=${appId} installation=${installationId}`,
+      );
+    }
+
+    // Load the pinned agent's display fields (name always; displayName /
+    // description are read defensively — not modeled in the current schema).
+    const agent = await this.loadAgentDisplay(app, agentId);
+    const name = (agent?.name && agent.name.trim()) || "the assistant";
+    const displayName =
+      (typeof agent?.displayName === "string" && agent.displayName.trim()) || name;
+    const description =
+      typeof agent?.description === "string" ? agent.description : null;
+
+    // (b) suggested prompts + (c) title — both best-effort, never throw.
+    try {
+      await setAssistantSuggestedPrompts(
+        botToken,
+        parsed.channel,
+        parsed.threadTs,
+        buildAssistantPrompts(description),
+        `Ask ${name}`,
+      );
+    } catch {
+      /* best-effort */
+    }
+    try {
+      await setAssistantTitle(
+        botToken,
+        parsed.channel,
+        parsed.threadTs,
+        displayName,
+      );
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  /**
+   * Extract the coordinates of an assistant-thread event
+   * (`assistant_thread_started` / `assistant_thread_context_changed`), or null
+   * to skip. Shape:
+   *   event.assistant_thread = { user_id: "U…", channel_id: "D…", thread_ts, context? }
+   * `channelThreadKey` is `slack:<channel_id>:<thread_ts>` — IDENTICAL to the
+   * key parseSlackAppEvent computes for the first threaded message.im, so the
+   * pinned row is reused.
+   */
+  private parseAssistantThreadEvent(event: any): {
+    channel: string;
+    user: string;
+    threadTs: string;
+    channelThreadKey: string;
+  } | null {
+    const at = event?.assistant_thread;
+    if (!at || typeof at !== "object") return null;
+    const channel = typeof at.channel_id === "string" ? at.channel_id : "";
+    const user = typeof at.user_id === "string" ? at.user_id : "";
+    const threadTs = typeof at.thread_ts === "string" ? at.thread_ts : "";
+    if (!channel || !user || !threadTs) return null;
+    return {
+      channel,
+      user,
+      threadTs,
+      channelThreadKey: `slack:${channel}:${threadTs}`,
+    };
+  }
+
+  /**
+   * Load the bound agent's display fields for assistant-thread decoration.
+   * Scope-pinned to the app owner. `name` is the only field guaranteed by the
+   * current schema; `displayName` / `description` are read defensively (absent
+   * today — Phase B is schema-free) via a no-`select` fetch so the query cannot
+   * throw an "unknown field" error and the fields light up automatically if a
+   * future migration adds them.
+   */
+  private async loadAgentDisplay(
+    app: any,
+    agentId: string,
+  ): Promise<{
+    name?: string;
+    displayName?: string;
+    description?: string;
+  } | null> {
+    if (!agentId) return null;
+    try {
+      const row = await this.prisma.platosAgent.findFirst({
+        where: {
+          id: agentId,
+          organizationId: String(app.organizationId),
+          projectId: String(app.projectId),
+          environmentId: String(app.environmentId),
+        },
+      });
+      return (row as any) ?? null;
+    } catch {
+      return null;
     }
   }
 

--- a/apps/agent/src/channels/slack-assistant.api.ts
+++ b/apps/agent/src/channels/slack-assistant.api.ts
@@ -1,0 +1,201 @@
+/**
+ * Connect v3 — Slack "Agents & AI Apps" surface Web API helpers.
+ *
+ * Slack apps that enable the "Agents & AI Apps" toggle + hold the
+ * `assistant:write` scope get a first-class split-view assistant panel. Its
+ * thread-decoration methods live here, split out of channel-runtime.service.ts
+ * so the runtime bridge stays focused on turn execution. Every call is:
+ *   - BEST-EFFORT: a status/title/prompt failure must NEVER fail the turn, so
+ *     these functions swallow all errors and return void (they never throw).
+ *   - Bounded by a 10s `AbortSignal.timeout` (same budget as chat.postMessage).
+ *   - Token-safe: the bot token + any user text are NEVER logged — only the
+ *     Slack method name + error code on failure, at debug level (cosmetic surface).
+ *
+ * All are POST https://slack.com/api/<method> with a JSON body and
+ * `Authorization: Bearer <bot token>`; Slack answers `{ ok: boolean, ... }`.
+ *
+ * SCOPES (recommend in the app manifest): `assistant:write` for the assistant
+ * thread methods, plus `chat:write` to post replies (which also clears the
+ * thinking status). Per Slack's 2026-03-05 change `assistant.threads.setStatus`
+ * additionally accepts `chat:write`, but the other `assistant.threads.*` methods
+ * still want `assistant:write` — request BOTH.
+ *
+ * Streaming is OUT OF SCOPE for v1 (setStatus + a single final chat.postMessage).
+ * The upgrade path is a throttled `chat.update` loop over a placeholder message
+ * (Slack recommends ≤1 update/sec) driven off the SDK's streaming turn — it can
+ * slot in behind postSlackMessage without touching these decoration helpers.
+ */
+
+import { Logger } from "@nestjs/common";
+
+const SLACK_API_BASE = "https://slack.com/api";
+const ASSISTANT_TIMEOUT_MS = 10_000;
+/** Slack renders the prompt `title` as a compact chip — keep it short. */
+const PROMPT_TITLE_MAX = 40;
+/** Defensive cap on the click-to-send `message` body. */
+const PROMPT_MESSAGE_MAX = 500;
+const MAX_PROMPTS = 4;
+
+const logger = new Logger("SlackAssistantApi");
+
+export interface AssistantPrompt {
+  /** Compact chip label shown in the split-view panel. */
+  title: string;
+  /** The message text sent as the user when the chip is clicked. */
+  message: string;
+}
+
+/**
+ * Generic starter prompts used when the bound agent has no description to
+ * derive from. Slack requires 1–4 prompts; this set is 3.
+ */
+const GENERIC_PROMPTS: AssistantPrompt[] = [
+  { title: "What can you help me with?", message: "What can you help me with?" },
+  {
+    title: "Give me an example",
+    message: "Give me an example of something you can help with.",
+  },
+  { title: "Help me get started", message: "Help me get started." },
+];
+
+function truncate(s: string, max: number): string {
+  const t = s.trim();
+  if (t.length <= max) return t;
+  return `${t.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+/**
+ * Derive up to 4 suggested prompts for the assistant panel from the bound
+ * agent's description. Split on newlines OR sentence boundaries, phrase each
+ * fragment as a starter prompt; fall back to the generic set when there is no
+ * usable description.
+ *
+ * NOTE: the current PlatosAgent schema models `name` but NOT `description`
+ * (Phase B is schema-free by design), so `description` is effectively always
+ * absent today → generic defaults. This function is written to light up
+ * automatically if/when a `description` column is added, with no code change.
+ */
+export function buildAssistantPrompts(
+  description?: string | null,
+): AssistantPrompt[] {
+  if (typeof description === "string" && description.trim()) {
+    const parts = description
+      // sentence boundary (keep the terminator via lookbehind) OR newline
+      .split(/\n+|(?<=[.!?])\s+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .slice(0, MAX_PROMPTS);
+    if (parts.length > 0) {
+      return parts.map((p) => ({
+        title: truncate(p, PROMPT_TITLE_MAX),
+        message: p.slice(0, PROMPT_MESSAGE_MAX),
+      }));
+    }
+  }
+  return GENERIC_PROMPTS;
+}
+
+/**
+ * POST an assistant.threads.* method, swallowing every failure. Returns void —
+ * callers treat this as fire-and-forget decoration. Never throws; never logs
+ * the token or body.
+ */
+async function callAssistantMethod(
+  method: string,
+  botToken: string,
+  body: Record<string, unknown>,
+): Promise<void> {
+  if (!botToken) return;
+  let res: Response;
+  try {
+    res = await fetch(`${SLACK_API_BASE}/${method}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Bearer ${botToken}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(ASSISTANT_TIMEOUT_MS),
+    });
+  } catch {
+    logger.debug(`[channel-apps] ${method} request failed`);
+    return;
+  }
+  let json: any = null;
+  try {
+    json = await res.json();
+  } catch {
+    /* non-JSON — treated as failure below */
+  }
+  if (!json?.ok) {
+    logger.debug(
+      `[channel-apps] ${method} rejected error=${json?.error ?? res.status}`,
+    );
+  }
+}
+
+/**
+ * assistant.threads.setStatus — show an ephemeral "is thinking…" status in the
+ * assistant thread. Cleared automatically when the bot next posts a message.
+ *   POST https://slack.com/api/assistant.threads.setStatus
+ *   body: { channel_id, thread_ts, status }
+ */
+export async function setAssistantStatus(
+  botToken: string,
+  channelId: string,
+  threadTs: string,
+  status: string,
+): Promise<void> {
+  if (!channelId || !threadTs) return;
+  await callAssistantMethod("assistant.threads.setStatus", botToken, {
+    channel_id: channelId,
+    thread_ts: threadTs,
+    status,
+  });
+}
+
+/**
+ * assistant.threads.setTitle — name the assistant thread (shown in the split
+ * view's history list).
+ *   POST https://slack.com/api/assistant.threads.setTitle
+ *   body: { channel_id, thread_ts, title }
+ */
+export async function setAssistantTitle(
+  botToken: string,
+  channelId: string,
+  threadTs: string,
+  title: string,
+): Promise<void> {
+  if (!channelId || !threadTs || !title) return;
+  await callAssistantMethod("assistant.threads.setTitle", botToken, {
+    channel_id: channelId,
+    thread_ts: threadTs,
+    title,
+  });
+}
+
+/**
+ * assistant.threads.setSuggestedPrompts — seed the split view with 1–4 starter
+ * prompt chips (with an optional heading `title`).
+ *   POST https://slack.com/api/assistant.threads.setSuggestedPrompts
+ *   body: { channel_id, thread_ts, prompts: [{ title, message }], title? }
+ */
+export async function setAssistantSuggestedPrompts(
+  botToken: string,
+  channelId: string,
+  threadTs: string,
+  prompts: AssistantPrompt[],
+  title?: string,
+): Promise<void> {
+  if (!channelId || !threadTs) return;
+  const trimmed = (Array.isArray(prompts) ? prompts : [])
+    .filter((p) => p && p.title && p.message)
+    .slice(0, MAX_PROMPTS);
+  if (trimmed.length === 0) return;
+  await callAssistantMethod("assistant.threads.setSuggestedPrompts", botToken, {
+    channel_id: channelId,
+    thread_ts: threadTs,
+    prompts: trimmed,
+    ...(title ? { title } : {}),
+  });
+}

--- a/apps/agent/src/mcp-platform/tools/channel-apps.ts
+++ b/apps/agent/src/mcp-platform/tools/channel-apps.ts
@@ -174,6 +174,15 @@ export function buildChannelAppToolHandlers(deps: {
         "(bool, default true), `defaultAgentId` (fallback agent for new " +
         "installs — validated in-scope), `agentRouting` (ordered `{match, " +
         "agentId}` rules, same shape + in-scope validation as channels.*). " +
+        "RECOMMENDED Slack `scopes` for the AI-Apps surface: `assistant:write` " +
+        "(assistant.threads.setTitle/setStatus/setSuggestedPrompts), " +
+        "`im:history` (read DMs in the assistant thread), `chat:write` (post " +
+        "replies — also clears the thinking status; since 2026-03-05 " +
+        "setStatus accepts chat:write too, but the other assistant.threads.* " +
+        "methods still need assistant:write, so request BOTH), and " +
+        "`app_mentions:read` (mention-bot fallback). Also enable the app's " +
+        "\"Agents & AI Apps\" toggle in the Slack app config so the split-view " +
+        "assistant panel + assistant_thread_started events are delivered. " +
         "Returns the app row (secrets redacted → `hasClientSecret` / " +
         "`hasSigningSecret`) plus `installUrl` — the Add-to-Slack href.",
       inputSchema: {
@@ -381,12 +390,14 @@ export function buildChannelAppToolHandlers(deps: {
       description:
         "Partial-patch a channel app: `displayName` (string|null), `clientId` " +
         "(string), `clientSecret` / `signingSecret` (re-encrypt; omit to keep " +
-        "the current value), `scopes` (string[]), `distribution` " +
-        "(private|public), `aiAppsSurface` (bool), `defaultAgentId` " +
-        "(string|null to clear — validated in-scope), `agentRouting` (array of " +
-        "`{match, agentId}` rules | null to clear). Scope-pinned — cross-scope " +
-        "ids return `{ error: 'not_found' }`. Returns the updated row with " +
-        "secrets redacted.",
+        "the current value), `scopes` (string[] — for the AI-Apps surface " +
+        "recommend `assistant:write` + `im:history` + `chat:write` + " +
+        "`app_mentions:read`, and enable the app's \"Agents & AI Apps\" " +
+        "toggle), `distribution` (private|public), `aiAppsSurface` (bool), " +
+        "`defaultAgentId` (string|null to clear — validated in-scope), " +
+        "`agentRouting` (array of `{match, agentId}` rules | null to clear). " +
+        "Scope-pinned — cross-scope ids return `{ error: 'not_found' }`. " +
+        "Returns the updated row with secrets redacted.",
       inputSchema: {
         type: "object",
         required: ["id"],


### PR DESCRIPTION
Assistant threads, suggested prompts, thinking status, panel titles — the surface Claude-in-Slack targets. Fable-gated (stuck-status on empty turns caught+fixed; echo-loop verified guarded). Deployed + verified live (PHASE_B_LIVE in the running container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)