### PR TITLE
feat(connect-v3): Phase D — BYO manifest-mint + token rotation + Grid polish

### DIFF
--- a/apps/agent/src/agent-runtime/channels.controller.ts
+++ b/apps/agent/src/agent-runtime/channels.controller.ts
@@ -10,6 +10,7 @@ import {
   HttpException,
   HttpStatus,
   Inject,
+  Logger,
 } from "@nestjs/common";
 import { type Request } from "express";
 import { ModuleRef } from "@nestjs/core";
@@ -44,8 +45,85 @@ import { validateAgentRouting } from "./channel-routing";
 const CHANNEL_PROVIDERS = new Set(["slack", "telegram", "whatsapp", "discord"]);
 const WEBHOOK_BASE = "/api/v1/channels/inbound";
 
+// ── Connect v3 (Phase D) — BYO app mint via the Slack App Manifest API ────────
+// `apps.manifest.create` requires a MANUALLY-generated App Configuration Token
+// (xoxe.xoxp-… access + xoxe-… refresh, 12h TTL, created by the user at
+// api.slack.com/apps → "Your App Configuration Tokens"). There is NO
+// delegated/OAuth path to mint config tokens, so the one paste is unavoidable.
+const SLACK_MANIFEST_CREATE_URL = "https://slack.com/api/apps.manifest.create";
+const SLACK_HTTP_TIMEOUT_MS = 10_000;
+// Bot scopes = the Phase-A/B recommended AI-Apps set. `assistant:write` unlocks
+// assistant.threads.setStatus/setTitle/setSuggestedPrompts; `im:history` reads
+// the assistant DM thread; `chat:write` posts replies; `app_mentions:read` is
+// the mention-bot fallback. Scope-minimized (marketplace requirement).
+const SLACK_BYO_BOT_SCOPES = [
+  "assistant:write",
+  "chat:write",
+  "im:history",
+  "app_mentions:read",
+] as const;
+// Slack caps display_information.name at 35 chars and bot_user.display_name at 80.
+const SLACK_APP_NAME_MAX = 35;
+
+/**
+ * Build a Slack app manifest for apps.manifest.create. Targets Slack's
+ * first-class "Agents & AI Apps" surface so a BYO app gets the SAME surface as
+ * the marketplace tier: presence of `features.assistant_view` turns the surface
+ * ON, `assistant:write` (in the bot scopes) unlocks assistant.threads.*, and the
+ * `assistant_thread_*` bot events deliver the panel lifecycle.
+ * `event_subscriptions.request_url` is the connection's OWN secret-bearing
+ * inbound URL — known only AFTER the row is created (the create-row-first
+ * ordering resolves that chicken-and-egg). The BYO bot token arrives later
+ * (OAuth-install or manual paste), so `token_rotation_enabled` stays false here
+ * (rotation is a marketplace-tier property: PlatosChannelApp.tokenRotation).
+ */
+function buildSlackAppManifest(appName: string, requestUrl: string) {
+  const name = appName.slice(0, SLACK_APP_NAME_MAX);
+  return {
+    display_information: { name },
+    features: {
+      app_home: {
+        home_tab_enabled: true,
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: appName.slice(0, 80),
+        always_online: true,
+      },
+      // Presence of assistant_view ENABLES the "Agents & AI Apps" surface.
+      assistant_view: {
+        assistant_description: `${name} is an AI assistant available in Slack.`,
+      },
+    },
+    oauth_config: {
+      scopes: { bot: [...SLACK_BYO_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        request_url: requestUrl,
+        bot_events: [
+          "app_mention",
+          "message.im",
+          "assistant_thread_started",
+          "assistant_thread_context_changed",
+        ],
+      },
+      // No interactivity handler on the BYO connection tier (it processes
+      // message + assistant events only), so leave it off — enabling it would
+      // require a registered interactivity request_url.
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: false,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
 @Controller("api/v1/agent/channels")
 export class ChannelsController {
+  private readonly logger = new Logger(ChannelsController.name);
+
   constructor(
     @Inject(PRISMA_TOKEN) private readonly prisma: any,
     private readonly messageCrypto: MessageCryptoService,
@@ -233,6 +311,244 @@ export class ChannelsController {
       webhookPath: this.webhookPathFull(row.id, webhookSecret),
       webhookUrl: this.webhookUrlFull(row.id, webhookSecret),
     };
+  }
+
+  /**
+   * Connect v3 (Phase D) — BYO app MINT. Upgrade the manual multi-screen Slack
+   * walkthrough to "paste one config token, Platos builds your Slack app". This
+   * operates on the CONNECTION tier (PlatosChannelConnection — the customer-owned
+   * BYO app), NOT the marketplace PlatosChannelApp tier.
+   *
+   * CHICKEN-AND-EGG: the manifest's `event_subscriptions.request_url` must embed
+   * the connection's id + webhookSecret, which only exist AFTER the row is
+   * created. ORDER: (1) create the PlatosChannelConnection row (mints its
+   * webhookSecret → its inbound URL is now known), (2) call apps.manifest.create
+   * with that URL baked into the manifest, (3) store the returned
+   * client_id/client_secret/signing_secret ENCRYPTED onto the row. On a Slack
+   * rejection the half-minted row is rolled back so a mint is all-or-nothing.
+   *
+   * apps.manifest.create does NOT install the app — the bot token still arrives
+   * later via OAuth-install (returned `oauthAuthorizeUrl`) or manual paste. The
+   * config token (12h TTL) is NEVER persisted or logged; the optional refresh
+   * token is discarded too — v1 is a one-shot create, we don't keep it for a
+   * later manifest.update.
+   */
+  @Post("mint")
+  async mintFromManifest(
+    @Req() req: Request,
+    @Body()
+    body: {
+      provider?: string;
+      agentId?: string;
+      displayName?: string;
+      configToken?: string;
+      configRefreshToken?: string;
+    },
+  ) {
+    const scope = this.getScope(req);
+    requireOperator(scope);
+
+    const provider = String(body?.provider ?? "slack").trim().toLowerCase();
+    const agentId = String(body?.agentId ?? "").trim();
+    const configToken =
+      typeof body?.configToken === "string" ? body.configToken.trim() : "";
+    const displayName =
+      typeof body?.displayName === "string" ? body.displayName.trim() : "";
+
+    // Only Slack exposes the App Manifest API.
+    if (provider !== "slack") {
+      throw new HttpException(
+        {
+          error: "unsupported_provider",
+          message: "manifest mint supports provider 'slack' only",
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (!agentId) {
+      throw new HttpException(
+        { error: "invalid_params", message: "agentId is required" },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    if (!configToken) {
+      throw new HttpException(
+        { error: "invalid_params", message: "configToken is required" },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // In-scope guard (forged ids rejected) + name fallback for the manifest.
+    const agent = await this.prisma.platosAgent.findFirst({
+      where: { id: agentId, ...this.scopeWhere(scope) },
+      select: { id: true, name: true },
+    });
+    if (!agent) {
+      throw new HttpException(
+        { error: "unknown_agent_id", message: `agent ${agentId} not found in scope`, agentId },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // The manifest's request_url must be an absolute HTTPS URL — refuse BEFORE
+    // creating anything if the public origin isn't backend-configured.
+    const origin = this.publicOrigin();
+    if (!origin) {
+      throw new HttpException(
+        {
+          error: "public_origin_unconfigured",
+          message:
+            "PLATOS_PUBLIC_BASE_URL (or PLATOS_AGENT_PUBLIC_WS_URL) must be set so the app's event request URL can be built.",
+        },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
+
+    const appName = (displayName || agent.name || "Platos Agent").trim() || "Platos Agent";
+
+    // (1) CREATE the connection row FIRST so its inbound URL (id + secret) exists.
+    const webhookSecret = crypto.randomBytes(32).toString("hex");
+    const row = await this.prisma.platosChannelConnection.create({
+      data: {
+        ...this.scopeWhere(scope),
+        provider,
+        agentId,
+        ...(displayName ? { displayName } : {}),
+        webhookSecret,
+      },
+    });
+
+    const requestUrl = `${origin}${this.webhookPathFull(row.id, webhookSecret)}`;
+    const manifest = buildSlackAppManifest(appName, requestUrl);
+
+    // (2) CALL apps.manifest.create with the URL baked in. The config token and
+    // manifest ride in the FORM BODY (never the URL); nothing here is logged.
+    let json: any;
+    try {
+      const form = new URLSearchParams({
+        token: configToken,
+        manifest: JSON.stringify(manifest),
+      });
+      const resp = await fetch(SLACK_MANIFEST_CREATE_URL, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+        signal: AbortSignal.timeout(SLACK_HTTP_TIMEOUT_MS),
+      });
+      json = await resp.json();
+    } catch {
+      await this.rollbackMint(row.id);
+      this.logger.error(
+        `[channels] apps.manifest.create request failed connection=${row.id}`,
+      );
+      throw new HttpException(
+        {
+          error: "slack_unreachable",
+          message: "Could not reach Slack to create the app. Please try again.",
+        },
+        HttpStatus.BAD_GATEWAY,
+      );
+    }
+
+    if (!json?.ok) {
+      await this.rollbackMint(row.id);
+      // Surface ONLY the Slack error code — never the config token / manifest.
+      const slackError = typeof json?.error === "string" ? json.error : "unknown_error";
+      this.logger.warn(
+        `[channels] apps.manifest.create rejected connection=${row.id} error=${slackError}`,
+      );
+      throw new HttpException(
+        {
+          error: "manifest_create_failed",
+          slackError,
+          message: `Slack rejected the manifest (code: ${slackError}).`,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // (3) STORE the returned credentials ENCRYPTED onto the row. signing_secret →
+    // credentials.signingSecret (the Slack adapter reads THAT key for signature
+    // verification); client_id/client_secret ride along in the same encrypted
+    // envelope. The bot token is still absent — it arrives via OAuth-install or
+    // manual paste later. app_id (public) goes into `config`.
+    // `json` is the untyped Slack response — read fields off it directly.
+    const clientId =
+      typeof json?.credentials?.client_id === "string" ? json.credentials.client_id : "";
+    const clientSecret =
+      typeof json?.credentials?.client_secret === "string" ? json.credentials.client_secret : "";
+    const signingSecret =
+      typeof json?.credentials?.signing_secret === "string" ? json.credentials.signing_secret : "";
+    const appId = typeof json.app_id === "string" ? json.app_id : null;
+    const oauthAuthorizeUrl =
+      typeof json.oauth_authorize_url === "string" ? json.oauth_authorize_url : null;
+
+    const encryptedCreds = this.encryptCredentials({
+      ...(clientId ? { clientId } : {}),
+      ...(clientSecret ? { clientSecret } : {}),
+      ...(signingSecret ? { signingSecret } : {}),
+    });
+    const config: Record<string, unknown> = {
+      ...(appId ? { slackAppId: appId } : {}),
+      // clientId is PUBLIC (rides the OAuth authorize URL) — surface it in the
+      // returned config so a later OAuth-install step has it without a decrypt.
+      ...(clientId ? { slackClientId: clientId } : {}),
+    };
+
+    let updated: any;
+    try {
+      updated = await this.prisma.platosChannelConnection.update({
+        where: { id: row.id },
+        data: {
+          ...(encryptedCreds !== null ? { credentials: encryptedCreds } : {}),
+          config,
+        },
+      });
+    } catch {
+      // The app WAS created at Slack but we couldn't persist its secrets. Do NOT
+      // roll back the row (that would orphan a live Slack app whose request URL
+      // points here) — surface the connectionId so the operator can retry the
+      // store via PATCH. Never log the secret material.
+      this.logger.error(`[channels] mint secret-store failed connection=${row.id}`);
+      throw new HttpException(
+        {
+          error: "secret_store_failed",
+          connectionId: row.id,
+          appId,
+          message: "The Slack app was created but its credentials could not be saved.",
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+    this.invalidateRuntime(row.id);
+
+    this.logger.log(
+      `[channels] minted BYO slack app connection=${row.id} appId=${appId ?? "?"}`,
+    );
+
+    // One-time reveal: the secret-bearing inbound URL (already registered at
+    // Slack as the request URL) + the authorize URL to finish the install.
+    return {
+      channel: this.projectRow(updated),
+      appId,
+      oauthAuthorizeUrl,
+      webhookSecret,
+      webhookPath: this.webhookPathFull(row.id, webhookSecret),
+      webhookUrl: requestUrl,
+    };
+  }
+
+  /**
+   * Best-effort rollback of a half-minted connection when Slack rejects the
+   * manifest (or is unreachable) — a credential-less row would verify nothing
+   * and post nothing, but keeping the mint all-or-nothing avoids clutter.
+   */
+  private async rollbackMint(connectionId: string): Promise<void> {
+    try {
+      await this.prisma.platosChannelConnection.delete({ where: { id: connectionId } });
+    } catch {
+      // Already gone / raced — nothing to undo.
+    }
   }
 
   @Get(":id")

--- a/apps/agent/src/channels/channel-app-events.controller.ts
+++ b/apps/agent/src/channels/channel-app-events.controller.ts
@@ -261,6 +261,35 @@ export class ChannelAppEventsController {
 
   // ───────────────────────────────────────────────────────────────────────
   // Installation lookup / lifecycle
+  //
+  // ORG-INSTALL (Enterprise Grid) ROUTING INVARIANT — Phase D consistency audit.
+  // Every consumer that resolves an installation from an inbound envelope MUST
+  // agree on this handle/routing convention, or a Grid org-install silently
+  // misroutes turns or leaves a live token "active" forever:
+  //
+  //   • STORAGE: an Enterprise Grid ORG-level install is stored teamId=NULL,
+  //     enterpriseId=<E…>, isEnterpriseInstall=true (oauth.v2.access returns
+  //     team:null for an org grant). A classic workspace install is the mirror:
+  //     teamId=<T…>, enterpriseId=NULL.
+  //   • ROUTING: event / lifecycle envelopes ALWAYS carry the ORIGINATING
+  //     WORKSPACE's team_id (a "T…", never null) even inside a Grid, so the
+  //     exact (appId, teamId, enterpriseId) tuple can NEVER hit the org row.
+  //     When the exact match misses AND we are inside a Grid (enterpriseId
+  //     present AND teamId present), fall back to (teamId:null, enterpriseId,
+  //     isEnterpriseInstall:true, status:active) — the org row.
+  //     findActiveInstallation (resolve) and revokeInstallations (uninstall)
+  //     both apply this exact fallback below.
+  //   • HANDLE: the "team" component of a slack identity handle is
+  //     `teamId ?? enterpriseId` EVERYWHERE, so an org-install's handle is
+  //     `<enterpriseId>:<userId>`. The runtime stamps identities with that rule
+  //     and keys its decrypted-token cache (appCacheKey) by it;
+  //     invalidateLinkedIdentities cannot see the installation row, so it tries
+  //     BOTH handle forms (workspace team first, then enterprise).
+  //   • TOKEN REFRESH (Phase D): getFreshBotToken does NOT re-route — it keys off
+  //     the already-resolved installation.id for both its Postgres write and its
+  //     `chanapp:refresh:<installationId>` Redis lock, so it inherits whichever
+  //     row findActiveInstallation selected (org or workspace) and cannot drift
+  //     from this convention. (See channel-runtime.service.ts getFreshBotToken.)
   // ───────────────────────────────────────────────────────────────────────
 
   private async findActiveInstallation(

--- a/apps/agent/src/channels/channel-link.controller.ts
+++ b/apps/agent/src/channels/channel-link.controller.ts
@@ -13,6 +13,7 @@ import type {
   Request as ExpressRequest,
   Response as ExpressResponse,
 } from "express";
+import { ModuleRef } from "@nestjs/core";
 import * as crypto from "node:crypto";
 import { PRISMA_TOKEN } from "../shared/database.provider";
 import { REDIS_TOKEN } from "../shared/redis.provider";
@@ -108,6 +109,10 @@ export class ChannelLinkService {
     @Inject(REDIS_TOKEN) private readonly redis: Redis,
     private readonly messageCrypto: MessageCryptoService,
     private readonly conversationService: ConversationService,
+    // Phase D — used to lazily resolve ChannelRuntimeService so the
+    // confirmation DM reads its bot token through the shared locked-refresh
+    // seam (getFreshBotToken). ModuleRef is always container-provided.
+    private readonly moduleRef: ModuleRef,
   ) {}
 
   // ───────────────────────────────────────────────────────────────────────
@@ -492,7 +497,7 @@ export class ChannelLinkService {
 
     // Best-effort confirmation DM — fire-and-forget so the success page renders
     // immediately (never blocks / fails the linking result).
-    void this.postConfirmationDm(installationId, replyChannel, replyThreadTs, email);
+    void this.postConfirmationDm(installationId, app, replyChannel, replyThreadTs, email);
 
     return { ok: true, email };
   }
@@ -503,6 +508,7 @@ export class ChannelLinkService {
 
   private async postConfirmationDm(
     installationId: string,
+    app: any,
     channel: string,
     threadTs: string | null,
     email: string,
@@ -514,7 +520,29 @@ export class ChannelLinkService {
           where: { id: String(installationId) },
         });
       if (!installation) return;
-      const botToken = this.decryptSecretField(installation.botToken);
+      // Phase D — read the bot token through ChannelRuntimeService's shared
+      // locked-refresh seam so a rotating install's near-expiry token is
+      // refreshed (under `chanapp:refresh:<installationId>`) BEFORE we post,
+      // rather than decrypting a possibly-expired token here. Lazy `require`
+      // (not a top-level import) because channel-runtime.service.ts already
+      // imports THIS file for linkStart — a static back-import would form a
+      // load-order cycle that breaks ChannelRuntimeService's own
+      // @Inject(ChannelLinkService) design:paramtypes. Resolved via ModuleRef
+      // (strict:false) since both providers live in the same module.
+      let botToken: string | null = null;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { ChannelRuntimeService: Runtime } = require("./channel-runtime.service");
+        const runtime = this.moduleRef.get(Runtime, { strict: false });
+        if (runtime) botToken = await runtime.getFreshBotToken(installation, app);
+      } catch {
+        botToken = null;
+      }
+      // Fallback: runtime not registered (e.g. a focused test module) or a
+      // total decrypt failure — best-effort direct decrypt keeps the prior
+      // behavior. A rotating token past expiry that also fails to refresh is
+      // already handled inside getFreshBotToken (degrades to current token).
+      if (!botToken) botToken = this.decryptSecretField(installation.botToken);
       if (!botToken) return;
       const body: Record<string, unknown> = {
         channel,

--- a/apps/agent/src/channels/channel-runtime.service.ts
+++ b/apps/agent/src/channels/channel-runtime.service.ts
@@ -7,6 +7,8 @@ import {
   type OnModuleDestroy,
 } from "@nestjs/common";
 import { PRISMA_TOKEN } from "../shared/database.provider";
+import { REDIS_TOKEN } from "../shared/redis.provider";
+import type Redis from "ioredis";
 import { MessageCryptoService } from "../monitoring/message-crypto.service";
 import { ConversationService } from "../memory/conversation.service";
 import { AgentTaskService } from "../agent-runtime/agent-task.service";
@@ -224,6 +226,15 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
   private readonly appCache = new Map<string, CachedAppCreds>();
   private readonly TTL_MS = 10 * 60 * 1000; // 10 min
   /**
+   * Connect v3 (Phase D) token rotation — refresh a rotating installation's bot
+   * token when it is within this window of expiry (or already past). Slack
+   * rotating tokens live 43200s (12h); 120s of headroom refreshes ahead of any
+   * plausible clock skew / in-flight turn without churning.
+   */
+  private static readonly TOKEN_REFRESH_SKEW_MS = 120 * 1000; // 120s
+  /** TTL of the single-refresh Redis lock `chanapp:refresh:<installationId>`. */
+  private static readonly REFRESH_LOCK_TTL_S = 30;
+  /**
    * Connect v3 (Phase C) — POSITIVE account-link memo: `installationId:slackHandle`
    * → expiry epoch-ms. A `linking:required` app checks per message whether the
    * author's slack person has a verified email link; a hit is cached for 10 min
@@ -237,6 +248,10 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     @Inject(PRISMA_TOKEN) private readonly prisma: any,
+    // Connect v3 (Phase D) — token rotation needs a fleet-wide single-refresh
+    // lock so concurrent events can't double-refresh a single-use refresh token.
+    // RedisModule is @Global, so no ChannelsModule import is required.
+    @Inject(REDIS_TOKEN) private readonly redis: Redis,
     private readonly messageCrypto: MessageCryptoService,
     private readonly conversationService: ConversationService,
     private readonly agentTaskService: AgentTaskService,
@@ -868,7 +883,7 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
   // a bare Slack Web API `chat.postMessage` over global fetch. No adapter, no
   // Postgres adapter-state, no ESM SDK load on this path. When Phase B adds the
   // AI-Apps streaming surface, a cached Chat instance can slot in behind the
-  // same getAppBotToken/invalidateApp seam.
+  // same getFreshBotToken/invalidateApp seam.
   // ───────────────────────────────────────────────────────────────────────
 
   /**
@@ -943,9 +958,11 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
 
     // Resolve the reply token UP FRONT — no point running a turn we cannot
     // deliver. Fail-closed: an undecryptable token skips the event entirely.
+    // getFreshBotToken also ROTATES the token when this is a rotating install
+    // (Phase D) within 120s of expiry, under a fleet-wide single-refresh lock.
     let botToken: string;
     try {
-      botToken = this.getAppBotToken(app, installation);
+      botToken = await this.getFreshBotToken(installation, app);
     } catch {
       this.logger.error(
         `[channel-apps] bot token unavailable app=${appId} installation=${installationId}`,
@@ -1154,9 +1171,11 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
     }
 
     // Need the bot token to decorate the thread; fail-closed on decrypt.
+    // getFreshBotToken rotates a Phase-D rotating token near expiry (single
+    // Redis-locked refresh) before we use it on the assistant surface.
     let botToken: string;
     try {
-      botToken = this.getAppBotToken(app, installation);
+      botToken = await this.getFreshBotToken(installation, app);
     } catch {
       this.logger.error(
         `[channel-apps] bot token unavailable (assistant_thread_started) app=${appId} installation=${installationId}`,
@@ -1445,17 +1464,352 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Bot token for an installation, ROTATION-fresh (Phase D). THE single entry
+   * point every bot-token read must go through — handleAppEvent and
+   * handleAssistantThreadStarted both route here (and this method is `public`
+   * so a future caller such as the account-link confirmation DM can reuse the
+   * same locked-refresh seam instead of decrypting a possibly-expired token).
+   *
+   * NON-ROTATING installs (the default; no `tokenExpiresAt` recorded) short
+   * circuit to the plain decrypted token — ZERO behavior change, zero extra I/O.
+   * The runtime signal for "this install rotates" is the per-installation
+   * `tokenExpiresAt` (populated by the OAuth callback only when Slack returns
+   * `expires_in`), NOT the app-level `PlatosChannelApp.tokenRotation` flag:
+   * `tokenExpiresAt` reflects the ACTUAL grant Slack issued, so it is the
+   * strictly-more-precise place to key the runtime decision (the app flag gates
+   * the manifest/OAuth side; a grant that carries an expiry must be refreshed
+   * regardless of the flag, and one that carries none cannot be).
+   *
+   * ORG-INSTALL (Enterprise Grid) NOTE: `installation` here has already been
+   * resolved by the events controller's findActiveInstallation (which applies
+   * the teamId:null→enterpriseId Grid fallback), so refresh keys off the
+   * resolved row's `id` for BOTH the DB write and the Redis lock — there is no
+   * (teamId/enterpriseId) re-routing on this path to drift from the controller's
+   * convention. See the ORG-INSTALL invariant block in
+   * channel-app-events.controller.ts.
+   *
+   * Fail-closed on a TOTAL decrypt failure (THROWS, like getAppBotToken — the
+   * caller skips the event). A failed REFRESH degrades to the current token
+   * (best-effort): a token still valid for up to 120s can serve this one event
+   * while the next event retries.
+   */
+  async getFreshBotToken(installation: any, app: any): Promise<string> {
+    // Current decrypted token — also the ONLY path for non-rotating installs.
+    // Throws (fail-closed) when the stored token is entirely unusable.
+    const current = this.getAppBotToken(app, installation);
+
+    // No expiry recorded ⇒ not a rotating install ⇒ current token is authoritative.
+    const expMs = this.expiryMs(installation.tokenExpiresAt);
+    if (!expMs) return current;
+    // Comfortably before the refresh window ⇒ current token is still good.
+    if (Date.now() < expMs - ChannelRuntimeService.TOKEN_REFRESH_SKEW_MS) {
+      return current;
+    }
+    // Within 120s of expiry (or past) ⇒ rotate under a fleet-wide single-flight
+    // lock (refresh tokens are SINGLE-USE with a 2-active cap — a concurrent
+    // double-refresh orphans one).
+    return this.rotateBotToken(installation, app, current);
+  }
+
+  /**
+   * Rotate a rotating installation's bot token under a cross-process
+   * single-refresh lock (`chanapp:refresh:<installationId>`, SET NX EX 30).
+   * WINNER performs the Slack refresh; LOSER waits for the lock to clear then
+   * re-reads the freshly-rotated row. On a Redis outage we refresh WITHOUT the
+   * lock (a rare duplicate refresh is within Slack's 2-active cap, whereas
+   * skipping the refresh entirely would post an expired token).
+   */
+  private async rotateBotToken(
+    installation: any,
+    app: any,
+    current: string,
+  ): Promise<string> {
+    const installationId = String(installation?.id ?? "");
+    if (!installationId) return current; // nothing to key a lock / update on
+    const lockKey = `chanapp:refresh:${installationId}`;
+
+    let haveLock = false;
+    try {
+      haveLock =
+        (await this.redis.set(
+          lockKey,
+          "1",
+          "EX",
+          ChannelRuntimeService.REFRESH_LOCK_TTL_S,
+          "NX",
+        )) === "OK";
+    } catch {
+      // Redis unreachable — cannot coordinate; refresh unlocked (see docstring).
+      return this.performRefresh(installation, app, current);
+    }
+
+    if (!haveLock) {
+      // Another event owns the refresh — wait it out, then re-read its result.
+      return this.awaitRotatedToken(installation, app, current, lockKey);
+    }
+
+    try {
+      // Re-read UNDER the lock: a peer may have finished refreshing between our
+      // expiry check and acquiring the lock. If the row is now comfortably
+      // valid, adopt it and skip a redundant (token-orphaning) refresh.
+      const row = (await this.reloadInstallation(installationId)) ?? installation;
+      const rowExp = this.expiryMs(row.tokenExpiresAt);
+      if (
+        rowExp &&
+        Date.now() < rowExp - ChannelRuntimeService.TOKEN_REFRESH_SKEW_MS
+      ) {
+        const token = this.adoptRefreshedRow(installation, app, row);
+        if (token) return token;
+      }
+      return this.performRefresh(installation, app, current);
+    } finally {
+      try {
+        await this.redis.del(lockKey);
+      } catch {
+        /* best-effort — the 30s TTL is the backstop */
+      }
+    }
+  }
+
+  /**
+   * LOSER path: another event holds the refresh lock. Poll for it to clear
+   * (bounded ≈3s), then re-read the row — the winner has by then written the
+   * rotated token. Falls back to the current token if the wait/read yields
+   * nothing newer (the event proceeds best-effort rather than blocking).
+   */
+  private async awaitRotatedToken(
+    installation: any,
+    app: any,
+    current: string,
+    lockKey: string,
+  ): Promise<string> {
+    const installationId = String(installation?.id ?? "");
+    for (let i = 0; i < 10; i++) {
+      await this.sleep(300);
+      let held: string | null;
+      try {
+        held = await this.redis.get(lockKey);
+      } catch {
+        held = null; // treat a read error as "clear" and re-read the row
+      }
+      if (!held) break; // winner released the lock
+    }
+    if (!installationId) return current;
+    const row = await this.reloadInstallation(installationId);
+    if (row) {
+      const token = this.adoptRefreshedRow(installation, app, row);
+      if (token) return token;
+    }
+    return current;
+  }
+
+  /**
+   * Perform the Slack token refresh and persist the rotated grant. Best-effort:
+   * on ANY failure (no refresh token, undecryptable app creds, Slack error,
+   * network) it degrades to `current` rather than throwing. Mutates the caller's
+   * in-memory `installation` + primes the decrypted-token cache so the rest of
+   * the handler sees the fresh token. NEVER logs tokens/secrets.
+   *
+   *   POST https://slack.com/api/oauth.v2.access
+   *   form: grant_type=refresh_token, refresh_token, client_id, client_secret
+   *   → { ok, access_token (xoxe.…), refresh_token (xoxe-1-…), expires_in 43200 }
+   */
+  private async performRefresh(
+    installation: any,
+    app: any,
+    current: string,
+  ): Promise<string> {
+    const installationId = String(installation?.id ?? "");
+    const refreshToken = this.decryptSecretField(installation.refreshToken);
+    if (!refreshToken) {
+      // Rotation is on (expiry set) but no usable refresh token to rotate with.
+      this.logger.warn(
+        `[channel-apps] token near expiry but no refresh token installation=${installationId}`,
+      );
+      return current;
+    }
+    const clientId = typeof app?.clientId === "string" ? app.clientId : "";
+    const clientSecret = this.decryptSecretField(app?.clientSecret);
+    if (!clientId || !clientSecret) {
+      this.logger.error(
+        `[channel-apps] token refresh blocked — app credentials unavailable installation=${installationId}`,
+      );
+      return current;
+    }
+
+    let json: any = null;
+    try {
+      const form = new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: clientId,
+        client_secret: clientSecret,
+      });
+      const res = await fetch("https://slack.com/api/oauth.v2.access", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: form.toString(),
+        signal: AbortSignal.timeout(10_000),
+      });
+      json = await res.json();
+    } catch {
+      this.logger.error(
+        `[channel-apps] token refresh request failed installation=${installationId}`,
+      );
+      return current;
+    }
+    if (
+      !json?.ok ||
+      typeof json.access_token !== "string" ||
+      !json.access_token
+    ) {
+      // Only the Slack error code — never a token/secret.
+      this.logger.error(
+        `[channel-apps] token refresh rejected installation=${installationId} error=${json?.error ?? "unknown"}`,
+      );
+      return current;
+    }
+
+    const newBotToken = json.access_token as string;
+    // Slack MAY roll the refresh token too; keep the old one if it doesn't.
+    const newRefreshToken =
+      typeof json.refresh_token === "string" && json.refresh_token
+        ? json.refresh_token
+        : refreshToken;
+    const newExpiresAt =
+      typeof json.expires_in === "number" && json.expires_in > 0
+        ? new Date(Date.now() + json.expires_in * 1000)
+        : null;
+
+    const encBot = this.encryptSecretField(newBotToken);
+    const encRefresh = this.encryptSecretField(newRefreshToken);
+
+    // Persist (best-effort — the in-memory token still serves THIS event even if
+    // the write fails; the next event refreshes again).
+    try {
+      await this.prisma.platosChannelInstallation.update({
+        where: { id: installationId },
+        data: {
+          botToken: encBot,
+          refreshToken: encRefresh,
+          ...(newExpiresAt ? { tokenExpiresAt: newExpiresAt } : {}),
+        },
+      });
+    } catch {
+      this.logger.error(
+        `[channel-apps] token refresh persist failed installation=${installationId}`,
+      );
+    }
+
+    // Keep the caller's in-memory row + decrypted-token cache coherent with the
+    // rotated grant (the encrypted-source self-invalidation key now matches, so
+    // a later getAppBotToken on this same row returns the new token from cache).
+    installation.botToken = encBot;
+    installation.refreshToken = encRefresh;
+    if (newExpiresAt) installation.tokenExpiresAt = newExpiresAt;
+    this.cacheAppToken(app, installation, encBot, newBotToken);
+
+    this.logger.log(
+      `[channel-apps] bot token refreshed installation=${installationId}`,
+    );
+    return newBotToken;
+  }
+
+  /**
+   * Adopt a freshly-reloaded installation row's token onto the caller's
+   * in-memory `installation` + the decrypted-token cache, returning the
+   * decrypted token (or null if the row's token can't be decrypted). Used by
+   * both the under-lock re-read and the loser's post-wait re-read so a peer's
+   * rotation is picked up WITHOUT a second Slack call.
+   */
+  private adoptRefreshedRow(
+    installation: any,
+    app: any,
+    row: any,
+  ): string | null {
+    const token = this.decryptSecretField(row?.botToken);
+    if (!token || typeof row.botToken !== "string") return null;
+    installation.botToken = row.botToken;
+    if (typeof row.refreshToken === "string") {
+      installation.refreshToken = row.refreshToken;
+    }
+    if (row.tokenExpiresAt) installation.tokenExpiresAt = row.tokenExpiresAt;
+    this.cacheAppToken(app, installation, row.botToken, token);
+    return token;
+  }
+
+  private async reloadInstallation(installationId: string): Promise<any | null> {
+    try {
+      return await this.prisma.platosChannelInstallation.findUnique({
+        where: { id: installationId },
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  /** Epoch-ms of a stored expiry (Date | string | null) or 0 when absent/invalid. */
+  private expiryMs(v: unknown): number {
+    if (!v) return 0;
+    const t = v instanceof Date ? v.getTime() : new Date(v as any).getTime();
+    return Number.isFinite(t) ? t : 0;
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Encrypt a scalar secret into the stored envelope — the inverse of
+   * decryptSecretField, mirroring channel-app-oauth.controller's
+   * encryptSecretString so a rotated token is stored in the identical shape the
+   * OAuth callback wrote.
+   */
+  private encryptSecretField(value: string): string {
+    return JSON.stringify(this.messageCrypto.encryptJsonField(value));
+  }
+
+  /**
+   * Canonical decrypted-token cache key for an installation:
+   * `app:<appId>:<teamId|enterpriseId|id>`. The team component follows the same
+   * `teamId ?? enterpriseId` handle convention used everywhere (an org-install
+   * has teamId null ⇒ keyed by enterpriseId); `id` is the final defensive
+   * fallback. See the ORG-INSTALL invariant in channel-app-events.controller.ts.
+   */
+  private appCacheKey(app: any, installation: any): string {
+    const team = String(
+      installation.teamId ?? installation.enterpriseId ?? installation.id ?? "",
+    );
+    return `app:${String(app.id)}:${team}`;
+  }
+
+  /** Prime the decrypted-token cache under the canonical key. */
+  private cacheAppToken(
+    app: any,
+    installation: any,
+    encSource: string,
+    botToken: string,
+  ): void {
+    this.appCache.set(this.appCacheKey(app, installation), {
+      enc: encSource,
+      botToken,
+      builtAt: Date.now(),
+    });
+  }
+
+  /**
    * Decrypted bot token for an installation, memoized per `app:<appId>:<team>`
    * with the same 10-min TTL as the connection cache. Fail-closed: an
    * undecryptable/absent token THROWS (the caller then skips the event) rather
    * than posting with an empty Authorization header.
+   *
+   * This is the raw decrypt+cache PRIMITIVE — it does NOT rotate. Callers that
+   * need a rotation-fresh token go through getFreshBotToken, which wraps this.
    */
   private getAppBotToken(app: any, installation: any): string {
-    const team = String(
-      installation.teamId ?? installation.enterpriseId ?? installation.id ?? "",
-    );
-    const key = `app:${String(app.id)}:${team}`;
-    const encSource = typeof installation.botToken === "string" ? installation.botToken : "";
+    const key = this.appCacheKey(app, installation);
+    const encSource =
+      typeof installation.botToken === "string" ? installation.botToken : "";
     const cached = this.appCache.get(key);
     // Reuse only when both the encrypted source AND the TTL still hold — a
     // re-install rotates the source and forces a fresh decrypt on the spot.
@@ -1464,7 +1818,7 @@ export class ChannelRuntimeService implements OnModuleInit, OnModuleDestroy {
     }
     const botToken = this.decryptSecretField(installation.botToken);
     if (!botToken) throw new Error("channel-app bot token unavailable");
-    this.appCache.set(key, { enc: encSource, botToken, builtAt: Date.now() });
+    this.cacheAppToken(app, installation, encSource, botToken);
     return botToken;
   }
 

--- a/apps/agent/src/mcp-platform/permission-gateway.service.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.ts
@@ -178,6 +178,13 @@ const PLATFORM_TIER_MINIMUMS: Array<{ pattern: string; min: McpPermissionState }
   { pattern: "channels.update", min: "require_approval" },
   { pattern: "channels.delete", min: "require_approval" },
   { pattern: "channels.rotate_webhook_secret", min: "require_approval" },
+  // Connect v3 (Phase D) — BYO manifest MINT on the connection tier. Strictly
+  // MORE powerful than channels.create: it creates a PlatosChannelConnection
+  // row, POSTs the pasted config token to Slack's apps.manifest.create, and
+  // stores the returned client_secret / signing_secret encrypted on the row.
+  // The REST path is operator-gated; without this entry the MCP path would
+  // resolve to auto_allow for a scope-tier token. Gate it like its siblings.
+  { pattern: "channels.mint_from_manifest", min: "require_approval" },
   // Connect v3 — marketplace channel-APP mutations (PlatosChannelApp +
   // PlatosChannelInstallation). An app is OAuth-installed into N external
   // workspaces, so every write has cross-tenant blast radius:

--- a/apps/agent/src/mcp-platform/tools/channels.ts
+++ b/apps/agent/src/mcp-platform/tools/channels.ts
@@ -90,6 +90,77 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
   return !!v && typeof v === "object" && !Array.isArray(v);
 }
 
+// ── Connect v3 (Phase D) — BYO app mint via the Slack App Manifest API ────────
+// `apps.manifest.create` requires a MANUALLY-generated App Configuration Token
+// (xoxe.xoxp-… access + xoxe-… refresh, 12h TTL, created by the user at
+// api.slack.com/apps → "Your App Configuration Tokens"). There is NO
+// delegated/OAuth path to mint config tokens, so the one paste is unavoidable.
+const SLACK_MANIFEST_CREATE_URL = "https://slack.com/api/apps.manifest.create";
+const SLACK_HTTP_TIMEOUT_MS = 10_000;
+// Bot scopes = the Phase-A/B recommended AI-Apps set (scope-minimized).
+const SLACK_BYO_BOT_SCOPES = [
+  "assistant:write",
+  "chat:write",
+  "im:history",
+  "app_mentions:read",
+] as const;
+// Slack caps display_information.name at 35 chars, bot_user.display_name at 80.
+const SLACK_APP_NAME_MAX = 35;
+
+/**
+ * Build a Slack app manifest for apps.manifest.create. Targets Slack's
+ * first-class "Agents & AI Apps" surface so a BYO app matches the marketplace
+ * tier: presence of `features.assistant_view` turns the surface ON,
+ * `assistant:write` (in the bot scopes) unlocks assistant.threads.*, and the
+ * `assistant_thread_*` bot events deliver the panel lifecycle. `request_url`
+ * is the connection's OWN secret-bearing inbound URL — known only AFTER the row
+ * is created (create-row-first ordering). The BYO bot token arrives later
+ * (OAuth-install or manual paste), so token rotation stays off here (it's a
+ * marketplace-tier property: PlatosChannelApp.tokenRotation).
+ */
+function buildSlackAppManifest(appName: string, requestUrl: string) {
+  const name = appName.slice(0, SLACK_APP_NAME_MAX);
+  return {
+    display_information: { name },
+    features: {
+      app_home: {
+        home_tab_enabled: true,
+        messages_tab_enabled: true,
+        messages_tab_read_only_enabled: false,
+      },
+      bot_user: {
+        display_name: appName.slice(0, 80),
+        always_online: true,
+      },
+      // Presence of assistant_view ENABLES the "Agents & AI Apps" surface.
+      assistant_view: {
+        assistant_description: `${name} is an AI assistant available in Slack.`,
+      },
+    },
+    oauth_config: {
+      scopes: { bot: [...SLACK_BYO_BOT_SCOPES] },
+    },
+    settings: {
+      event_subscriptions: {
+        request_url: requestUrl,
+        bot_events: [
+          "app_mention",
+          "message.im",
+          "assistant_thread_started",
+          "assistant_thread_context_changed",
+        ],
+      },
+      // No interactivity handler on the BYO connection tier (it processes
+      // message + assistant events only), so leave it off — enabling it would
+      // require a registered interactivity request_url.
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: false,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
 export function buildChannelToolHandlers(deps: {
   prisma: any;
   messageCrypto: MessageCryptoService;
@@ -323,6 +394,266 @@ export function buildChannelToolHandlers(deps: {
           auditMutation(scope, "channels.create", auditArgs, null, "failed", startedAt, message);
           return { error: "create_failed", message };
         }
+      },
+    },
+
+    {
+      name: "channels.mint_from_manifest",
+      description:
+        "Connect v3 (Phase D) — BYO app MINT: \"paste one Slack App " +
+        "Configuration Token, Platos builds your Slack app.\" Operates on the " +
+        "CONNECTION tier (the customer-owned BYO app), not the marketplace app " +
+        "tier. `configToken` is an App Configuration Token (xoxe.xoxp-… access, " +
+        "12h TTL) the user generates MANUALLY at api.slack.com/apps → \"Your " +
+        "App Configuration Tokens\" — there is NO OAuth way to mint it. " +
+        "`provider` must be 'slack'. FLOW: creates a PlatosChannelConnection " +
+        "row FIRST (so its secret-bearing inbound URL exists), bakes that URL " +
+        "into a manifest that enables Slack's \"Agents & AI Apps\" surface " +
+        "(assistant:write + assistant_thread_* events) with the recommended " +
+        "bot scopes, calls apps.manifest.create, then stores the returned " +
+        "client_id / client_secret / signing_secret ENCRYPTED on the row " +
+        "(signing_secret is what verifies inbound Slack signatures). The app " +
+        "is NOT installed by this call — the bot token arrives later via the " +
+        "returned `oauthAuthorizeUrl` or a manual paste. The config token is " +
+        "NEVER persisted or logged; the optional `configRefreshToken` is " +
+        "accepted but DISCARDED (v1 is a one-shot create). Returns the row " +
+        "(secrets redacted), `appId`, `oauthAuthorizeUrl`, and the one-time " +
+        "`webhookUrl` / `webhookSecret`.",
+      inputSchema: {
+        type: "object",
+        required: ["agentId", "configToken"],
+        properties: {
+          provider: { type: "string", enum: ["slack"] },
+          agentId: { type: "string" },
+          displayName: { type: "string" },
+          configToken: { type: "string" },
+          configRefreshToken: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      async execute(params, scope) {
+        const startedAt = Date.now();
+        const provider = String(params["provider"] ?? "slack").trim().toLowerCase();
+        const agentId = String(params["agentId"] ?? "").trim();
+        const configToken =
+          typeof params["configToken"] === "string" ? params["configToken"].trim() : "";
+        const displayName =
+          typeof params["displayName"] === "string" ? params["displayName"].trim() : "";
+
+        // Redacted audit args — NEVER echo the config token / refresh token.
+        const auditArgs = {
+          provider,
+          agentId,
+          displayName,
+          hasConfigToken: configToken.length > 0,
+          hasConfigRefreshToken:
+            typeof params["configRefreshToken"] === "string" &&
+            params["configRefreshToken"].length > 0,
+        };
+
+        if (provider !== "slack") {
+          const err = "manifest mint supports provider 'slack' only";
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, err);
+          return { error: "unsupported_provider", message: err };
+        }
+        if (!agentId) {
+          const err = "agentId required";
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, err);
+          return { error: "invalid_params", message: err };
+        }
+        if (!configToken) {
+          const err = "configToken required";
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, err);
+          return { error: "invalid_params", message: err };
+        }
+
+        // In-scope guard (forged ids rejected) + name fallback for the manifest.
+        const agent = await prisma.platosAgent.findFirst({
+          where: { id: agentId, ...scopeTuple(scope) },
+          select: { id: true, name: true },
+        });
+        if (!agent) {
+          auditMutation(
+            scope,
+            "channels.mint_from_manifest",
+            auditArgs,
+            null,
+            "failed",
+            startedAt,
+            "unknown_agent_id",
+          );
+          return { error: "unknown_agent_id", agentId };
+        }
+
+        // The manifest's request_url must be an absolute HTTPS URL — refuse
+        // BEFORE creating anything if the public origin isn't configured.
+        const origin = publicOrigin();
+        if (!origin) {
+          auditMutation(
+            scope,
+            "channels.mint_from_manifest",
+            auditArgs,
+            null,
+            "failed",
+            startedAt,
+            "public_origin_unconfigured",
+          );
+          return {
+            error: "public_origin_unconfigured",
+            message:
+              "PLATOS_PUBLIC_BASE_URL (or PLATOS_AGENT_PUBLIC_WS_URL) must be set so the app's event request URL can be built.",
+          };
+        }
+
+        const appName =
+          (displayName || (agent as any).name || "Platos Agent").trim() || "Platos Agent";
+
+        // (1) CREATE the connection row FIRST so its inbound URL (id + secret)
+        // exists — the chicken-and-egg the manifest request_url depends on.
+        const webhookSecret = crypto.randomBytes(32).toString("hex");
+        let row: any;
+        try {
+          row = await prisma.platosChannelConnection.create({
+            data: {
+              ...scopeTuple(scope),
+              provider,
+              agentId,
+              ...(displayName ? { displayName } : {}),
+              webhookSecret,
+            },
+          });
+        } catch (err: any) {
+          const message = err?.message ?? String(err);
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, message);
+          return { error: "create_failed", message };
+        }
+
+        /** Best-effort rollback — a credential-less row verifies/posts nothing. */
+        const rollback = async () => {
+          try {
+            await prisma.platosChannelConnection.delete({ where: { id: row.id } });
+          } catch {
+            // Already gone / raced — nothing to undo.
+          }
+        };
+
+        const requestUrl = `${origin}${webhookPathFull(row.id, webhookSecret)}`;
+        const manifest = buildSlackAppManifest(appName, requestUrl);
+
+        // (2) CALL apps.manifest.create. Config token + manifest ride in the
+        // FORM BODY (never the URL); nothing here is logged. 10s bound.
+        let json: any;
+        try {
+          const form = new URLSearchParams({
+            token: configToken,
+            manifest: JSON.stringify(manifest),
+          });
+          const resp = await fetch(SLACK_MANIFEST_CREATE_URL, {
+            method: "POST",
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+            body: form.toString(),
+            signal: AbortSignal.timeout(SLACK_HTTP_TIMEOUT_MS),
+          });
+          json = await resp.json();
+        } catch {
+          await rollback();
+          const message = "could not reach Slack to create the app";
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, "slack_unreachable");
+          return { error: "slack_unreachable", message };
+        }
+
+        if (!json?.ok) {
+          await rollback();
+          // Surface ONLY the Slack error code — never the config token/manifest.
+          const slackError = typeof json?.error === "string" ? json.error : "unknown_error";
+          auditMutation(
+            scope,
+            "channels.mint_from_manifest",
+            auditArgs,
+            null,
+            "failed",
+            startedAt,
+            `manifest_create_failed:${slackError}`,
+          );
+          return {
+            error: "manifest_create_failed",
+            slackError,
+            message: `Slack rejected the manifest (code: ${slackError}).`,
+          };
+        }
+
+        // (3) STORE the returned credentials ENCRYPTED. signing_secret →
+        // credentials.signingSecret (the key the Slack adapter reads for
+        // signature verification); client_id/client_secret ride the same
+        // envelope. Bot token is absent — it arrives via OAuth-install / paste.
+        // `json` is the untyped Slack response — read fields off it directly.
+        const clientId =
+          typeof json?.credentials?.client_id === "string" ? json.credentials.client_id : "";
+        const clientSecret =
+          typeof json?.credentials?.client_secret === "string" ? json.credentials.client_secret : "";
+        const signingSecret =
+          typeof json?.credentials?.signing_secret === "string" ? json.credentials.signing_secret : "";
+        const appId = typeof json.app_id === "string" ? json.app_id : null;
+        const oauthAuthorizeUrl =
+          typeof json.oauth_authorize_url === "string" ? json.oauth_authorize_url : null;
+
+        const encryptedCreds = encryptCredentials({
+          ...(clientId ? { clientId } : {}),
+          ...(clientSecret ? { clientSecret } : {}),
+          ...(signingSecret ? { signingSecret } : {}),
+        });
+        const config: Record<string, unknown> = {
+          ...(appId ? { slackAppId: appId } : {}),
+          // clientId is PUBLIC (rides the authorize URL) — surface it in config
+          // so a later OAuth-install step has it without a decrypt.
+          ...(clientId ? { slackClientId: clientId } : {}),
+        };
+
+        let updated: any;
+        try {
+          updated = await prisma.platosChannelConnection.update({
+            where: { id: row.id },
+            data: {
+              ...(encryptedCreds !== null ? { credentials: encryptedCreds } : {}),
+              config,
+            },
+          });
+        } catch {
+          // The app WAS created at Slack but the secret store failed. Do NOT
+          // roll back (that orphans a live Slack app pointing here) — return the
+          // connectionId so the caller can retry the store. A generic message
+          // (never the raw DB error, which could echo the write payload) + no
+          // secret is ever logged.
+          auditMutation(scope, "channels.mint_from_manifest", auditArgs, null, "failed", startedAt, "secret_store_failed");
+          return {
+            error: "secret_store_failed",
+            connectionId: row.id,
+            appId,
+            message: "The Slack app was created but its credentials could not be saved.",
+          };
+        }
+        evictRuntime(row.id);
+
+        // Redacted audit — log the id + appId presence, never the secrets/URL.
+        auditMutation(
+          scope,
+          "channels.mint_from_manifest",
+          auditArgs,
+          { id: row.id, appId, minted: true },
+          "success",
+          startedAt,
+        );
+
+        // One-time reveal: the secret-bearing inbound URL (already registered at
+        // Slack as the request URL) + the authorize URL to finish the install.
+        return {
+          ...projectRow(updated),
+          appId,
+          oauthAuthorizeUrl,
+          webhookSecret,
+          webhookPath: webhookPathFull(row.id, webhookSecret),
+          webhookUrl: requestUrl,
+        };
       },
     },
 

--- a/internal-packages/database/prisma/migrations/20260722150000_token_rotation/migration.sql
+++ b/internal-packages/database/prisma/migrations/20260722150000_token_rotation/migration.sql
@@ -1,0 +1,19 @@
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- Connect v3 (Phase D) — OAuth token rotation flag on a channel APP.
+--
+-- `tokenRotation` mirrors Slack's app-level `token_rotation_enabled` setting
+-- (declared in the manifest `settings.token_rotation_enabled`, which is
+-- ONE-WAY). When enabled, oauth.v2.access returns a 12h `xoxe.` bot token, a
+-- single-use `xoxe-1-` refresh token, and expires_in=43200; the runtime must
+-- refresh the bot token before it expires (getFreshBotToken + a per-installation
+-- Redis lock so two concurrent events can't double-refresh — refresh tokens are
+-- single-use with a 2-active cap). The `refreshToken` + `tokenExpiresAt` columns
+-- that carry the rotating grant already exist on PlatosChannelInstallation
+-- (Phase A migration 20260722090000_channel_apps), and Phase A already tolerates
+-- a refresh_token's absence, so `false` is a zero-behavior-change default.
+--
+-- Idempotent (ADD COLUMN IF NOT EXISTS) so a partial re-run — or a deploy target
+-- that applies this via psql directly — is safe.
+-- ═══════════════════════════════════════════════════════════════════════════════
+ALTER TABLE "public"."PlatosChannelApp"
+    ADD COLUMN IF NOT EXISTS "tokenRotation" BOOLEAN NOT NULL DEFAULT false;

--- a/internal-packages/database/prisma/schema.prisma
+++ b/internal-packages/database/prisma/schema.prisma
@@ -3823,6 +3823,17 @@ model PlatosChannelApp {
   // than a bare app_mention bot. Default on for new apps.
   aiAppsSurface Boolean @default(true)
 
+  // Connect v3 (Phase D) — OAuth token rotation. Slack's
+  // `token_rotation_enabled` is a ONE-WAY app-level setting (manifest
+  // settings.token_rotation_enabled); when on, oauth.v2.access returns a
+  // 12h `xoxe.` bot token + a single-use `xoxe-1-` refresh token +
+  // expires_in=43200. This bool mirrors that app-level property so the
+  // runtime knows to expect + refresh rotating tokens (the refresh LOGIC —
+  // getFreshBotToken + the per-installation Redis lock — lives in
+  // channel-runtime). Phase A already tolerates a refresh_token's absence,
+  // so leaving this false is a zero-behavior-change default.
+  tokenRotation Boolean @default(false)
+
   // Connect v3 (Phase C) — hosted account-linking policy:
   //   none     — no linking behavior (default; zero behavior change).
   //   optional — never blocks a turn; the connect URL is surfaced only when the


### PR DESCRIPTION
Completes Connect v3 A–D. BYO app mint ('paste one config token → Platos builds your Slack app' via apps.manifest.create, operator-gated on REST AND MCP), token rotation (getFreshBotToken under a Redis single-refresh lock at every bot-token read site), Grid enterprise-path consistency. Fable-gated (missing MCP approval floor + stale-token-in-link-DM caught+fixed); deployed + healthy on test.platos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)