### PR TITLE
feat(privacy): enforce legal holds server-side; document hard erasure

### DIFF
--- a/apps/agent/src/privacy/erasure.service.ts
+++ b/apps/agent/src/privacy/erasure.service.ts
@@ -12,6 +12,7 @@ import {
   type ErasureReceipt, type StoreOutcome,
 } from "./erasure-receipt";
 import { runErasure, retryErasure, type StoreExecutors } from "./erasure-orchestrator";
+import { findLegalHold, parseLegalHoldList } from "./legal-hold";
 import { planDeletions, subjectKeyPatterns, retainedAggregatePatterns } from "./redis-keys";
 import { ErasureObjectStore } from "./object-store";
 
@@ -317,21 +318,39 @@ export class ErasureService {
     const hash = this.hash(args.externalUserId, args.organizationId);
     const inventory = await this.inventory(subject);
 
+    // Server-side hold check, over every alias the subject resolves to. Runs
+    // before the operation row is created so a held subject leaves no
+    // half-started operation, and before any executor can touch a store.
+    // A caller-supplied legalHoldPolicyId still wins if present; this only adds
+    // the holds the caller did not know about.
+    const heldBy =
+      args.legalHoldPolicyId ??
+      findLegalHold(
+        subject,
+        args.externalUserId,
+        parseLegalHoldList(process.env.PLATOS_LEGAL_HOLD_USER_IDS),
+      );
+
     const row = await this.prisma.platosErasureOperation.create({
       data: {
         id: randomUUID(),
         idempotencyKey: args.idempotencyKey,
         subjectKeyHash: hash,
         organizationId: args.organizationId,
-        status: "pending",
+        status: heldBy ? "blocked_legal_hold" : "pending",
         scopes: subject.scopes as any,
         stores: [] as any,
         inventory: inventory as any,
         policyVersion: ERASURE_POLICY_VERSION,
-        legalHoldPolicyId: args.legalHoldPolicyId ?? null,
+        legalHoldPolicyId: heldBy ?? null,
         attempts: 0,
       },
     });
+
+    // Return the blocked receipt without running any executor. The operation is
+    // recorded rather than dropped: a refused erasure request is itself an event
+    // the operator has to be able to evidence later.
+    if (heldBy) return this.toReceipt(row);
 
     const started = await runErasure(this.toReceipt(row), subject, this.executors(), {
       legalHold: args.legalHoldPolicyId ? { policyId: args.legalHoldPolicyId } : null,

--- a/apps/agent/src/privacy/legal-hold.test.ts
+++ b/apps/agent/src/privacy/legal-hold.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { parseLegalHoldList, findLegalHold } from "./legal-hold";
+import type { SubjectKeys } from "./subject-graph";
+
+const subject = (over: Partial<SubjectKeys> = {}): SubjectKeys => ({
+  platosEndUserIds: [],
+  legacyUserIds: [],
+  scopes: [],
+  ...over,
+});
+
+describe("parseLegalHoldList", () => {
+  it("returns nothing for unset, empty, or whitespace-only registers", () => {
+    expect(parseLegalHoldList(undefined)).toEqual([]);
+    expect(parseLegalHoldList(null)).toEqual([]);
+    expect(parseLegalHoldList("")).toEqual([]);
+    expect(parseLegalHoldList("   ")).toEqual([]);
+  });
+
+  it("splits and trims", () => {
+    expect(parseLegalHoldList("a@x.com, b@y.com ,c@z.com")).toEqual([
+      "a@x.com",
+      "b@y.com",
+      "c@z.com",
+    ]);
+  });
+
+  it("drops blank entries so a trailing comma cannot match an aliasless subject", () => {
+    // The dangerous shape: "" in the list matching "" in a subject's aliases
+    // would place every subject on hold, or — with the filters removed on the
+    // other side — none of them.
+    expect(parseLegalHoldList("a@x.com,,")).toEqual(["a@x.com"]);
+  });
+});
+
+describe("findLegalHold", () => {
+  it("returns null when no register is configured", () => {
+    expect(findLegalHold(subject(), "a@x.com", [])).toBeNull();
+  });
+
+  it("matches the requested identifier", () => {
+    expect(findLegalHold(subject(), "a@x.com", ["a@x.com"])).toBe("a@x.com");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(findLegalHold(subject(), "A@X.com", ["a@x.com"])).toBe("a@x.com");
+  });
+
+  it("returns null for a subject nobody registered", () => {
+    expect(findLegalHold(subject(), "b@y.com", ["a@x.com"])).toBeNull();
+  });
+
+  // The reason this module exists over a plain equality check.
+  it("blocks an erasure requested under an alias the hold does not name", () => {
+    const s = subject({ legacyUserIds: ["slack:U08JTN5FX39", "a@x.com"] });
+    expect(findLegalHold(s, "a@x.com", ["slack:U08JTN5FX39"])).toBe("slack:U08JTN5FX39");
+  });
+
+  it("blocks when the hold names the canonical end-user id", () => {
+    const s = subject({ platosEndUserIds: ["eu_123"] });
+    expect(findLegalHold(s, "a@x.com", ["eu_123"])).toBe("eu_123");
+  });
+
+  it("ignores empty aliases so a subject with no history is not held by a blank entry", () => {
+    const s = subject({ legacyUserIds: ["", ""] as string[] });
+    expect(findLegalHold(s, "a@x.com", ["b@y.com"])).toBeNull();
+  });
+
+  it("names which register entry blocked it", () => {
+    const s = subject({ legacyUserIds: ["b@y.com"] });
+    expect(findLegalHold(s, "a@x.com", ["z@z.com", "b@y.com"])).toBe("b@y.com");
+  });
+});

--- a/apps/agent/src/privacy/legal-hold.ts
+++ b/apps/agent/src/privacy/legal-hold.ts
@@ -1,0 +1,71 @@
+/**
+ * Legal holds — the check that must run before anything is destroyed.
+ *
+ * THE DEFECT THIS EXISTS TO FIX
+ *
+ * `docs/gdpr.md` told operators that `PLATOS_LEGAL_HOLD_USER_IDS` "is checked
+ * by the delete route and rejects the request for any user on the list". No
+ * code read that variable. An operator who set it believed held subjects were
+ * protected and would have been wrong at exactly the moment it mattered — the
+ * erasure is irreversible, so the failure is discovered only after the evidence
+ * is gone.
+ *
+ * The erasure API did carry a `legalHoldPolicyId`, but the CALLER supplies it.
+ * That protects a subject only when whoever fires the request already knows
+ * about the hold, which is precisely the knowledge a hold register exists
+ * because people do not reliably have.
+ *
+ * MATCHING IS OVER EVERY ALIAS, NOT THE REQUESTED ID
+ *
+ * A hold naming `slack:U08JTN5FX39` must also stop an erasure requested as
+ * `user@example.com` when both resolve to the same person. Checking only the
+ * requested identifier would leave every held subject erasable through any
+ * alias they were not registered under, which is the same hole the subject
+ * graph exists to close for deletion.
+ *
+ * Pure and dependency-free, like the subject graph: this is a security
+ * boundary, so it is testable without a database or an environment.
+ */
+
+import type { SubjectKeys } from "./subject-graph";
+
+/**
+ * Parse the operator's hold register.
+ *
+ * Comma-separated, whitespace-tolerant, case-insensitive on match. Empty and
+ * blank entries are dropped so a trailing comma cannot produce an empty-string
+ * identifier that matches a subject with no aliases.
+ */
+export function parseLegalHoldList(raw: string | undefined | null): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * The identifier that placed this subject on hold, or null if none did.
+ *
+ * Returns the held identifier rather than a boolean so the refusal can name
+ * which registry entry stopped it — an operator seeing "blocked" with no
+ * reason cannot tell a hold from a bug.
+ */
+export function findLegalHold(
+  subject: SubjectKeys,
+  requestedExternalUserId: string,
+  holdList: string[],
+): string | null {
+  if (holdList.length === 0) return null;
+
+  const aliases = new Set(
+    [requestedExternalUserId, ...subject.legacyUserIds, ...subject.platosEndUserIds]
+      .filter((a): a is string => typeof a === "string" && a.length > 0)
+      .map((a) => a.toLowerCase()),
+  );
+
+  for (const held of holdList) {
+    if (aliases.has(held.toLowerCase())) return held;
+  }
+  return null;
+}

--- a/content/docs/hard-erasure.md
+++ b/content/docs/hard-erasure.md
@@ -1,0 +1,98 @@
+---
+slug: hard-erasure
+title: Hard erasure
+description: The service-authenticated API that destroys everything Platos holds about one person and returns a receipt saying what it proved.
+category: platform
+order: 95
+trigger_dev_primitive: false
+trigger_dev_link: ""
+questions:
+  - "How do I delete everything Platos knows about a user?"
+  - "How do I prove to a regulator that a deletion happened?"
+  - "What is an erasure receipt and what do its statuses mean?"
+  - "How do legal holds stop an erasure?"
+  - "Why does erasure need an idempotency key?"
+  - "Which tables does erasure deliberately not touch?"
+related:
+  - safety-and-pii
+  - legal-and-policies
+  - memory
+  - scope-and-multi-tenancy
+source_files_referenced:
+  - apps/agent/src/privacy/erasure.service.ts
+  - apps/agent/src/privacy/erasure-orchestrator.ts
+  - apps/agent/src/privacy/erasure-receipt.ts
+  - apps/agent/src/privacy/subject-graph.ts
+  - apps/agent/src/privacy/legal-hold.ts
+  - apps/agent/src/privacy/redis-keys.ts
+---
+
+# Hard erasure
+
+Deleting a person from an agent platform is harder than deleting rows. The same human arrives as a Slack id in one thread, an email in another, and a channel handle in a third; their content is spread across Postgres, Redis, ClickHouse, and object storage; and the operation has to be provable afterwards, when the evidence that would have proved it is exactly what you destroyed.
+
+Hard erasure is one API call that resolves the person, sweeps every store, and returns a durable receipt recording what it deleted and what it verified gone.
+
+## What it is
+
+Four routes under `/api/v1/agent/admin/privacy`:
+
+| Route | Purpose |
+| --- | --- |
+| `GET /subjects/:externalUserId/inventory` | What a request would target, without deleting |
+| `POST /erasures` | Request an erasure |
+| `GET /erasures/:operationId` | Fetch the receipt |
+| `POST /erasures/:operationId/retry` | Re-run the stores that did not settle |
+
+Authenticated with `PLATOS_ADMIN_TOKEN` in the `X-Platos-Admin-Token` header, compared in constant time. **Ordinary Platos session tokens cannot reach these routes** — erasure is an operator capability, not something an end user's token can trigger.
+
+```json
+POST /api/v1/agent/admin/privacy/erasures
+{ "externalUserId": "user@example.com", "organizationId": "org_…", "idempotencyKey": "…" }
+```
+
+`idempotencyKey` is required. Replaying a request returns the original receipt rather than running a second destructive pass — which matters because the natural response to an ambiguous erasure result is to fire it again.
+
+## Why it matters
+
+**One person is many handles.** Erasure resolves a subject from the requested `externalUserId`, any linked external id, and any channel identity handle. Deleting only rows matching the string you were given leaves the person reconstructable from the threads they entered by another route.
+
+**Deletion is not evidence of deletion.** S3-compatible deletes succeed for keys that never existed, so a successful delete call proves nothing. Every executor re-probes after sweeping and records the surviving count. An inconclusive probe is recorded as *still present*, never rounded down to "gone" — that is the direction that manufactures a false certificate.
+
+**Erasure order matters.** Stores are swept `minio → redis → clickhouse → postgres`. Postgres is last because it holds the pointers the other sweeps need; deleting it first would orphan objects that could no longer be found, let alone deleted.
+
+**Some tables must never be swept.** A `userId` column appears on operator tables too — accounts, access tokens, MFA recovery codes. Deleting by column name across every table carrying it would destroy an operator's account while purporting to serve a customer's request. The tables are therefore enumerated explicitly in `subject-graph.ts`: an allow-list is auditable, a column scan is a loaded gun.
+
+## Reading a receipt
+
+Each store reports independently, and the operation's status is derived from them.
+
+- `deleted` — swept, and verified gone. Settled.
+- `nothing_to_delete` — the subject had nothing here. Settled.
+- `not_provisioned` — this store is not wired in this deployment. **Settles the operation but is not evidence of deletion.** If you run ClickHouse or object storage, wire them before the receipt means anything.
+- `failed` — the sweep errored. Retryable.
+- `unknown` — the executor crashed mid-pass and the true state was never established. Retryable, and deliberately *not* reported as failed: the distinction between "we know it didn't work" and "we don't know what happened" is the one a regulator will ask about.
+- `blocked_legal_hold` — see below. Nothing was destroyed.
+
+Receipts are content-free by construction. They record counts, statuses, and error *classes* — never the erased content, and never the raw external user id, which is stored only as a salted org-scoped hash. A receipt that quoted the data it destroyed would reintroduce the thing the erasure removed.
+
+## Legal holds
+
+Set `PLATOS_LEGAL_HOLD_USER_IDS` to a comma-separated register of held identifiers. The check runs before the operation row is created and before any executor touches a store; a match returns `blocked_legal_hold` naming the entry that stopped it and destroys nothing. The refused request is still recorded — a refusal is itself an event you may have to evidence.
+
+Matching runs across **every alias the subject resolves to**, not just the requested identifier, so a hold registered against a Slack id also blocks an erasure requested by that person's email. Registering any one identifier is sufficient. Changing the register requires a restart.
+
+## Common pitfalls
+
+- **Treating `not_provisioned` as success.** It means "not wired here", not "nothing to delete". Check it against the stores you actually run.
+- **Erasure is org-scoped by design.** A request cannot reach across organizations. Someone present in several needs one request per org.
+- **ClickHouse is not swept automatically yet.** The executor detects the deployment but does not submit a mutation. Scrub by hand and record it alongside the receipt — see [GDPR + data deletion](https://github.com/winsenlabs/platos/blob/main/docs/gdpr.md).
+- **Late writes can resurrect a subject.** An in-flight write landing after the sweep reintroduces rows. Quiesce, or re-run, for anyone active at the moment of erasure.
+- **Audit rows survive on purpose.** Tool-call and admin audit records retain identifiers for forensics. Document that window in your privacy notice; it is the one thing that outlives the request.
+
+## Related
+
+- [Safety and PII](/docs/safety-and-pii): redaction before data is stored.
+- [Legal and policies](/docs/legal-and-policies): what applies when you self-host.
+- [Memory](/docs/memory): the per-user memory delete, a narrower operation than this one.
+- [Scope and multi-tenancy](/docs/scope-and-multi-tenancy): why the org boundary is the erasure boundary.

--- a/content/docs/legal-and-policies.md
+++ b/content/docs/legal-and-policies.md
@@ -14,6 +14,7 @@ questions:
   - "How does Platos handle my data?"
   - "Is Platos GDPR compliant?"
 related:
+  - hard-erasure
   - encryption-and-secrets
   - self-hosting
 ---

--- a/content/docs/safety-and-pii.md
+++ b/content/docs/safety-and-pii.md
@@ -14,6 +14,7 @@ questions:
   - "Can a safety event auto-pause an agent?"
   - "How do I export safety events for compliance review?"
 related:
+  - hard-erasure
   - approvals-and-hitl
   - audit-log
   - encryption-and-secrets

--- a/docs/gdpr.md
+++ b/docs/gdpr.md
@@ -34,42 +34,53 @@ Four stores hold user-identifiable data:
 
 ## Right to erasure — per-user delete
 
+Use the hard-erasure API. It performs the whole cascade across Postgres, Redis, ClickHouse, and object storage in one idempotent operation and returns a durable receipt recording what was deleted and what was verified gone. The full request/response contract, the receipt status model, and the deployment prerequisites live in [Hard erasure — contract and evidence](./gdpr-erasure.md).
+
 <Steps>
-<Step title="Identify the scope">
-A user lives within an `(organizationId, projectId, environmentId)` tuple. A single person may have separate records across multiple scopes — delete in each scope where they have data.
+<Step title="Identify the subject">
+A subject is resolved from an `externalUserId` within an `organizationId`. Platos matches on the external id, any linked external id, and any linked identity handle, so one request covers the same person arriving through several channels.
+
+A single person may still hold data in more than one organization. Erasure is org-scoped by design — a request cannot reach across orgs — so raise one request per organization where they have data.
 </Step>
 
-<Step title="Run the admin delete route">
-`DELETE /api/v1/admin/users/:userId/data?organizationId=…&projectId=…&environmentId=…`
+<Step title="Request the erasure">
+`POST /api/v1/agent/admin/privacy/erasures`
 
-Guarded by `PLATOS_ADMIN_TOKEN` in the `X-Platos-Admin-Token` header. Cascades:
-- Delete `PlatosMemory` + `PlatosMemoryEntity` + `PlatosMemoryRelationship` for the user.
-- Delete `PlatosAgentUserProfile`.
-- Delete `PlatosMessageRating` written by the user.
-- Delete `PlatosAgentMessage` rows in threads owned by the user.
-- Delete `PlatosAgentThread` rows for the user.
-- Delete `PlatosMessageAttachment` rows + schedule a MinIO object delete.
-</Step>
-
-<Step title="Purge attachment bytes">
-The attachment deletion is asynchronous — the scheduled `platos.attachments.retention` task (runs hourly) sweeps the MinIO objects. To force immediate purge:
-`POST /api/v1/agent/attachments/retention?forceUserId={userId}`
-</Step>
-
-<Step title="ClickHouse label scrub">
-ClickHouse stores the `userId` as a label on span + cost rows. Labels are not indexed by user, so scrub via:
-```sql
-ALTER TABLE platos_spans_v1
-  UPDATE platos_user_id = 'deleted'
-  WHERE platos_user_id = '{userId}';
+```json
+{ "externalUserId": "…", "organizationId": "…", "idempotencyKey": "…" }
 ```
-Run in `ON CLUSTER` mode if you're sharded.
+
+Authenticated with `PLATOS_ADMIN_TOKEN` in the `X-Platos-Admin-Token` header, compared in constant time. Ordinary Platos session tokens cannot reach this route. The `idempotencyKey` is required: replaying a request returns the original receipt rather than running a second destructive pass.
 </Step>
 
-<Step title="Verify">
-`GET /api/v1/admin/users/:userId/data?dryRun=1` returns a count per table. After deletion, every count should be zero except audit rows.
+<Step title="Read the receipt">
+`GET /api/v1/agent/admin/privacy/erasures/:operationId`
+
+Each store reports independently. Treat only `deleted` and `nothing_to_delete` as settled. `not_provisioned` means that store is not wired in this deployment — it settles the operation but is **not** evidence of deletion, and if you run ClickHouse or object storage you must wire them before the receipt means anything. `failed` and `unknown` are retryable; `unknown` specifically means a store crashed mid-pass and its true state was never established, which is deliberately not rounded down to success.
+</Step>
+
+<Step title="Retry anything unsettled">
+`POST /api/v1/agent/admin/privacy/erasures/:operationId/retry`
+
+Retries only the stores that are not settled. Safe to call repeatedly — deletion is idempotent, and stores already `deleted` are skipped rather than re-swept.
+</Step>
+
+<Step title="Verify independently">
+The receipt carries its own negative verification: after deleting, each executor re-probes for survivors and records the count. For an external audit, query the stores yourself rather than trusting the receipt — `GET /api/v1/agent/admin/privacy/subjects/:externalUserId/inventory` returns the per-store counts the operation would target, and should return zero across the board once the operation is settled.
 </Step>
 </Steps>
+
+### If you are scrubbing ClickHouse by hand
+
+The API handles this when ClickHouse is provisioned. If you are working on an older deployment, note that spans live in `trigger_dev.platos_spans_v1` and the identity columns are `user_id` (SHA256-hashed, the canonical join key), plus `user_display_name` and `user_email`, which hold plaintext when an entity signed a `userMeta` claim into the session token.
+
+```sql
+ALTER TABLE trigger_dev.platos_spans_v1
+  UPDATE user_display_name = '', user_email = ''
+  WHERE user_id = '{hashedUserId}';
+```
+
+Null the plaintext columns and keep the hashed `user_id`: it carries no personal data on its own and it is what every cost and usage rollup joins on, so blanking it corrupts historical billing to no privacy benefit. ClickHouse mutations are asynchronous — poll `system.mutations` for `is_done` before reporting the erasure complete. Run `ON CLUSTER` if you are sharded.
 
 ### Audit exception
 
@@ -118,7 +129,15 @@ Already has a TTL — `PLATOS_ATTACHMENT_TTL_DAYS` (default 30). Past the TTL, a
 
 ## Legal holds
 
-Before deleting, check whether the user is subject to a legal hold (lit-hold, tax audit, ongoing incident). Platos does not automate hold management; track this in your operator playbook. The `PLATOS_LEGAL_HOLD_USER_IDS` env (comma-separated) is checked by the delete route and rejects the request for any user on the list.
+Before deleting, check whether the user is subject to a legal hold (lit-hold, tax audit, ongoing incident).
+
+Set `PLATOS_LEGAL_HOLD_USER_IDS` to a comma-separated register of held identifiers. The erasure API checks it before creating the operation and before any executor touches a store; a match returns a receipt with status `blocked_legal_hold` naming the register entry that stopped it, and destroys nothing. The refused request is still recorded as an operation, because a refusal is itself an event you may have to evidence.
+
+Matching runs across **every alias the subject resolves to**, not just the identifier in the request. A hold registered against a Slack user id therefore also blocks an erasure requested by that person's email. Registering any one of a subject's identifiers is sufficient; matching is case-insensitive.
+
+The API also accepts a `legalHoldPolicyId` in the request body for a hold the caller already knows about. That is a supplement, not a substitute — it only protects a subject when whoever fires the request is already aware of the hold, which is exactly the knowledge a register exists because people do not reliably have.
+
+Platos does not manage hold lifecycle: adding, reviewing, and releasing holds stays in your operator playbook. Changing the env requires a restart to take effect.
 
 ## Breach notification
 
@@ -127,3 +146,12 @@ If you suspect a breach, rotate every secret in `docs/self-hosting.md#key-rotati
 ## Why this isn't baked into the UI yet
 
 The OSS mode focuses on giving operators the primitives. A polished admin UI for deletion/export is a post-v1 item. If you need it sooner, wire the routes above into your own admin tooling — they're stable.
+
+## Known gaps
+
+Be precise with regulators about what the receipt currently proves:
+
+- **ClickHouse is not swept automatically.** The executor detects the deployment and reports `not_provisioned` where the table is absent, but it does not yet submit and poll a mutation. Where you run ClickHouse, scrub by hand as above and record it alongside the receipt.
+- **`not_provisioned` is not evidence of deletion.** It settles an operation so the receipt is not left hanging, and it means only that a store is not wired here. Confirm every store you actually run reports `deleted` or `nothing_to_delete`.
+- **Late-event resurrection is not prevented.** An in-flight write that lands after the sweep can reintroduce rows for an erased subject. Quiesce or re-run for a subject who was active at the moment of erasure.
+- **Object storage and Redis executors are lightly exercised.** Both are implemented and unit-tested, but have not been run against a large real corpus.


### PR DESCRIPTION
## The defect

`docs/gdpr.md` told operators:

> The `PLATOS_LEGAL_HOLD_USER_IDS` env (comma-separated) is checked by the delete route and rejects the request for any user on the list.

**Nothing in the codebase read that variable** — zero references. An operator who set it believed held subjects were protected, and would have discovered otherwise only after an irreversible deletion had destroyed the evidence.

The erasure API did carry a `legalHoldPolicyId`, but the *caller* supplies it. That protects a subject only when whoever fires the request already knows about the hold — precisely the knowledge a hold register exists because people do not reliably have.

## The fix

`legal-hold.ts` adds the check. It runs before the operation row is created and before any executor touches a store.

It matches across **every alias the subject resolves to**, not the requested identifier alone. A hold naming a Slack id must also stop an erasure requested by that person's email, or every held subject stays erasable through an alias they were not registered under — the same hole the subject graph exists to close for deletion.

A blocked request is still recorded as an operation with status `blocked_legal_hold` naming the entry that stopped it. A refusal is itself an event an operator has to evidence, and "blocked" with no reason is indistinguishable from a bug.

A caller-supplied `legalHoldPolicyId` still wins if present; this only adds the holds the caller did not know about.

## Also corrected

The documented ClickHouse scrub targeted a `platos_user_id` column on `platos_spans_v1`. The real column is `user_id` on `trigger_dev.platos_spans_v1`, so **the published ALTER would have failed on an unknown column**. The replacement nulls the plaintext identity columns (`user_display_name`, `user_email`) and keeps the hashed join key — it carries no personal data alone and every cost rollup joins on it, so blanking it corrupts billing history to no privacy benefit.

`content/docs/hard-erasure.md` is new — the API had no user-facing page. It states the known gaps plainly (ClickHouse not swept automatically, `not_provisioned` is not evidence of deletion, late-event resurrection), because a receipt that overstates what it proves is worse than no receipt.

## Test plan

- `vitest run src/privacy/` — 72 passed, including 11 new. `tsc --noEmit` clean in `privacy/` (3 pre-existing TS2307s elsewhere from an uninstalled MCP SDK).
- Deployed to test.platos and verified against the **compiled artifact in the running image**, not local source:
  - unset register → `null` (inert; no behaviour change where the register is unconfigured)
  - hold on `slack:U…` + request by email → blocked
  - hold on canonical end-user id → blocked
  - case-insensitive → blocked; unrelated id → `null`; trailing comma → no empty entry
- Live auth matrix unchanged: no token → 401, bad token → 401, valid token → 400 validation.

Enabling the register on test.platos needs `PLATOS_LEGAL_HOLD_USER_IDS` set in `/opt/platos/.env` — I did not edit the production env file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ2P5P9kCF2ihh6YipRmzM