### PR TITLE
feat(connect-v3): Phase C — hosted account linking (Sign in with Slack)

### DIFF
--- a/apps/agent/src/agent-runtime/channel-apps.controller.ts
+++ b/apps/agent/src/agent-runtime/channel-apps.controller.ts
@@ -61,10 +61,21 @@ import { validateAgentRouting } from "./channel-routing";
  * BOTH. The app must additionally enable the "Agents & AI Apps" toggle in its
  * Slack config so the split-view panel + assistant_thread_started events are
  * delivered.
+ *
+ * ACCOUNT LINKING (`linking`, Connect v3 Phase C): `none` (default) | `optional`
+ * | `required`. `optional` exposes a "Connect your account" URL when the user
+ * types `link`/`connect` (and honours `unlink`); `required` additionally
+ * WITHHOLDS an unlinked user's turns until they complete Sign in with Slack,
+ * which attaches a verified email identity to the same canonical person. The
+ * hosted flow reuses THIS app's Slack client credentials for SIWS, so the app
+ * must register the extra OIDC redirect URL
+ * `<publicOrigin>/api/v1/channels/link/callback` in its Slack "Redirect URLs".
  */
 
 const APP_PROVIDERS = new Set(["slack"]);
 const DISTRIBUTIONS = new Set(["private", "public"]);
+// Connect v3 (Phase C) — hosted account-linking policy.
+const LINKING = new Set(["none", "optional", "required"]);
 const OAUTH_BASE = "/api/v1/channels/oauth";
 
 @Controller("api/v1/agent/channel-apps")
@@ -219,6 +230,7 @@ export class ChannelAppsController {
       scopes?: string[];
       distribution?: string;
       aiAppsSurface?: boolean;
+      linking?: string;
       defaultAgentId?: string | null;
       agentRouting?: unknown;
     },
@@ -254,6 +266,21 @@ export class ChannelAppsController {
         { error: "invalid_params", message: "distribution must be private | public" },
         HttpStatus.BAD_REQUEST,
       );
+    }
+
+    // linking (optional) — enum-validated; defaults to "none" at the DB layer.
+    let linking: string | undefined;
+    if (body?.linking !== undefined) {
+      linking = String(body.linking).trim().toLowerCase();
+      if (!LINKING.has(linking)) {
+        throw new HttpException(
+          {
+            error: "invalid_params",
+            message: "linking must be none | optional | required",
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
     }
 
     const displayName =
@@ -300,6 +327,7 @@ export class ChannelAppsController {
         ...(displayName !== undefined ? { displayName } : {}),
         ...(scopes !== undefined ? { scopes } : {}),
         ...(aiAppsSurface !== undefined ? { aiAppsSurface } : {}),
+        ...(linking !== undefined ? { linking } : {}),
         ...(defaultAgentId ? { defaultAgentId } : {}),
         ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
       },
@@ -337,6 +365,7 @@ export class ChannelAppsController {
       scopes?: string[];
       distribution?: string;
       aiAppsSurface?: boolean;
+      linking?: string;
       defaultAgentId?: string | null;
       agentRouting?: unknown;
     },
@@ -385,6 +414,19 @@ export class ChannelAppsController {
       data.distribution = distribution;
     }
     if (typeof body.aiAppsSurface === "boolean") data.aiAppsSurface = body.aiAppsSurface;
+    if (typeof body.linking === "string") {
+      const linking = body.linking.trim().toLowerCase();
+      if (!LINKING.has(linking)) {
+        throw new HttpException(
+          {
+            error: "invalid_params",
+            message: "linking must be none | optional | required",
+          },
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+      data.linking = linking;
+    }
     if (Object.prototype.hasOwnProperty.call(body, "defaultAgentId")) {
       const raw = body.defaultAgentId;
       if (raw === null || raw === "") {

--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -179,13 +179,21 @@ export class ScopeGuard implements CanActivate {
     //     URL per app. Every POST is verified by the Slack v0 signature
     //     (HMAC-SHA256 over `v0:<ts>:<rawBody>` with the app's DECRYPTED
     //     signing secret, timing-safe) + a stale-timestamp reject.
-    // The caller is Slack (or a browser mid-install), not a Platos user, so
-    // there is no per-scope session context. ScopeGuard just lets it land.
-    // (The operator-only MANAGEMENT surface lives at /api/v1/agent/channel-apps
-    // and is NOT bypassed — it runs under normal scope extraction below.)
+    //   /api/v1/channels/link/{:nonce,callback} — Phase C hosted account
+    //     linking (Sign in with Slack / OIDC). GET-only; auth is IN the
+    //     controller — a single-use Redis nonce (bound to team+user), a second
+    //     OIDC `nonce` bound into the id_token, and a userInfo-authoritative
+    //     team_id/user_id + email_verified match. The caller is a browser
+    //     mid-flow, not a Platos user.
+    // The caller is Slack (or a browser mid-install/mid-link), not a Platos
+    // user, so there is no per-scope session context. ScopeGuard just lets it
+    // land. (The operator-only MANAGEMENT surface lives at
+    // /api/v1/agent/channel-apps and is NOT bypassed — it runs under normal
+    // scope extraction below.)
     if (
       url.startsWith("/api/v1/channels/oauth/") ||
-      url.startsWith("/api/v1/channels/apps/")
+      url.startsWith("/api/v1/channels/apps/") ||
+      url.startsWith("/api/v1/channels/link/")
     ) {
       return true;
     }

--- a/apps/agent/src/channels/channel-app-events.controller.ts
+++ b/apps/agent/src/channels/channel-app-events.controller.ts
@@ -159,16 +159,71 @@ export class ChannelAppEventsController {
     // ── Lifecycle (uninstall/revoke) handled INLINE, before the detach ────
     const innerType =
       envelope?.type === "event_callback" ? envelope?.event?.type : null;
-    if (innerType === "app_uninstalled" || innerType === "tokens_revoked") {
+
+    // app_uninstalled — the whole app was removed. Always SOFT-revoke every
+    // installation for this (app, team, enterprise). Idempotent.
+    if (innerType === "app_uninstalled") {
       try {
         await this.revokeInstallations(String(app.id), teamId, enterpriseId);
         this.logger.log(
-          `[chanapp] lifecycle ${innerType} app=${appId} — installation revoked`,
+          `[chanapp] lifecycle app_uninstalled app=${appId} — installation revoked`,
         );
       } catch {
         this.logger.error(
-          `[chanapp] lifecycle ${innerType} revoke failed app=${appId}`,
+          `[chanapp] lifecycle app_uninstalled revoke failed app=${appId}`,
         );
+      }
+      res.status(200).json({ ok: true });
+      return;
+    }
+
+    // tokens_revoked — `event.tokens` = { bot?: string[], oauth?: string[] }.
+    // Phase C splits the two revocation kinds Phase A conflated:
+    //   • BOT tokens revoked   → the installation can no longer act → SOFT-revoke
+    //     it (the original Phase A behavior).
+    //   • USER (oauth) tokens  → a user pulled their Sign-in-with-Slack consent
+    //     (or was deactivated). Do NOT revoke the installation — the bot still
+    //     works for everyone else — instead invalidate THAT user's linked
+    //     verified EMAIL identities so the linked-email trust no longer anchors
+    //     resolution / passes the `linking: required` policy gate.
+    // Fail-safe: if `tokens` is absent/unparseable (Slack always sends it), fall
+    // back to revoking the installation, preserving Phase A's "never leave a
+    // possibly-compromised token live" property.
+    if (innerType === "tokens_revoked") {
+      const tokens = envelope?.event?.tokens;
+      const botIds = Array.isArray(tokens?.bot)
+        ? (tokens.bot as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+      const oauthIds = Array.isArray(tokens?.oauth)
+        ? (tokens.oauth as unknown[]).filter((v): v is string => typeof v === "string")
+        : [];
+      const unparseable = botIds.length === 0 && oauthIds.length === 0;
+
+      if (botIds.length > 0 || unparseable) {
+        try {
+          await this.revokeInstallations(String(app.id), teamId, enterpriseId);
+          this.logger.log(
+            `[chanapp] lifecycle tokens_revoked (bot) app=${appId} — installation revoked`,
+          );
+        } catch {
+          this.logger.error(
+            `[chanapp] lifecycle tokens_revoked revoke failed app=${appId}`,
+          );
+        }
+      }
+      if (oauthIds.length > 0) {
+        try {
+          await this.invalidateLinkedIdentities(
+            app,
+            teamId,
+            enterpriseId,
+            oauthIds,
+          );
+        } catch {
+          this.logger.error(
+            `[chanapp] lifecycle tokens_revoked identity-invalidate failed app=${appId}`,
+          );
+        }
       }
       res.status(200).json({ ok: true });
       return;
@@ -274,6 +329,90 @@ export class ChannelAppEventsController {
         },
         data: { status: "revoked", revokedAt },
       });
+    }
+  }
+
+  /**
+   * Phase C lifecycle — a USER (oauth) token was revoked (Sign-in-with-Slack
+   * consent pulled / member deactivated). Do NOT revoke the installation;
+   * instead invalidate that user's SIWS-linked EMAIL identities so the
+   * verified-email trust no longer anchors resolution or passes the
+   * `linking: required` gate.
+   *
+   * TRADEOFF (v1): we SET verified=false on the person's email identity rows
+   * rather than DELETE the slack→email linkage. Deletion is destructive and
+   * irreversible if the revoke was transient (e.g. a re-auth churn); flipping
+   * `verified` is reversible — a subsequent re-link restores it — and is enough
+   * to fail the trust gate. Scope is the app OWNER's (installations carry no
+   * scope of their own). The slack handle is `<team>:<userId>` (team = teamId ??
+   * enterpriseId), matching how the runtime attaches the identity. Per-user
+   * isolation: one bad lookup never aborts the rest. No PII (handle/email) is
+   * ever logged — only counts + appId.
+   */
+  private async invalidateLinkedIdentities(
+    app: any,
+    teamId: string | null,
+    enterpriseId: string | null,
+    userIds: string[],
+  ): Promise<void> {
+    const organizationId = String(app.organizationId);
+    const projectId = String(app.projectId);
+    const environmentId = String(app.environmentId);
+    // Candidate handle team components: the event carries the WORKSPACE team_id
+    // even for Grid org-level installs, but the runtime stored the slack handle
+    // with `installation.teamId ?? enterpriseId` — which is the ENTERPRISE id
+    // for org-installs (teamId null). We don't have the installation here, so
+    // try both forms (workspace team first, then enterprise) — same enterprise
+    // fallback shape findActiveInstallation/revokeInstallations use.
+    const teamCandidates = Array.from(
+      new Set([teamId, enterpriseId].filter((t): t is string => !!t)),
+    );
+    for (const userId of userIds) {
+      if (!userId) continue;
+      const handleCandidates =
+        teamCandidates.length > 0
+          ? teamCandidates.map((t) => `${t}:${userId}`)
+          : [userId];
+      try {
+        let slackIdentity: { platosEndUserId: string | null } | null = null;
+        for (const handle of handleCandidates) {
+          slackIdentity = await this.prisma.platosEndUserIdentity.findUnique({
+            where: {
+              organizationId_projectId_environmentId_channel_handle: {
+                organizationId,
+                projectId,
+                environmentId,
+                channel: "slack",
+                handle,
+              },
+            },
+            select: { platosEndUserId: true },
+          });
+          if (slackIdentity?.platosEndUserId) break;
+        }
+        if (!slackIdentity?.platosEndUserId) continue;
+        const { count } = await this.prisma.platosEndUserIdentity.updateMany({
+          where: {
+            organizationId,
+            projectId,
+            environmentId,
+            platosEndUserId: slackIdentity.platosEndUserId,
+            channel: "email",
+            verified: true,
+          },
+          data: { verified: false },
+        });
+        if (count > 0) {
+          this.logger.log(
+            `[chanapp] tokens_revoked invalidated ${count} email identity(ies) app=${String(app.id)}`,
+          );
+        }
+      } catch {
+        // Per-user isolation — one bad lookup must not abort the rest.
+        this.logger.error(
+          `[chanapp] tokens_revoked identity lookup failed app=${String(app.id)}`,
+        );
+      }
     }
   }
 

--- a/apps/agent/src/channels/channel-link.controller.ts
+++ b/apps/agent/src/channels/channel-link.controller.ts
@@ -1,0 +1,921 @@
+import {
+  Controller,
+  Get,
+  Injectable,
+  Param,
+  Query,
+  Req,
+  Res,
+  Logger,
+  Inject,
+} from "@nestjs/common";
+import type {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+import * as crypto from "node:crypto";
+import { PRISMA_TOKEN } from "../shared/database.provider";
+import { REDIS_TOKEN } from "../shared/redis.provider";
+import type Redis from "ioredis";
+import { MessageCryptoService } from "../monitoring/message-crypto.service";
+import { ConversationService } from "../memory/conversation.service";
+
+/**
+ * Connect v3 — Phase C hosted ACCOUNT LINKING (Sign in with Slack / OIDC).
+ *
+ * An installed marketplace app can require (or offer) that a Slack user attach a
+ * VERIFIED EMAIL identity to the same canonical Platos end-user as their Slack
+ * identity — zero developer code; the platform owns the whole choreography.
+ *
+ * SHAPE:
+ *   linkStart(app, installation, {teamId, slackUserId, channel, threadTs})
+ *     — INTERNAL. Called from the runtime (policy gate / `link` command) to mint
+ *       a single-use nonce bound to (team, user, reply target) into Redis
+ *       (`chanapp:link:<nonce>`, TTL 900s) and return the hosted-flow URL.
+ *
+ *   GET /api/v1/channels/link/:nonce
+ *     — the user clicks the URL. Loads the nonce payload (NOT consumed yet),
+ *       mints a SECOND fresh `oidcNonce` alongside it, and 302-redirects to the
+ *       Slack SIWS authorize screen (`openid profile email`).
+ *
+ *   GET /api/v1/channels/link/callback?code&state
+ *     — Slack's redirect target. GETDELs the nonce (single-use), exchanges the
+ *       code, then — the mandated security design — does NOT trust the raw
+ *       id_token JWT (no JWKS/crypto verify dep): it calls openid.connect.userInfo
+ *       and treats THAT response as the authoritative claims. The id_token is
+ *       base64-decoded ONLY to check its `nonce` equals the stored `oidcNonce`.
+ *       It REQUIRES email_verified === true AND that the userInfo team_id/user_id
+ *       EXACTLY match the nonce's (teamId, slackUserId) — i.e. the person who
+ *       clicked in Slack is the person who authenticated (else 403 mismatch) —
+ *       then attaches the verified slack + email identities to one canonical
+ *       Platos person (link-not-merge) and fires a best-effort confirmation DM.
+ *
+ * PUBLIC surface: both GET routes are anonymous (the caller is a browser
+ * mid-flow / Slack, not a Platos user). ScopeGuard allowlists the
+ * `/api/v1/channels/link/` prefix; auth lives IN this slice (single-use nonce +
+ * OIDC nonce binding + authoritative-claim match). Every Slack HTTP call is
+ * bounded by a 10s AbortSignal.timeout; no token/secret is ever logged or
+ * rendered into an HTML response. Per-IP rate limiting mirrors the OAuth
+ * controller (anonymous surface, RateLimitGuard never sees it).
+ *
+ * SIWS redirect-URL requirement: `<publicOrigin>/api/v1/channels/link/callback`
+ * must be registered in the Slack app's OAuth Redirect URLs (surfaced in the
+ * management descriptions — item (6)).
+ */
+
+// ── nonce payload persisted in Redis (`chanapp:link:<nonce>`) ───────────────
+interface LinkNoncePayload {
+  appId: string;
+  installationId: string;
+  /**
+   * The runtime's HANDLE team component: installation.teamId ?? enterpriseId.
+   * For an Enterprise Grid ORG-LEVEL install this is the "E…" enterprise id —
+   * it builds the identity handle (`<team>:<user>`) so the gate lookup stays
+   * consistent, but it is NOT what SIWS userInfo returns as team_id.
+   */
+  teamId: string;
+  slackUserId: string;
+  /**
+   * The originating WORKSPACE team id ("T…") from the verified event envelope.
+   * SIWS userInfo's https://slack.com/team_id is always a workspace id, so the
+   * callback matches against THIS (falling back to teamId when absent — for a
+   * workspace-level install they are the same value).
+   */
+  eventTeamId?: string;
+  replyChannel: string;
+  replyThreadTs: string | null;
+  /** Minted on the /:nonce redirect; bound into the SIWS authorize `nonce`. */
+  oidcNonce?: string;
+}
+
+type CallbackResult =
+  | { ok: true; email: string }
+  | {
+      ok: false;
+      reason: "expired" | "config" | "slack" | "mismatch" | "attach" | "conflict";
+    };
+
+type RedirectResult =
+  | { redirectUrl: string }
+  | { error: "not_found" | "config" };
+
+@Injectable()
+export class ChannelLinkService {
+  private readonly logger = new Logger(ChannelLinkService.name);
+
+  constructor(
+    @Inject(PRISMA_TOKEN) private readonly prisma: any,
+    @Inject(REDIS_TOKEN) private readonly redis: Redis,
+    private readonly messageCrypto: MessageCryptoService,
+    private readonly conversationService: ConversationService,
+  ) {}
+
+  // ───────────────────────────────────────────────────────────────────────
+  // INTERNAL — mint a link nonce + return the hosted-flow URL
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Mint a single-use 32-byte-hex nonce bound to (team, user, reply target),
+   * persist it (`chanapp:link:<nonce>`, TTL 900s), and return the hosted URL
+   * `<publicOrigin>/api/v1/channels/link/<nonce>`. Returns null when the public
+   * origin is unset or Redis is unavailable (the caller then skips offering the
+   * link rather than emitting a broken one). Never throws.
+   */
+  async linkStart(
+    app: any,
+    installation: any,
+    coords: {
+      teamId: string;
+      slackUserId: string;
+      channel: string;
+      threadTs?: string | null;
+      /** Originating workspace team id ("T…") from the event envelope — see LinkNoncePayload. */
+      eventTeamId?: string | null;
+    },
+  ): Promise<string | null> {
+    const appId = String(app?.id ?? "");
+    const installationId = String(installation?.id ?? "");
+    if (!appId || !installationId) return null;
+
+    const origin = this.publicOrigin();
+    if (!origin) {
+      this.logger.error(
+        `[chanapp-link] linkStart blocked — PLATOS_PUBLIC_BASE_URL unset app=${appId}`,
+      );
+      return null;
+    }
+
+    const nonce = crypto.randomBytes(32).toString("hex");
+    const payload: LinkNoncePayload = {
+      appId,
+      installationId,
+      teamId: String(coords.teamId ?? ""),
+      slackUserId: String(coords.slackUserId ?? ""),
+      eventTeamId: coords.eventTeamId ? String(coords.eventTeamId) : undefined,
+      replyChannel: String(coords.channel ?? ""),
+      replyThreadTs: coords.threadTs ? String(coords.threadTs) : null,
+    };
+    try {
+      await this.redis.set(
+        this.nonceKey(nonce),
+        JSON.stringify(payload),
+        "EX",
+        900,
+      );
+    } catch {
+      this.logger.error(`[chanapp-link] nonce persist failed app=${appId}`);
+      return null;
+    }
+    return `${origin}/api/v1/channels/link/${nonce}`;
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // /:nonce — load payload (NOT consumed), mint oidcNonce, build SIWS URL
+  // ───────────────────────────────────────────────────────────────────────
+
+  async buildAuthorizeRedirect(nonce: string): Promise<RedirectResult> {
+    // Read WITHOUT consuming — the single-use GETDEL happens on /callback.
+    let raw: string | null = null;
+    try {
+      raw = (await this.redis.get(this.nonceKey(nonce))) as string | null;
+    } catch {
+      raw = null;
+    }
+    if (!raw) return { error: "not_found" };
+
+    let payload: LinkNoncePayload;
+    try {
+      payload = JSON.parse(raw) as LinkNoncePayload;
+    } catch {
+      return { error: "not_found" };
+    }
+
+    const app = await this.loadApp(payload.appId);
+    if (!app) return { error: "config" };
+
+    const origin = this.publicOrigin();
+    if (!origin) return { error: "config" };
+
+    // Fresh OIDC nonce, stored alongside the payload so /callback can bind the
+    // returned id_token to THIS authorize request (anti-replay / anti-CSRF).
+    const oidcNonce = crypto.randomBytes(32).toString("hex");
+    payload.oidcNonce = oidcNonce;
+    try {
+      // Re-persist with the full 900s window so the user has time to complete
+      // Slack auth; the single-use property is still enforced by the /callback
+      // GETDEL, not by the TTL.
+      await this.redis.set(
+        this.nonceKey(nonce),
+        JSON.stringify(payload),
+        "EX",
+        900,
+      );
+    } catch {
+      this.logger.error(`[chanapp-link] oidcNonce persist failed app=${payload.appId}`);
+      return { error: "config" };
+    }
+
+    // scope = openid profile email — SIWS returns verified email + team/user ids.
+    const params = new URLSearchParams({
+      response_type: "code",
+      scope: "openid profile email",
+      client_id: String(app.clientId ?? ""),
+      state: nonce,
+      nonce: oidcNonce,
+      redirect_uri: this.callbackUrl(origin),
+    });
+    this.logger.log(`[chanapp-link] siws authorize redirect app=${payload.appId}`);
+    return {
+      redirectUrl: `https://slack.com/openid/connect/authorize?${params.toString()}`,
+    };
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // /callback — exchange, userInfo-authoritative claims, attach, DM
+  // ───────────────────────────────────────────────────────────────────────
+
+  async completeCallback(code: string, state: string): Promise<CallbackResult> {
+    // ── Single-use: atomically read + consume the nonce ───────────────────
+    let raw: string | null = null;
+    try {
+      raw = (await (this.redis as any).getdel(this.nonceKey(state))) as
+        | string
+        | null;
+    } catch {
+      raw = null;
+    }
+    if (!raw) return { ok: false, reason: "expired" };
+
+    let payload: LinkNoncePayload;
+    try {
+      payload = JSON.parse(raw) as LinkNoncePayload;
+    } catch {
+      return { ok: false, reason: "expired" };
+    }
+    const {
+      appId,
+      installationId,
+      teamId,
+      slackUserId,
+      eventTeamId,
+      replyChannel,
+      replyThreadTs,
+      oidcNonce,
+    } = payload;
+
+    const app = await this.loadApp(appId);
+    if (!app) return { ok: false, reason: "config" };
+
+    const origin = this.publicOrigin();
+    if (!origin) return { ok: false, reason: "config" };
+
+    let clientSecret: string;
+    try {
+      clientSecret = this.decryptSecretString(app.clientSecret);
+    } catch {
+      this.logger.error(`[chanapp-link] client_secret decrypt failed app=${appId}`);
+      return { ok: false, reason: "config" };
+    }
+
+    // ── Token exchange (10s bound; secrets in the body, never the URL) ─────
+    // redirect_uri MUST byte-match the one sent to /authorize.
+    let tokenJson: any;
+    try {
+      const form = new URLSearchParams({
+        code,
+        client_id: String(app.clientId ?? ""),
+        client_secret: clientSecret,
+        redirect_uri: this.callbackUrl(origin),
+      });
+      const resp = await fetch("https://slack.com/api/openid.connect.token", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+        signal: AbortSignal.timeout(10_000),
+      });
+      tokenJson = await resp.json();
+    } catch {
+      this.logger.error(`[chanapp-link] openid.connect.token failed app=${appId}`);
+      return { ok: false, reason: "slack" };
+    }
+    if (
+      !tokenJson?.ok ||
+      typeof tokenJson.access_token !== "string" ||
+      !tokenJson.access_token
+    ) {
+      this.logger.warn(
+        `[chanapp-link] token exchange rejected app=${appId} error=${
+          typeof tokenJson?.error === "string" ? tokenJson.error : "unknown_error"
+        }`,
+      );
+      return { ok: false, reason: "slack" };
+    }
+    const accessToken = tokenJson.access_token as string;
+    const idToken = typeof tokenJson.id_token === "string" ? tokenJson.id_token : "";
+
+    // ── AUTHORITATIVE claims: openid.connect.userInfo (NOT the raw id_token) ─
+    // The mandated security design: do not verify the unsigned JWT and do not
+    // pull in a JWKS/crypto dep — trust the userInfo response reached with the
+    // access token instead.
+    let info: any;
+    try {
+      const resp = await fetch(
+        "https://slack.com/api/openid.connect.userInfo",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${accessToken}` },
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+      info = await resp.json();
+    } catch {
+      this.logger.error(`[chanapp-link] openid.connect.userInfo failed app=${appId}`);
+      return { ok: false, reason: "slack" };
+    }
+    if (info?.ok === false) {
+      this.logger.warn(
+        `[chanapp-link] userInfo rejected app=${appId} error=${
+          typeof info?.error === "string" ? info.error : "unknown_error"
+        }`,
+      );
+      return { ok: false, reason: "slack" };
+    }
+
+    const email =
+      typeof info?.email === "string" ? info.email.trim().toLowerCase() : "";
+    const emailVerified =
+      info?.email_verified === true || info?.email_verified === "true";
+    const infoTeamId = String(info?.["https://slack.com/team_id"] ?? "");
+    const infoUserId = String(info?.["https://slack.com/user_id"] ?? "");
+
+    // ── The id_token's `nonce` must equal the stored oidcNonce (decode only) ─
+    const tokenNonce = this.decodeJwtNonce(idToken);
+    if (
+      !oidcNonce ||
+      !tokenNonce ||
+      !this.constEq(String(tokenNonce), String(oidcNonce))
+    ) {
+      this.logger.warn(`[chanapp-link] oidc nonce mismatch app=${appId}`);
+      return { ok: false, reason: "mismatch" };
+    }
+
+    // ── REQUIRE verified email AND that the authenticated Slack person is the
+    //    exact person who clicked in Slack (team_id + user_id match). ────────
+    if (!email || !emailVerified) {
+      this.logger.warn(`[chanapp-link] email not verified app=${appId}`);
+      return { ok: false, reason: "mismatch" };
+    }
+    // userInfo's team_id is always the user's WORKSPACE id ("T…"). For an
+    // Enterprise Grid ORG-LEVEL install the handle team (payload.teamId) is the
+    // "E…" enterprise id, which can never match — so compare against the event
+    // envelope's workspace id when the runtime supplied it, falling back to the
+    // handle team (identical for workspace-level installs). user_id stays an
+    // exact match either way.
+    const expectedTeamId = String(eventTeamId || teamId || "");
+    if (
+      infoTeamId !== expectedTeamId ||
+      infoUserId !== String(slackUserId ?? "")
+    ) {
+      const enterpriseHint =
+        !eventTeamId && String(teamId ?? "").startsWith("E")
+          ? " (enterprise org-level install without eventTeamId — the runtime must pass the event envelope's workspace team_id or this can never match)"
+          : "";
+      this.logger.warn(
+        `[chanapp-link] identity mismatch app=${appId}${enterpriseHint}`,
+      );
+      return { ok: false, reason: "mismatch" };
+    }
+
+    // ── Attach identity (link-not-merge) to the app OWNER's scope ──────────
+    // resolveEndUser anchors on the existing VERIFIED slack identity (created on
+    // the message path) and links the verified email onto that SAME canonical
+    // person — unifying the slack person with any pre-existing email-keyed
+    // person per the identity foundation's rules. NEVER maps by typed email.
+    const handle = `${teamId}:${slackUserId}`;
+    const scope = {
+      organizationId: String(app.organizationId),
+      projectId: String(app.projectId),
+      environmentId: String(app.environmentId),
+      userId: `slack:${handle}`,
+      userIdentities: [
+        { channel: "slack", handle, verified: true },
+        { channel: "email", handle: email, verified: true },
+      ],
+    };
+    let resolvedId: string | null = null;
+    try {
+      resolvedId = await this.conversationService.resolveEndUser(scope, {});
+    } catch {
+      resolvedId = null;
+    }
+    if (!resolvedId) {
+      this.logger.error(`[chanapp-link] identity attach failed app=${appId}`);
+      return { ok: false, reason: "attach" };
+    }
+
+    // ── VERIFY the email actually attached to the resolved person ──────────
+    // resolveEndUser's step (c) silently SKIPS attaching a claim whose
+    // (channel, handle) row already belongs to a DIFFERENT person
+    // (link-not-merge) — but still returns resolvedId. Without this check a
+    // P_slack/P_email split renders "Account linked" while the policy gate
+    // (isSlackUserLinked: slack row → person → verified email row) keeps
+    // withholding turns forever. Re-query the email row and require it to be
+    // verified AND pointing at the resolved person; otherwise render an honest
+    // failure instead of a success-but-still-gated loop.
+    //
+    // TODO(identity): decide the deliberate unification behavior for the
+    // P_slack/P_email split — today neither anchor order can unify once both
+    // persons exist (link-not-merge never re-points, never merges).
+    let emailRow: { platosEndUserId: string; verified: boolean } | null = null;
+    let emailRowLookupOk = false;
+    try {
+      emailRow = await this.prisma.platosEndUserIdentity.findUnique({
+        where: {
+          organizationId_projectId_environmentId_channel_handle: {
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+            channel: "email",
+            handle: email,
+          },
+        },
+        select: { platosEndUserId: true, verified: true },
+      });
+      emailRowLookupOk = true;
+    } catch {
+      emailRow = null;
+    }
+    if (!emailRowLookupOk || !emailRow) {
+      // DB blip or the attach itself failed — retryable, not a conflict.
+      this.logger.error(
+        `[chanapp-link] email identity verify-back failed app=${appId}`,
+      );
+      return { ok: false, reason: "attach" };
+    }
+    if (emailRow.platosEndUserId !== resolvedId) {
+      // The email already belongs to a different canonical person — the
+      // link-not-merge split. Log the split (redacted handle, never raw PII).
+      this.logger.warn(
+        `[chanapp-link] link conflict app=${appId} email=${this.redactHandle(
+          email,
+        )} attachedTo=${emailRow.platosEndUserId} resolved=${resolvedId} (link-not-merge split)`,
+      );
+      return { ok: false, reason: "conflict" };
+    }
+    if (emailRow.verified !== true) {
+      // Same person but the row is unverified (e.g. flipped by the
+      // tokens_revoked lifecycle). We JUST verified this email via SIWS for
+      // this exact person — re-verify in place (no re-pointing involved).
+      try {
+        await this.prisma.platosEndUserIdentity.updateMany({
+          where: {
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+            channel: "email",
+            handle: email,
+            platosEndUserId: resolvedId,
+          },
+          data: { verified: true },
+        });
+      } catch {
+        this.logger.error(
+          `[chanapp-link] email re-verify failed app=${appId}`,
+        );
+        return { ok: false, reason: "attach" };
+      }
+    }
+
+    this.logger.log(
+      `[chanapp-link] account linked app=${appId} installation=${installationId}`,
+    );
+
+    // Best-effort confirmation DM — fire-and-forget so the success page renders
+    // immediately (never blocks / fails the linking result).
+    void this.postConfirmationDm(installationId, replyChannel, replyThreadTs, email);
+
+    return { ok: true, email };
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Confirmation DM (best-effort)
+  // ───────────────────────────────────────────────────────────────────────
+
+  private async postConfirmationDm(
+    installationId: string,
+    channel: string,
+    threadTs: string | null,
+    email: string,
+  ): Promise<void> {
+    try {
+      if (!installationId || !channel) return;
+      const installation =
+        await this.prisma.platosChannelInstallation.findUnique({
+          where: { id: String(installationId) },
+        });
+      if (!installation) return;
+      const botToken = this.decryptSecretField(installation.botToken);
+      if (!botToken) return;
+      const body: Record<string, unknown> = {
+        channel,
+        text: `✅ Account linked — I now know you as ${email}`,
+      };
+      if (threadTs) body.thread_ts = threadTs;
+      const res = await fetch("https://slack.com/api/chat.postMessage", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Bearer ${botToken}`,
+        },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(10_000),
+      });
+      let json: any = null;
+      try {
+        json = await res.json();
+      } catch {
+        /* non-JSON — treat as failure below */
+      }
+      if (!json?.ok) {
+        this.logger.warn(
+          `[chanapp-link] confirmation DM rejected error=${json?.error ?? res.status}`,
+        );
+      }
+    } catch {
+      this.logger.warn(
+        `[chanapp-link] confirmation DM failed installation=${installationId}`,
+      );
+    }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Helpers (mirror channel-app-oauth.controller.ts / channel-runtime.service.ts)
+  // ───────────────────────────────────────────────────────────────────────
+
+  private nonceKey(nonce: string): string {
+    return `chanapp:link:${nonce}`;
+  }
+
+  private callbackUrl(origin: string): string {
+    return `${origin}/api/v1/channels/link/callback`;
+  }
+
+  private async loadApp(appId: string): Promise<any | null> {
+    if (!appId) return null;
+    try {
+      return await this.prisma.platosChannelApp.findUnique({
+        where: { id: String(appId) },
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Base64-decode the id_token payload (segment 1) WITHOUT signature
+   * verification and return its `nonce` claim — used ONLY to bind the token to
+   * this authorize request. Deliberately no JWKS/crypto verify: the trusted
+   * claims come from openid.connect.userInfo, not this JWT.
+   */
+  private decodeJwtNonce(idToken: string): string | null {
+    try {
+      const parts = String(idToken).split(".");
+      if (parts.length < 2 || !parts[1]) return null;
+      const json = Buffer.from(parts[1], "base64url").toString("utf8");
+      const payload = JSON.parse(json);
+      return typeof payload?.nonce === "string" ? payload.nonce : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** PII-safe log form of an identity handle (mirrors ConversationService). */
+  private redactHandle(handle: string): string {
+    return `sha256:${crypto
+      .createHash("sha256")
+      .update(String(handle))
+      .digest("hex")
+      .slice(0, 12)}`;
+  }
+
+  private constEq(a: string, b: string): boolean {
+    if (typeof a !== "string" || typeof b !== "string") return false;
+    const ab = Buffer.from(a);
+    const bb = Buffer.from(b);
+    if (ab.length !== bb.length) return false;
+    try {
+      return crypto.timingSafeEqual(ab, bb);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Decrypt the app's ENCRYPTED clientSecret envelope → plaintext (fail-closed). */
+  private decryptSecretString(stored: unknown): string {
+    const parsed = JSON.parse(String(stored));
+    const decrypted = this.messageCrypto.decryptJsonField(parsed);
+    // On a key mismatch decryptJsonField returns its {__platos_enc,error}
+    // envelope (an object) — treat anything non-string as a fail-closed error
+    // rather than POSTing a broken secret to Slack.
+    if (typeof decrypted !== "string" || !decrypted) {
+      throw new Error("secret unavailable");
+    }
+    return decrypted;
+  }
+
+  /** Decrypt a single ENCRYPTED string column → plaintext, or null (best-effort). */
+  private decryptSecretField(stored: unknown): string | null {
+    if (typeof stored !== "string" || !stored) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stored);
+    } catch {
+      return null;
+    }
+    const dec = this.messageCrypto.decryptJsonField(parsed);
+    return typeof dec === "string" && dec ? dec : null;
+  }
+
+  /**
+   * Public origin, backend-configured (never guessed client-side):
+   * PLATOS_PUBLIC_BASE_URL wins; else derived from PLATOS_AGENT_PUBLIC_WS_URL
+   * (wss://host → https://host); else null. Mirrors ChannelAppOAuthController.
+   */
+  private publicOrigin(): string | null {
+    const explicit = (process.env.PLATOS_PUBLIC_BASE_URL || "")
+      .trim()
+      .replace(/\/+$/, "");
+    if (explicit) return explicit;
+    const ws = (process.env.PLATOS_AGENT_PUBLIC_WS_URL || "")
+      .trim()
+      .replace(/\/+$/, "");
+    if (ws.startsWith("wss://")) return `https://${ws.slice(6)}`;
+    if (ws.startsWith("ws://")) return `http://${ws.slice(5)}`;
+    return null;
+  }
+}
+
+/**
+ * The HTTP surface for the hosted linking flow. Thin: rate-limit → delegate to
+ * ChannelLinkService → render a self-contained HTML page (or 302). The static
+ * `/callback` route is declared BEFORE the `/:nonce` route so Express matches it
+ * first, and `/:nonce` additionally requires a 64-hex-char nonce (so "callback"
+ * can never be mistaken for a nonce).
+ */
+@Controller()
+export class ChannelLinkController {
+  private readonly logger = new Logger(ChannelLinkController.name);
+
+  private static readonly RL_WINDOW_SECONDS = 300;
+
+  constructor(
+    @Inject(REDIS_TOKEN) private readonly redis: Redis,
+    private readonly linkService: ChannelLinkService,
+  ) {}
+
+  // ── GET /callback — declared first so it wins over /:nonce ────────────────
+  @Get("api/v1/channels/link/callback")
+  async callback(
+    @Req() req: ExpressRequest,
+    @Query("code") code: string | undefined,
+    @Query("state") state: string | undefined,
+    @Res() res: ExpressResponse,
+  ): Promise<void> {
+    if (await this.rateLimited(req)) {
+      this.sendPage(
+        res,
+        429,
+        "Too many requests",
+        "Too many attempts from your network. Please try again in a few minutes.",
+      );
+      return;
+    }
+
+    if (typeof code !== "string" || !code || typeof state !== "string" || !state) {
+      this.sendPage(
+        res,
+        400,
+        "Sign-in incomplete",
+        "Slack did not return the information needed to finish linking. Please start again from Slack.",
+      );
+      return;
+    }
+
+    const result = await this.linkService.completeCallback(code, state);
+    if (result.ok) {
+      this.sendPage(
+        res,
+        200,
+        "Account linked",
+        `You're all set — your account is now linked as ${this.htmlEscape(
+          result.email,
+        )}. You can close this tab and return to Slack.`,
+      );
+      return;
+    }
+
+    switch (result.reason) {
+      case "expired":
+        this.sendPage(
+          res,
+          403,
+          "Link expired",
+          "This linking request has expired or was already used. Please start again from Slack.",
+        );
+        return;
+      case "mismatch":
+        this.sendPage(
+          res,
+          403,
+          "Identity mismatch",
+          "We couldn't verify that this Slack account matches the one that started linking. Please start again from Slack.",
+        );
+        return;
+      case "slack":
+        this.sendPage(
+          res,
+          502,
+          "Couldn't reach Slack",
+          "We couldn't complete the sign-in with Slack. Please try again.",
+        );
+        return;
+      case "attach":
+        this.sendPage(
+          res,
+          500,
+          "Couldn't finish linking",
+          "We verified your account but couldn't finish linking just now. Please try again.",
+        );
+        return;
+      case "conflict":
+        this.sendPage(
+          res,
+          409,
+          "Email already linked",
+          "This email address is already connected to a different account here, so we couldn't finish linking. Please contact the app owner to resolve it.",
+        );
+        return;
+      case "config":
+      default:
+        this.sendPage(
+          res,
+          500,
+          "Not configured",
+          "This linking flow is not fully configured. Please contact the app owner.",
+        );
+        return;
+    }
+  }
+
+  // ── GET /:nonce — redirect into Slack SIWS ────────────────────────────────
+  @Get("api/v1/channels/link/:nonce")
+  async redirect(
+    @Req() req: ExpressRequest,
+    @Param("nonce") nonce: string,
+    @Res() res: ExpressResponse,
+  ): Promise<void> {
+    if (await this.rateLimited(req)) {
+      this.sendPage(
+        res,
+        429,
+        "Too many requests",
+        "Too many attempts from your network. Please try again in a few minutes.",
+      );
+      return;
+    }
+
+    // A nonce is 32 random bytes hex = 64 lowercase hex chars. This also rejects
+    // the sibling static segment "callback" outright.
+    if (!/^[a-f0-9]{64}$/.test(String(nonce))) {
+      this.sendPage(
+        res,
+        404,
+        "Link not found",
+        "This link is no longer valid. Please start again from Slack.",
+      );
+      return;
+    }
+
+    const out = await this.linkService.buildAuthorizeRedirect(nonce);
+    if ("redirectUrl" in out) {
+      res.redirect(302, out.redirectUrl);
+      return;
+    }
+    if (out.error === "not_found") {
+      this.sendPage(
+        res,
+        403,
+        "Link expired",
+        "This linking request has expired or was already used. Please start again from Slack.",
+      );
+      return;
+    }
+    this.sendPage(
+      res,
+      500,
+      "Not configured",
+      "This linking flow is not fully configured. Please contact the app owner.",
+    );
+  }
+
+  // ── Per-IP rate limit (mirrors ChannelAppOAuthController) ─────────────────
+  // Anonymous surface; RateLimitGuard never sees it (no request.scope). Fixed
+  // 5-min bucket, Redis INCR + first-hit EXPIRE. Fails OPEN on a Redis blip.
+  private async rateLimited(req: ExpressRequest): Promise<boolean> {
+    const limit =
+      Number(process.env.PLATOS_CHANNEL_LINK_IP_LIMIT) > 0
+        ? Number(process.env.PLATOS_CHANNEL_LINK_IP_LIMIT)
+        : 30;
+    const windowSeconds = ChannelLinkController.RL_WINDOW_SECONDS;
+    const ip = this.clientIp(req);
+    try {
+      const bucket = Math.floor(Date.now() / (windowSeconds * 1000));
+      const key = `chanapp:link:rl:${ip}:${bucket}`;
+      const count = await this.redis.incr(key);
+      if (count === 1) {
+        await this.redis.expire(key, windowSeconds).catch(() => undefined);
+      }
+      if (count > limit) {
+        this.logger.warn(`[chanapp-link] rate limit exceeded ip=${ip}`);
+        return true;
+      }
+      return false;
+    } catch {
+      return false; // Redis hiccup — fail open, same policy as the OAuth slice.
+    }
+  }
+
+  private clientIp(req: ExpressRequest): string {
+    const xff = req.headers["x-forwarded-for"];
+    if (typeof xff === "string" && xff.length > 0) {
+      const first = xff.split(",")[0]?.trim();
+      if (first) return first;
+    }
+    if (Array.isArray(xff) && xff.length > 0) {
+      const first = xff[0]?.trim();
+      if (first) return first;
+    }
+    return req.socket?.remoteAddress || "unknown";
+  }
+
+  // ── Self-contained, theme-neutral HTML responses (mirror the OAuth slice) ─
+  private sendPage(
+    res: ExpressResponse,
+    status: number,
+    heading: string,
+    message: string,
+  ): void {
+    res.status(status).type("html").send(this.renderPage(heading, message));
+  }
+
+  private renderPage(heading: string, message: string): string {
+    return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${this.htmlEscape(heading)}</title>
+<style>
+  :root { color-scheme: light dark; }
+  html,body { margin:0; height:100%; }
+  body {
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    display:flex; align-items:center; justify-content:center; min-height:100%;
+    background:#f5f6f8; color:#1f2430; padding:24px;
+  }
+  .card {
+    max-width:440px; width:100%; background:#fff; border-radius:14px;
+    box-shadow:0 8px 30px rgba(0,0,0,.08); padding:32px; text-align:center;
+  }
+  h1 { font-size:20px; margin:0 0 12px; }
+  p { margin:0; color:#5b6472; }
+  @media (prefers-color-scheme: dark) {
+    body { background:#0f1115; color:#e6e8ec; }
+    .card { background:#171a21; box-shadow:0 8px 30px rgba(0,0,0,.5); }
+    p { color:#a4adba; }
+  }
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>${this.htmlEscape(heading)}</h1>
+    <p>${message}</p>
+  </div>
+</body>
+</html>`;
+  }
+
+  private htmlEscape(s: string): string {
+    return String(s).replace(/[&<>"']/g, (c) =>
+      c === "&"
+        ? "&amp;"
+        : c === "<"
+          ? "&lt;"
+          : c === ">"
+            ? "&gt;"
+            : c === '"'
+              ? "&quot;"
+              : "&#39;",
+    );
+  }
+}

--- a/apps/agent/src/channels/channel-runtime.service.ts
+++ b/apps/agent/src/channels/channel-runtime.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   Logger,
   Inject,
+  Optional,
   type OnModuleInit,
   type OnModuleDestroy,
 } from "@nestjs/common";
@@ -17,6 +18,13 @@ import {
   setAssistantSuggestedPrompts,
   setAssistantTitle,
 } from "./slack-assistant.api";
+// Connect v3 (Phase C) — hosted account linking. The link/unlink START of the
+// hosted SIWS flow lives in the OTHER slice's controller; this service CONSUMES
+// it via constructor DI. Injected @Optional() (see constructor) so that until
+// that slice lands — or in a focused test module that omits it — the service
+// degrades to `linking:none` behavior (no connect URLs, no gate) instead of
+// failing to construct.
+import { ChannelLinkService } from "./channel-link.controller";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Chat SDK (v4.34) — RUNTIME + BRIDGE slice.
@@ -215,6 +223,14 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
    */
   private readonly appCache = new Map<string, CachedAppCreds>();
   private readonly TTL_MS = 10 * 60 * 1000; // 10 min
+  /**
+   * Connect v3 (Phase C) — POSITIVE account-link memo: `installationId:slackHandle`
+   * → expiry epoch-ms. A `linking:required` app checks per message whether the
+   * author's slack person has a verified email link; a hit is cached for 10 min
+   * so the two-query lookup doesn't run on every turn. NEGATIVES are never cached
+   * (a user who links mid-conversation is unblocked on their very next message).
+   */
+  private readonly linkStatusCache = new Map<string, number>();
   /** Discord keep-warm sweep cadence (see onModuleInit). */
   private readonly DISCORD_WARM_INTERVAL_MS = 60 * 1000;
   private discordWarmTimer: ReturnType<typeof setInterval> | null = null;
@@ -224,6 +240,11 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
     private readonly messageCrypto: MessageCryptoService,
     private readonly conversationService: ConversationService,
     private readonly agentTaskService: AgentTaskService,
+    // Connect v3 (Phase C) — owned by the link-controller slice. @Optional so its
+    // absence degrades cleanly to `linking:none` (no connect URLs surfaced).
+    @Optional()
+    @Inject(ChannelLinkService)
+    private readonly channelLinkService?: ChannelLinkService,
   ) {}
 
   // ───────────────────────────────────────────────────────────────────────
@@ -971,6 +992,36 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
       userId: this.appConversationUserId(installationId, parsed.channelThreadKey),
     };
 
+    // ── Connect v3 (Phase C) — account-linking commands + policy gate ─────
+    // BEFORE any turn work: link/connect/unlink commands bypass the LLM, and a
+    // `linking:required` app withholds the turn for an unlinked author (posting
+    // the connect URL instead). Placed ahead of thread binding so a blocked /
+    // command message never mints a Platos thread or resolves an end-user. A
+    // `linking:none` app returns `proceed=true` immediately (zero behavior
+    // change). `isAssistantThread` is computed here (the same predicate the
+    // reply path uses) so a handled message can clear the assistant status.
+    const isAssistantThread =
+      parsed.channel.startsWith("D") && !!parsed.replyThreadTs;
+    // Originating WORKSPACE team id ("T…") off the signature-verified envelope
+    // (same derivation as the events controller). Needed by the SIWS callback's
+    // identity match: for an Enterprise Grid ORG-LEVEL install `team` is the
+    // "E…" enterprise id, but openid.connect.userInfo always returns the
+    // user's workspace id — matching against `team` there can never succeed.
+    const eventTeamId = String(
+      envelope?.team_id ?? envelope?.authorizations?.[0]?.team_id ?? "",
+    );
+    const proceed = await this.applyLinkingGate(app, installation, authorScope, botToken, {
+      team,
+      eventTeamId,
+      slackUserId: parsed.user,
+      slackHandle: handle,
+      text: parsed.text,
+      replyChannel: parsed.channel,
+      replyThreadTs: parsed.replyThreadTs,
+      isAssistantThread,
+    });
+    if (!proceed) return;
+
     // ── Resolve or create the (pinned) agent + Platos thread ──────────────
     let agentId: string;
     let platosThreadId: string;
@@ -999,8 +1050,7 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
     // status before the turn; the reply's chat.postMessage clears it
     // automatically. A plain DM (no thread_ts) is NOT an assistant thread and
     // keeps its existing behavior (no status). Never fails the turn.
-    const isAssistantThread =
-      parsed.channel.startsWith("D") && !!parsed.replyThreadTs;
+    // (`isAssistantThread` was computed above for the linking gate.)
     if (isAssistantThread) {
       try {
         await setAssistantStatus(
@@ -1464,6 +1514,279 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
       this.logger.error(
         `[channel-apps] chat.postMessage rejected channel=${channel} error=${json?.error ?? res.status}`,
       );
+    }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // CONNECT v3 (Phase C) — hosted account linking (bridge side)
+  //
+  // Three modes on PlatosChannelApp.linking:
+  //   none     — passthrough; not even the commands intercept (zero change).
+  //   optional — link/connect/unlink commands work; a turn is NEVER withheld.
+  //   required — commands work AND an unlinked author's turn is withheld until
+  //              they complete Sign in with Slack (a verified email identity on
+  //              the same canonical person). The hosted flow itself (nonce mint,
+  //              SIWS redirect, OIDC callback, identity attach) lives in the
+  //              link-controller slice; here we only START it and READ its
+  //              result off PlatosEndUserIdentity.
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Linking commands + policy gate, run BEFORE the turn. Returns `true` when the
+   * caller should proceed to run the normal agent turn, or `false` when this
+   * message was fully handled here (a link/connect/unlink command, or a withheld
+   * turn under `linking:required`).
+   *
+   * Command matching is a case-insensitive EXACT match on the trimmed text, so
+   * it fires for bare DM / assistant-thread text ("link") but NOT for a channel
+   * app_mention (whose text carries the `<@BOT>` prefix) — matching the "DM +
+   * assistant threads" contract without a surface special-case.
+   */
+  private async applyLinkingGate(
+    app: any,
+    installation: any,
+    scope: { organizationId: string; projectId: string; environmentId: string },
+    botToken: string,
+    ctx: {
+      team: string;
+      /** Originating workspace team id ("T…") from the event envelope (may be ""). */
+      eventTeamId?: string;
+      slackUserId: string;
+      /** `team:slackUserId` — the slack channel identity handle. */
+      slackHandle: string;
+      text: string;
+      replyChannel: string;
+      replyThreadTs?: string;
+      isAssistantThread: boolean;
+    },
+  ): Promise<boolean> {
+    // The hosted flow itself is owned by the link-controller slice (injected
+    // @Optional). If it isn't wired, the ENTIRE feature degrades to `none`
+    // (zero behavior change) — including the commands, which would otherwise
+    // surface a dead "not available" reply or a half-working unlink. This is
+    // the mandated "absence degrades to linking:none behavior" contract.
+    if (!this.channelLinkService) return true;
+
+    const linking = typeof app?.linking === "string" ? app.linking : "none";
+    // `none` (default) — zero behavior change: no command interception, no gate.
+    if (linking !== "optional" && linking !== "required") return true;
+
+    const command = ctx.text.trim().toLowerCase();
+
+    // ── Commands (bypass the LLM entirely) — active in optional + required ──
+    if (command === "link" || command === "connect") {
+      const url = await this.linkStartUrl(app, installation, ctx);
+      await this.postSlackMessage(
+        botToken,
+        ctx.replyChannel,
+        ctx.replyThreadTs,
+        url
+          ? `🔗 Connect your account: ${url}`
+          : "Account linking isn't available right now. Please try again later.",
+      );
+      if (ctx.isAssistantThread) await this.clearAssistantStatus(botToken, ctx);
+      return false;
+    }
+    if (command === "unlink") {
+      const removed = await this.unlinkEmailIdentities(scope, ctx.slackHandle);
+      // Drop the positive memo so a `required` app re-gates on the next message.
+      this.linkStatusCache.delete(this.linkCacheKey(installation, ctx.slackHandle));
+      await this.postSlackMessage(
+        botToken,
+        ctx.replyChannel,
+        ctx.replyThreadTs,
+        removed > 0
+          ? `✅ Unlinked — removed ${removed} linked email ${removed === 1 ? "identity" : "identities"}.`
+          : "You don't have a linked account to remove.",
+      );
+      if (ctx.isAssistantThread) await this.clearAssistantStatus(botToken, ctx);
+      return false;
+    }
+
+    // ── Policy gate — only `required` withholds a turn ─────────────────────
+    if (linking !== "required") return true; // optional never blocks
+
+    const linked = await this.isSlackUserLinked(installation, scope, ctx.slackHandle);
+    if (linked) return true;
+
+    const url = await this.linkStartUrl(app, installation, ctx);
+    await this.postSlackMessage(
+      botToken,
+      ctx.replyChannel,
+      ctx.replyThreadTs,
+      url
+        ? `🔗 Connect your account to continue: ${url}`
+        : "This assistant requires a linked account, but linking isn't available right now. Please try again later.",
+    );
+    if (ctx.isAssistantThread) await this.clearAssistantStatus(botToken, ctx);
+    return false;
+  }
+
+  /** Positive-link memo cache key. `team:slackUserId` already encodes the user. */
+  private linkCacheKey(installation: any, slackHandle: string): string {
+    return `${String(installation?.id ?? "")}:${slackHandle}`;
+  }
+
+  /**
+   * Start the hosted link flow via the OTHER slice's ChannelLinkService and
+   * return its connect URL, or null when the service is absent (feature not yet
+   * wired) or the call fails. Best-effort — never throws to the caller.
+   */
+  private async linkStartUrl(
+    app: any,
+    installation: any,
+    ctx: {
+      team: string;
+      eventTeamId?: string;
+      slackUserId: string;
+      replyChannel: string;
+      replyThreadTs?: string;
+    },
+  ): Promise<string | null> {
+    if (!this.channelLinkService) return null;
+    try {
+      // NOTE: the live ChannelLinkService.linkStart takes `{teamId, slackUserId,
+      // channel, threadTs}` (it maps channel→replyChannel / threadTs→replyThreadTs
+      // into its Redis nonce payload internally). The task brief named the last
+      // two `replyChannel`/`replyThreadTs`, but the merged controller is the
+      // ground truth and TypeScript enforces its shape — so pass channel/threadTs.
+      const url = await this.channelLinkService.linkStart(app, installation, {
+        teamId: ctx.team,
+        slackUserId: ctx.slackUserId,
+        channel: ctx.replyChannel,
+        threadTs: ctx.replyThreadTs,
+        // Workspace "T…" id off the event envelope — lets the SIWS callback
+        // match userInfo's team_id for Enterprise Grid org-level installs
+        // (where ctx.team is the "E…" enterprise id and could never match).
+        eventTeamId: ctx.eventTeamId || null,
+      });
+      return typeof url === "string" && url ? url : null;
+    } catch {
+      this.logger.error(
+        `[channel-apps] linkStart failed app=${String(app?.id ?? "")}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * True when the slack person (`team:slackUserId`) resolves to a canonical
+   * PlatosEndUser who ALSO carries a verified email-channel identity — i.e. they
+   * completed Sign in with Slack. Two scoped queries: slack handle row →
+   * platosEndUserId → any verified email row on that person. Positive results
+   * are memoized 10 min per (installation, slackHandle); negatives are not.
+   *
+   * FAIL CLOSED: on a DB error we return false (treat as unlinked). For a
+   * `required` gate the correct posture is "no positive confirmation ⇒ no turn"
+   * — surfacing the connect URL on a transient blip is safer than admitting an
+   * unverified user, and the turn would very likely fail on the same blip anyway.
+   */
+  private async isSlackUserLinked(
+    installation: any,
+    scope: { organizationId: string; projectId: string; environmentId: string },
+    slackHandle: string,
+  ): Promise<boolean> {
+    const key = this.linkCacheKey(installation, slackHandle);
+    const now = Date.now();
+    const memo = this.linkStatusCache.get(key);
+    if (memo && memo > now) return true;
+    if (memo && memo <= now) this.linkStatusCache.delete(key); // prune stale
+
+    try {
+      const slackRow = await this.prisma.platosEndUserIdentity.findUnique({
+        where: {
+          organizationId_projectId_environmentId_channel_handle: {
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+            channel: "slack",
+            handle: slackHandle,
+          },
+        },
+        select: { platosEndUserId: true },
+      });
+      if (!slackRow?.platosEndUserId) return false;
+
+      const emailRow = await this.prisma.platosEndUserIdentity.findFirst({
+        where: {
+          organizationId: scope.organizationId,
+          projectId: scope.projectId,
+          environmentId: scope.environmentId,
+          platosEndUserId: slackRow.platosEndUserId,
+          channel: "email",
+          verified: true,
+        },
+        select: { id: true },
+      });
+      if (emailRow) {
+        this.linkStatusCache.set(key, now + this.TTL_MS);
+        return true;
+      }
+      return false;
+    } catch {
+      this.logger.error("[channel-apps] link-status lookup failed");
+      return false; // fail closed — see docstring
+    }
+  }
+
+  /**
+   * `unlink` command (safe v1): delete the email-channel identity rows attached
+   * to the canonical person behind this slack handle. We deliberately do NOT
+   * delete the slack identity or the person, and we do NOT distinguish
+   * SIWS-created email rows from any other email identity on that person — the
+   * only email identities that ever land on a channel-app person are the ones
+   * this hosted flow attaches, so deleting all of them is both the simplest and
+   * the correct v1 behavior. Returns the number of rows removed. Scoped to the
+   * app owner; best-effort (never throws).
+   */
+  private async unlinkEmailIdentities(
+    scope: { organizationId: string; projectId: string; environmentId: string },
+    slackHandle: string,
+  ): Promise<number> {
+    try {
+      const slackRow = await this.prisma.platosEndUserIdentity.findUnique({
+        where: {
+          organizationId_projectId_environmentId_channel_handle: {
+            organizationId: scope.organizationId,
+            projectId: scope.projectId,
+            environmentId: scope.environmentId,
+            channel: "slack",
+            handle: slackHandle,
+          },
+        },
+        select: { platosEndUserId: true },
+      });
+      if (!slackRow?.platosEndUserId) return 0;
+
+      const { count } = await this.prisma.platosEndUserIdentity.deleteMany({
+        where: {
+          organizationId: scope.organizationId,
+          projectId: scope.projectId,
+          environmentId: scope.environmentId,
+          platosEndUserId: slackRow.platosEndUserId,
+          channel: "email",
+        },
+      });
+      this.logger.log(
+        `[channel-apps] unlink removed ${count} email identity row(s)`,
+      );
+      return count;
+    } catch {
+      this.logger.error("[channel-apps] unlink failed");
+      return 0;
+    }
+  }
+
+  /** Best-effort: clear a lingering assistant-thread status (empty string). */
+  private async clearAssistantStatus(
+    botToken: string,
+    ctx: { replyChannel: string; replyThreadTs?: string },
+  ): Promise<void> {
+    if (!ctx.replyThreadTs) return;
+    try {
+      await setAssistantStatus(botToken, ctx.replyChannel, ctx.replyThreadTs, "");
+    } catch {
+      /* best-effort */
     }
   }
 

--- a/apps/agent/src/channels/channels.module.ts
+++ b/apps/agent/src/channels/channels.module.ts
@@ -2,6 +2,10 @@ import { Module } from "@nestjs/common";
 import { ChannelsInboundController } from "./channels-inbound.controller";
 import { ChannelAppOAuthController } from "./channel-app-oauth.controller";
 import { ChannelAppEventsController } from "./channel-app-events.controller";
+import {
+  ChannelLinkController,
+  ChannelLinkService,
+} from "./channel-link.controller";
 import { ChannelRuntimeService } from "./channel-runtime.service";
 import { AgentRuntimeModule } from "../agent-runtime/agent-runtime.module";
 import { MemoryModule } from "../memory/memory.module";
@@ -16,6 +20,12 @@ import { MonitoringModule } from "../monitoring/monitoring.module";
  *   - ChannelAppEventsController — the single Slack Events API request URL per
  *     app (public; Slack v0 signature verify + event_id dedupe, hands verified
  *     events to ChannelRuntimeService.handleAppEvent).
+ *   - ChannelLinkController / ChannelLinkService — Phase C hosted account
+ *     linking (public; single-use Redis nonce + Sign-in-with-Slack OIDC +
+ *     userInfo-authoritative claims → verified email identity attach — see
+ *     scope.guard.ts allowlist `/api/v1/channels/link/`). ChannelLinkService is
+ *     EXPORTED so ChannelRuntimeService can call `linkStart(...)` from the
+ *     policy gate / `link` command (item (3)).
  *
  * Dependencies (all via already-exporting feature modules — nothing new
  * provided here except the channel components):
@@ -37,8 +47,9 @@ import { MonitoringModule } from "../monitoring/monitoring.module";
     ChannelsInboundController,
     ChannelAppOAuthController,
     ChannelAppEventsController,
+    ChannelLinkController,
   ],
-  providers: [ChannelRuntimeService],
-  exports: [ChannelRuntimeService],
+  providers: [ChannelRuntimeService, ChannelLinkService],
+  exports: [ChannelRuntimeService, ChannelLinkService],
 })
 export class ChannelsModule {}

--- a/apps/agent/src/main.ts
+++ b/apps/agent/src/main.ts
@@ -185,6 +185,13 @@ async function bootstrap() {
     // /api/v1/channels/oauth prefix is GET-only, so the method check above
     // already skips it.
     { prefix: "/api/v1/channels/apps", cap: CHANNELS_BODY_CAP_BYTES },
+    // Connect v3 Phase C hosted account linking (/api/v1/channels/link/*). This
+    // is the same unauthenticated-bypass family; the caps list matches by exact
+    // prefix, and neither of the entries above covers `/link`. The link routes
+    // are GET-only today (the method check above skips them), so this is a
+    // forward-guard: if a POST link route is ever added, it inherits the same
+    // 1MB cap instead of falling back to the effectively-unbounded 15mb parser.
+    { prefix: "/api/v1/channels/link", cap: CHANNELS_BODY_CAP_BYTES },
   ];
   app.use((req: any, res: any, next: () => void) => {
     const method = req.method;

--- a/apps/agent/src/mcp-platform/tools/channel-apps.ts
+++ b/apps/agent/src/mcp-platform/tools/channel-apps.ts
@@ -28,6 +28,8 @@ import { validateAgentRouting } from "../../agent-runtime/channel-routing";
 
 const APP_PROVIDERS = new Set(["slack"]);
 const DISTRIBUTIONS = new Set(["private", "public"]);
+// Connect v3 (Phase C) — hosted account-linking policy.
+const LINKING = new Set(["none", "optional", "required"]);
 const OAUTH_BASE = "/api/v1/channels/oauth";
 
 function scopeTuple(scope: RequestScope) {
@@ -183,8 +185,17 @@ export function buildChannelAppToolHandlers(deps: {
         "`app_mentions:read` (mention-bot fallback). Also enable the app's " +
         "\"Agents & AI Apps\" toggle in the Slack app config so the split-view " +
         "assistant panel + assistant_thread_started events are delivered. " +
-        "Returns the app row (secrets redacted → `hasClientSecret` / " +
-        "`hasSigningSecret`) plus `installUrl` — the Add-to-Slack href.",
+        "`linking` (none|optional|required, default none) sets the hosted " +
+        "account-linking policy: `optional` surfaces a \"Connect your account\" " +
+        "URL when a user types link/connect (and honours unlink); `required` " +
+        "additionally WITHHOLDS an unlinked user's turns until they complete " +
+        "Sign in with Slack (attaching a verified email identity to the same " +
+        "person). SIWS reuses this app's Slack client credentials, so register " +
+        "the extra OIDC redirect URL " +
+        "`<publicOrigin>/api/v1/channels/link/callback` in the Slack app's " +
+        "Redirect URLs. Returns the app row (secrets redacted → " +
+        "`hasClientSecret` / `hasSigningSecret`) plus `installUrl` — the " +
+        "Add-to-Slack href.",
       inputSchema: {
         type: "object",
         required: ["clientId", "clientSecret", "signingSecret"],
@@ -197,6 +208,13 @@ export function buildChannelAppToolHandlers(deps: {
           scopes: { type: "array", items: { type: "string" } },
           distribution: { type: "string", enum: ["private", "public"] },
           aiAppsSurface: { type: "boolean" },
+          linking: {
+            type: "string",
+            enum: ["none", "optional", "required"],
+            description:
+              "Hosted account-linking policy (default none). required also needs " +
+              "<publicOrigin>/api/v1/channels/link/callback in the Slack app's Redirect URLs.",
+          },
           defaultAgentId: { type: "string" },
           agentRouting: {
             type: "array",
@@ -239,6 +257,10 @@ export function buildChannelAppToolHandlers(deps: {
           : "private";
         const aiAppsSurface =
           typeof params["aiAppsSurface"] === "boolean" ? params["aiAppsSurface"] : undefined;
+        const linking =
+          params["linking"] !== undefined
+            ? String(params["linking"]).trim().toLowerCase()
+            : undefined;
         const defaultAgentId =
           typeof params["defaultAgentId"] === "string" ? params["defaultAgentId"].trim() : "";
         const routingProvided =
@@ -250,6 +272,7 @@ export function buildChannelAppToolHandlers(deps: {
           clientId,
           displayName,
           distribution,
+          ...(linking !== undefined ? { linking } : {}),
           hasClientSecret: !!clientSecret,
           hasSigningSecret: !!signingSecret,
           scopeCount: scopes?.length ?? 0,
@@ -269,6 +292,11 @@ export function buildChannelAppToolHandlers(deps: {
         }
         if (!DISTRIBUTIONS.has(distribution)) {
           const err = "distribution must be private | public";
+          auditMutation(scope, "channel_apps.create", auditArgs, null, "failed", startedAt, err);
+          return { error: "invalid_params", message: err };
+        }
+        if (linking !== undefined && !LINKING.has(linking)) {
+          const err = "linking must be none | optional | required";
           auditMutation(scope, "channel_apps.create", auditArgs, null, "failed", startedAt, err);
           return { error: "invalid_params", message: err };
         }
@@ -315,6 +343,7 @@ export function buildChannelAppToolHandlers(deps: {
               ...(displayName !== undefined ? { displayName } : {}),
               ...(scopes !== undefined ? { scopes } : {}),
               ...(aiAppsSurface !== undefined ? { aiAppsSurface } : {}),
+              ...(linking !== undefined ? { linking } : {}),
               ...(defaultAgentId ? { defaultAgentId } : {}),
               ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
             },
@@ -394,10 +423,13 @@ export function buildChannelAppToolHandlers(deps: {
         "recommend `assistant:write` + `im:history` + `chat:write` + " +
         "`app_mentions:read`, and enable the app's \"Agents & AI Apps\" " +
         "toggle), `distribution` (private|public), `aiAppsSurface` (bool), " +
-        "`defaultAgentId` (string|null to clear — validated in-scope), " +
-        "`agentRouting` (array of `{match, agentId}` rules | null to clear). " +
-        "Scope-pinned — cross-scope ids return `{ error: 'not_found' }`. " +
-        "Returns the updated row with secrets redacted.",
+        "`linking` (none|optional|required — the hosted account-linking policy; " +
+        "`required` withholds unlinked users' turns until they Sign in with " +
+        "Slack, and needs <publicOrigin>/api/v1/channels/link/callback in the " +
+        "Slack app's Redirect URLs), `defaultAgentId` (string|null to clear — " +
+        "validated in-scope), `agentRouting` (array of `{match, agentId}` rules " +
+        "| null to clear). Scope-pinned — cross-scope ids return " +
+        "`{ error: 'not_found' }`. Returns the updated row with secrets redacted.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -410,6 +442,13 @@ export function buildChannelAppToolHandlers(deps: {
           scopes: { type: "array", items: { type: "string" } },
           distribution: { type: "string", enum: ["private", "public"] },
           aiAppsSurface: { type: "boolean" },
+          linking: {
+            type: "string",
+            enum: ["none", "optional", "required"],
+            description:
+              "Hosted account-linking policy. required also needs " +
+              "<publicOrigin>/api/v1/channels/link/callback in the Slack app's Redirect URLs.",
+          },
           defaultAgentId: { type: ["string", "null"] },
           agentRouting: {
             type: ["array", "null"],
@@ -456,6 +495,9 @@ export function buildChannelAppToolHandlers(deps: {
             : {}),
           ...(typeof params["aiAppsSurface"] === "boolean"
             ? { aiAppsSurface: params["aiAppsSurface"] }
+            : {}),
+          ...(typeof params["linking"] === "string"
+            ? { linking: params["linking"] }
             : {}),
           ...(Object.prototype.hasOwnProperty.call(params, "defaultAgentId")
             ? { defaultAgentId: params["defaultAgentId"] }
@@ -515,6 +557,15 @@ export function buildChannelAppToolHandlers(deps: {
         }
         if (typeof params["aiAppsSurface"] === "boolean") {
           data.aiAppsSurface = params["aiAppsSurface"];
+        }
+        if (typeof params["linking"] === "string") {
+          const linking = params["linking"].trim().toLowerCase();
+          if (!LINKING.has(linking)) {
+            const err = "linking must be none | optional | required";
+            auditMutation(scope, "channel_apps.update", auditArgs, null, "failed", startedAt, err);
+            return { error: "invalid_params", message: err };
+          }
+          data.linking = linking;
         }
         if (Object.prototype.hasOwnProperty.call(params, "defaultAgentId")) {
           const raw = params["defaultAgentId"];

--- a/internal-packages/database/prisma/migrations/20260722120000_channel_linking/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260722120000_channel_linking/migration.sql
@@ -1,0 +1,15 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Connect v3 (Phase C) — hosted account linking policy on a channel APP.
+--
+-- `linking` declares whether end-users must attach a VERIFIED email identity
+-- (via Sign in with Slack / OIDC) before an agent turn runs:
+--   none     — no linking behavior (default; zero behavior change).
+--   optional — never blocks a turn; the connect URL is surfaced on demand.
+--   required — an unlinked author's turn is withheld until they connect.
+--
+-- Bindings are PlatosEndUserIdentity rows (existing); the hosted flow's link
+-- nonces live in Redis. NO new tables. Idempotent (IF NOT EXISTS) so a partial
+-- re-run is safe.
+-- ═══════════════════════════════════════════════════════════════════════════════
+ALTER TABLE "public"."PlatosChannelApp"
+    ADD COLUMN IF NOT EXISTS "linking" TEXT NOT NULL DEFAULT 'none';

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -3823,6 +3823,16 @@ model PlatosChannelApp {
   // than a bare app_mention bot. Default on for new apps.
   aiAppsSurface Boolean @default(true)
 
+  // Connect v3 (Phase C) — hosted account-linking policy:
+  //   none     — no linking behavior (default; zero behavior change).
+  //   optional — never blocks a turn; the connect URL is surfaced only when the
+  //              user types "link"/"connect".
+  //   required — an unlinked author's turn is WITHHELD until they complete Sign
+  //              in with Slack (attaches a verified email identity to the same
+  //              canonical person). Bindings are PlatosEndUserIdentity rows;
+  //              the hosted flow's nonces live in Redis (no table here).
+  linking String @default("none")
+
   // Fallback agent for a NEW installation when the install carries no binding
   // override. A per-install `agentId` (see PlatosChannelInstallation) wins.
   defaultAgentId String?


### PR DESCRIPTION
Zero-developer-code account linking: linking policy (none/optional/required), bot-delivered connect URL, SIWS OIDC with userInfo-authoritative claims + exact team/user match (link-forgery blocked), verified-email identity unified onto the canonical Platos person, lifecycle invalidation. Fable linking-security gate clean; deployed + PHASE_C_LIVE verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)