### PR TITLE
fix(tools): registry never pruned — stale tools injected and dispatched at deleted entities

### DIFF
--- a/apps/agent/src/auth/auth.module.ts
+++ b/apps/agent/src/auth/auth.module.ts
@@ -5,9 +5,10 @@ import { ProviderHealthService } from "./provider-health.service";
 import { SessionTokenController } from "./session-token.controller";
 import { PublicGuestTokenController } from "./public-guest-token.controller";
 import { ProvidersModule } from "../providers/providers.module";
+import { ToolGatewayModule } from "../tool-gateway/tool-gateway.module";
 
 @Module({
-  imports: [ProvidersModule],
+  imports: [ProvidersModule, ToolGatewayModule],
   controllers: [
     // EOBD.95 — entity-authed mint endpoint.
     SessionTokenController,

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Inject, Logger } from "@nestjs/common";
+import { Injectable, Inject, Logger, Optional } from "@nestjs/common";
 import { PRISMA_TOKEN } from "../shared/database.provider";
 import { REDIS_TOKEN } from "../shared/redis.provider";
 import type Redis from "ioredis";
 import * as crypto from "crypto";
 import { env } from "../shared/env";
+import { ToolRegistryService } from "../tool-gateway/tool-registry.service";
 
 /**
  * Session token claims.
@@ -107,6 +108,10 @@ export class AuthService {
   constructor(
     @Inject(PRISMA_TOKEN) prisma: any,
     @Inject(REDIS_TOKEN) private readonly redis: Redis,
+    // Optional so focused test modules that never touch entity deletion do not
+    // have to pull the whole tool gateway in. ToolGatewayModule has no edge
+    // back into AuthModule, so this import direction introduces no cycle.
+    @Optional() private readonly toolRegistry?: ToolRegistryService,
   ) {
     this.prisma = prisma;
   }
@@ -584,7 +589,42 @@ export class AuthService {
     });
   }
 
+  /**
+   * Delete an entity and everything the tool registry still believes about it.
+   *
+   * The DB row was previously all that got deleted. The registry's in-memory
+   * scoped-tool cache is keyed by (org, project, env, entityId) and had no
+   * eviction path on this route, so a deleted entity's tools stayed live: they
+   * were still injected into every turn with full schemas, and dispatching one
+   * resolved `entityPk` against a row that no longer existed, failing with
+   * "Entity <id> not registered". Only a process restart cleared it.
+   *
+   * The purge runs BEFORE the row is deleted so the cache key can be rebuilt
+   * from the entity; `purgeEntity` also matches buckets by entityPk so it stays
+   * correct if that order ever changes.
+   */
   async deleteEntity(organizationId: string, projectId: string, entityId: string): Promise<boolean> {
+    const entity = await this.prisma.platosConnectedEntity.findFirst({
+      where: { organizationId, projectId, entityId },
+      select: { id: true },
+    });
+
+    if (entity && this.toolRegistry) {
+      try {
+        const purged = await this.toolRegistry.purgeEntity(entity.id);
+        this.logger.log(
+          `deleteEntity ${entityId}: purged ${purged.mappingsRemoved} tool mappings, ${purged.bucketsEvicted} cache buckets`,
+        );
+      } catch (err: any) {
+        // A failed purge must not block the delete — the operator asked for the
+        // entity to be gone. Loud, because the surviving cache entries are the
+        // exact condition that produces "Entity not registered" at dispatch.
+        this.logger.error(
+          `deleteEntity ${entityId}: registry purge failed, stale tools may persist until restart — ${err?.message ?? err}`,
+        );
+      }
+    }
+
     const result = await this.prisma.platosConnectedEntity.deleteMany({
       where: { organizationId, projectId, entityId },
     });

--- a/apps/agent/src/tool-gateway/bm25.test.ts
+++ b/apps/agent/src/tool-gateway/bm25.test.ts
@@ -107,6 +107,16 @@ describe("ToolRegistryService — source/entity filter", () => {
       state: { toolDefs, mappings },
       platosToolDefinition: {
         findUnique: async (args: any) => toolDefs.get(args.where.name) ?? null,
+        // Tool definitions are tenant-scoped rows, so `registerTools` looks them
+        // up by (name, org, project) via findFirst. The stub only had findUnique
+        // by name, from before that scoping landed.
+        findFirst: async (args: any) =>
+          Array.from(toolDefs.values()).find(
+            (r) =>
+              r.name === args.where.name &&
+              r.organizationId === args.where.organizationId &&
+              r.projectId === args.where.projectId,
+          ) ?? null,
         findMany: async () => Array.from(toolDefs.values()),
         create: async (args: any) => {
           const row = { id: `tool_${toolDefs.size + 1}`, ...args.data };
@@ -118,6 +128,13 @@ describe("ToolRegistryService — source/entity filter", () => {
           if (row) Object.assign(row, args.data);
           return row;
         },
+      },
+      // `registerTools` reads the entity row for linkedAgentIds / mcpConfig and
+      // is written to tolerate a miss (defaults to unrestricted, no envelope).
+      // The stub omitted the model entirely, so the read threw on `findFirst`
+      // of undefined rather than returning null.
+      platosConnectedEntity: {
+        findFirst: async () => null,
       },
       platosEntityToolMapping: {
         findMany: async () => mappings,

--- a/apps/agent/src/tool-gateway/bm25.ts
+++ b/apps/agent/src/tool-gateway/bm25.ts
@@ -47,6 +47,20 @@ export class BM25Index {
   private totalDocs = 0;
 
   /**
+   * Drop every document.
+   *
+   * `addDocument` is idempotent per id, so a rebuild could refresh and add, but
+   * never drop a doc that had left the source set — the index could only grow.
+   * A rebuild that cannot shrink is not a rebuild.
+   */
+  clear(): void {
+    this.docs.clear();
+    this.docFreqs.clear();
+    this.avgDocLength = 0;
+    this.totalDocs = 0;
+  }
+
+  /**
    * Add a document to the index.
    * Call this when a tool is registered. The text should be:
    * `${tool.name} ${tool.description} ${paramNames.join(" ")}`

--- a/apps/agent/src/tool-gateway/registry-invalidation.test.ts
+++ b/apps/agent/src/tool-gateway/registry-invalidation.test.ts
@@ -140,3 +140,31 @@ describe("rebuildIndex — must replace, not merge", () => {
     expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(0);
   });
 });
+
+describe("rebuildIndex — BM25 must only hold dispatchable tools", () => {
+  it("does not index a definition that no mapping references", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b"]), [entity]);
+    // A definition row with no mapping — the shape left behind by a deleted
+    // entity, since definitions are shared and outlive their mappings.
+    const orphan = { id: "t_ghost", name: "ghost", description: "", paramSchema: {}, category: null };
+    const realFindMany = prisma.platosToolDefinition.findMany;
+    prisma.platosToolDefinition.findMany = async () => [...(await realFindMany()), orphan];
+
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+
+    // 2 mapped tools indexed, the orphan excluded.
+    expect(svc.getIndexStats().totalDocs).toBe(2);
+  });
+
+  it("shrinks the index when mappings go away", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b", "c"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+    expect(svc.getIndexStats().totalDocs).toBe(3);
+
+    prisma.state.rows = [];
+    await svc.rebuildIndex();
+    expect(svc.getIndexStats().totalDocs).toBe(0);
+  });
+});

--- a/apps/agent/src/tool-gateway/registry-invalidation.test.ts
+++ b/apps/agent/src/tool-gateway/registry-invalidation.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ToolRegistryService } from "./tool-registry.service";
+
+/**
+ * Registry invalidation — the two paths that only ever added.
+ *
+ * Both live bugs came from the same shape: `scopedToolCache` was written by
+ * `registerTools` and cleared in exactly one place (`reconcileEntityTools`),
+ * which only the MCP discovery path ever called. So over the WebSocket
+ * transport a shrinking tool set never shrank, and a deleted entity's tools
+ * stayed injected until the process restarted — resolving at dispatch against
+ * an entity row that no longer existed.
+ */
+
+type Row = { id: string; toolId: string; entityId: string; environmentId: string; tool: { id: string; name: string } };
+
+function makePrisma(rows: Row[], entities: any[]) {
+  const state = { rows: [...rows] };
+  return {
+    state,
+    platosToolDefinition: {
+      findMany: async () => state.rows.map((r) => ({ ...r.tool, description: "", paramSchema: {}, category: null })),
+    },
+    platosEntityToolMapping: {
+      findMany: async ({ where }: any) => {
+        let out = state.rows;
+        if (where?.entityId) out = out.filter((r) => r.entityId === where.entityId);
+        if (where?.environmentId) out = out.filter((r) => r.environmentId === where.environmentId);
+        return out.map((r) => ({
+          ...r,
+          enabled: true,
+          callbackUrl: "http://x",
+          entity: entities.find((e) => e.id === r.entityId) ?? null,
+        }));
+      },
+      deleteMany: async ({ where }: any) => {
+        const before = state.rows.length;
+        if (where?.id?.in) state.rows = state.rows.filter((r) => !where.id.in.includes(r.id));
+        else if (where?.entityId) state.rows = state.rows.filter((r) => r.entityId !== where.entityId);
+        return { count: before - state.rows.length };
+      },
+      count: async ({ where }: any) => state.rows.filter((r) => r.toolId === where.toolId).length,
+    },
+    platosConnectedEntity: {
+      findFirst: async ({ where }: any) => entities.find((e) => e.id === where.id) ?? null,
+    },
+  };
+}
+
+const entity = {
+  id: "pk_walle",
+  entityId: "walle-tools",
+  organizationId: "org1",
+  projectId: "proj1",
+  linkedAgentIds: [],
+  mcpConfig: null,
+};
+
+const rowsFor = (names: string[]): Row[] =>
+  names.map((n, i) => ({
+    id: `m${i}`,
+    toolId: `t_${n}`,
+    entityId: "pk_walle",
+    environmentId: "env1",
+    tool: { id: `t_${n}`, name: n },
+  }));
+
+function makeRegistry(prisma: any) {
+  const svc = new ToolRegistryService(prisma as any);
+  return svc;
+}
+
+describe("reconcileEntityTools — shrinking a declared tool set", () => {
+  it("removes the tools a fresh declaration no longer reports", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b", "c", "d"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+
+    // Entity re-declares a smaller surface — the case that stayed at 22.
+    const res = await svc.reconcileEntityTools("pk_walle", "env1", ["a", "b"]);
+
+    expect(res.removed).toBe(2);
+    expect(prisma.state.rows.map((r) => r.tool.name).sort()).toEqual(["a", "b"]);
+  });
+
+  it("is a no-op when the declaration is unchanged", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+    expect((await svc.reconcileEntityTools("pk_walle", "env1", ["a", "b"])).removed).toBe(0);
+  });
+});
+
+describe("purgeEntity — deleting an entity", () => {
+  it("drops the mappings and evicts the cache bucket", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b", "c"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+    expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(1);
+
+    const res = await svc.purgeEntity("pk_walle");
+
+    expect(res.mappingsRemoved).toBe(3);
+    expect(res.bucketsEvicted).toBe(1);
+    expect(prisma.state.rows).toHaveLength(0);
+    // The condition that produced "Entity walle-tools not registered": tools
+    // still resolvable from cache after the entity is gone.
+    expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(0);
+    expect(
+      svc.getScopedTools({ organizationId: "org1", projectId: "proj1", environmentId: "env1" }),
+    ).toHaveLength(0);
+  });
+
+  it("still evicts when the entity row is already deleted", async () => {
+    // purge called after the row is gone — the key cannot be rebuilt, so the
+    // bucket has to be found by the entityPk stamped on its entries.
+    const prisma = makePrisma(rowsFor(["a"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+
+    prisma.platosConnectedEntity.findFirst = async () => null;
+    const res = await svc.purgeEntity("pk_walle");
+
+    expect(res.bucketsEvicted).toBe(1);
+    expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(0);
+  });
+});
+
+describe("rebuildIndex — must replace, not merge", () => {
+  it("clears a bucket whose entity no longer has mappings", async () => {
+    const prisma = makePrisma(rowsFor(["a", "b"]), [entity]);
+    const svc = makeRegistry(prisma);
+    await svc.rebuildIndex();
+    expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(1);
+
+    // Entity deleted out from under the process (what actually happened live).
+    prisma.state.rows = [];
+    await svc.rebuildIndex();
+
+    expect(svc.getIndexStats().cachedScopeEntityPairs).toBe(0);
+  });
+});

--- a/apps/agent/src/tool-gateway/tool-registry.service.ts
+++ b/apps/agent/src/tool-gateway/tool-registry.service.ts
@@ -134,12 +134,7 @@ export class ToolRegistryService implements OnModuleInit {
       // memory with no way to clear them short of a process restart. Clearing
       // first makes this the operational recovery path it always read like.
       this.scopedToolCache.clear();
-
-      const tools = await this.prisma.platosToolDefinition.findMany();
-      for (const tool of tools) {
-        const text = `${tool.name} ${tool.description} ${this.extractParamNames(tool.paramSchema)}`;
-        this.bm25.addDocument(tool.id, text);
-      }
+      this.bm25.clear();
 
       // Load entity mappings into cache, joining to entity so we know scope.
       // Include mcpConfig so `injectMcpContext` lands on the cached entry —
@@ -184,6 +179,20 @@ export class ToolRegistryService implements OnModuleInit {
             : [],
           entityMcpInjectContext: entity.mcpConfig?.injectMcpContext === true,
         });
+
+        // Index for find_tools ONLY when a live mapping exists.
+        //
+        // This used to seed from `platosToolDefinition.findMany()` with no
+        // filter, i.e. every definition ever registered in the deployment.
+        // Definition rows are shared and deliberately outlive their mappings,
+        // so the index filled with tools no entity still offers — on this box,
+        // 32 indexed against 9 dispatchable. `find_tools` could then return a
+        // tool with no mapping, and calling it fails at dispatch with "Entity
+        // not registered". It also undid the eviction work: both
+        // `reconcileEntityTools` and `purgeEntity` remove a BM25 doc when its
+        // last mapping goes, and the next restart put every one of them back.
+        const text = `${m.tool.name} ${m.tool.description} ${this.extractParamNames(m.tool.paramSchema)}`;
+        this.bm25.addDocument(m.toolId, text);
       }
 
       const stats = this.bm25.getStats();

--- a/apps/agent/src/tool-gateway/tool-registry.service.ts
+++ b/apps/agent/src/tool-gateway/tool-registry.service.ts
@@ -128,6 +128,13 @@ export class ToolRegistryService implements OnModuleInit {
    */
   async rebuildIndex(): Promise<void> {
     try {
+      // A rebuild must REPLACE, not merge. Buckets were only ever created when
+      // absent and written into, so re-running this could add and update
+      // entries but never remove one — leaving a deleted entity's tools live in
+      // memory with no way to clear them short of a process restart. Clearing
+      // first makes this the operational recovery path it always read like.
+      this.scopedToolCache.clear();
+
       const tools = await this.prisma.platosToolDefinition.findMany();
       for (const tool of tools) {
         const text = `${tool.name} ${tool.description} ${this.extractParamNames(tool.paramSchema)}`;
@@ -517,6 +524,79 @@ export class ToolRegistryService implements OnModuleInit {
     }
 
     return { removed: stale.length };
+  }
+
+  /**
+   * Drop every trace of an entity from the registry: mappings, the in-memory
+   * scoped-tool buckets across ALL environments, and any BM25 doc nothing else
+   * references.
+   *
+   * THE DEFECT THIS EXISTS TO FIX
+   *
+   * `deleteEntity` was a bare `deleteMany` on PlatosConnectedEntity. The row
+   * vanished; the cache did not. `scopedToolCache` is keyed by
+   * (org, project, env, entityId) and only ever written — the sole delete in
+   * this service lives in `reconcileEntityTools`, which the WebSocket path
+   * never calls. So a deleted entity's tools kept being injected into every
+   * turn, and dispatching one looked up `toolEntry.entityPk` against a row that
+   * no longer existed and failed with "Entity <id> not registered".
+   *
+   * That is a bad failure to leave in place: the tools are advertised to the
+   * model with full schemas, so the model reasonably calls them, and the user
+   * sees a capability the agent claims and cannot perform. It also silently
+   * inflates every prompt with dead schemas until the process restarts, which
+   * is the only thing that ever cleared this.
+   *
+   * Takes the PK because entityId is only unique per (org, project), and the
+   * caller has already resolved the row it is about to delete.
+   */
+  async purgeEntity(entityPk: string): Promise<{ mappingsRemoved: number; bucketsEvicted: number }> {
+    const mappings = await this.prisma.platosEntityToolMapping.findMany({
+      where: { entityId: entityPk },
+      include: { tool: { select: { id: true, name: true } } },
+    });
+
+    // Resolve the cache-key parts before the row is gone. A purge called after
+    // the entity row is deleted can still clean mappings and BM25, but cannot
+    // rebuild the bucket key — so fall back to scanning buckets by entityPk.
+    const entity = await this.prisma.platosConnectedEntity.findFirst({
+      where: { id: entityPk },
+      select: { organizationId: true, projectId: true, entityId: true },
+    });
+
+    if (mappings.length > 0) {
+      await this.prisma.platosEntityToolMapping.deleteMany({
+        where: { entityId: entityPk },
+      });
+    }
+
+    // Evict every bucket owned by this entity. Keyed lookup when the row is
+    // still present; otherwise identify buckets by the entityPk stamped on
+    // their entries, which is what makes this safe to call in either order.
+    let bucketsEvicted = 0;
+    for (const [key, bucket] of this.scopedToolCache.entries()) {
+      const ownedByKey =
+        entity !== null &&
+        key.startsWith(`${entity.organizationId}:${entity.projectId}:`) &&
+        key.endsWith(`:${entity.entityId}`);
+      const ownedByEntry = [...bucket.values()].some((e) => e.entityPk === entityPk);
+      if (ownedByKey || ownedByEntry) {
+        this.scopedToolCache.delete(key);
+        bucketsEvicted++;
+      }
+    }
+
+    // Drop BM25 docs for definitions nothing else points at. The definition row
+    // itself is shared and tenant-scoped, so it stays — same rule as reconcile.
+    for (const m of mappings) {
+      if (!m.tool) continue;
+      const remaining = await this.prisma.platosEntityToolMapping.count({
+        where: { toolId: m.tool.id },
+      });
+      if (remaining === 0) this.bm25.removeDocument(m.tool.id);
+    }
+
+    return { mappingsRemoved: mappings.length, bucketsEvicted };
   }
 
   /**

--- a/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
+++ b/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
@@ -461,6 +461,40 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
             normalized,
             callbackUrl,
           );
+          // `tool_register` is a COMPLETE declaration of what this entity
+          // offers, so registration has to be a replace and not an accumulation.
+          // `registerTools` is additive-upsert, so without this prune an entity
+          // that cut its surface from 22 tools to 9 stayed registered at 22: the
+          // 13 it dropped were never in the fresh frame, so nothing ever removed
+          // them. The model kept being offered tools the backend had retired,
+          // and the operator saw a count that disagreed with their own config.
+          //
+          // The MCP discovery path already did this (`EntityMcpDiscoveryService`
+          // pairs registerTools with reconcileEntityTools); only the WebSocket
+          // path was missing it, which is why the two transports disagreed.
+          //
+          // A client that genuinely needs to register in batches can opt out
+          // with `partial: true` — then the frame is a fragment and pruning
+          // against it would delete the other fragments.
+          // Best-effort: the registration itself already succeeded, so a failed
+          // prune must not turn a good register into an error the client will
+          // retry. The next `tool_register` reconciles against the same fresh
+          // set, so the only cost of a miss is staying stale until then.
+          let pruned = 0;
+          if (msg.partial !== true) {
+            try {
+              const rec = await this.toolRegistry.reconcileEntityTools(
+                conn.entityPk,
+                conn.environmentId,
+                normalized.map((t) => t.name),
+              );
+              pruned = rec.removed;
+            } catch (err: any) {
+              this.logger.warn(
+                `entity ${entityId}/${environmentId}: tool prune failed, retired tools may linger — ${err?.message ?? err}`,
+              );
+            }
+          }
           this.send(ws, {
             type: "tools_registered",
             entity_id: entityId,
@@ -468,9 +502,10 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
             count: result.registered,
             new_tools: result.newTools,
             updated: result.updated,
+            pruned,
           });
           this.logger.log(
-            `entity ${entityId}/env=${environmentId}: registered ${result.registered} tools (+${result.newTools} new, ${result.updated} updated)`,
+            `entity ${entityId}/env=${environmentId}: registered ${result.registered} tools (+${result.newTools} new, ${result.updated} updated, -${pruned} pruned)`,
           );
         } catch (err: any) {
           this.logger.warn(`entity ${entityId}/${environmentId}: tool_register failed — ${err?.message}`);


### PR DESCRIPTION
## Core issue

Both reported symptoms are one bug: **the tool registry only ever added.**

`scopedToolCache` is keyed by `(org, project, env, entityId)` and written by `registerTools`. The only delete in the entire service lived in `reconcileEntityTools` — which **only `EntityMcpDiscoveryService` ever called**. Over the WebSocket transport, nothing could ever shrink.

### Evidence from test.platos

- `10:55:23` — `entity walle-tools connected`, `registered 18 tools`
- Entity `walle-tools` then deleted; `walle-mcp-service` created with 9 tools
- DB: 9 mappings, all pointing at the live entity. Clean.
- `13:31–13:33` — every tool call fails `Entity walle-tools not registered`, dispatching against `entityPk=cmryt4gz4000sqo011tm0675q`, **a row that does not exist**

The DB was correct the whole time. The in-memory cache was serving a deleted entity's 18 tools, and `tool-executor.service.ts:840` resolved their `entityPk` against a missing row.

## Three fixes

1. **WS `tool_register` now prunes.** It is a complete declaration, but `registerTools` is additive-upsert and the WS path never reconciled — so 22→9 stayed at 22. Best-effort, so a failed prune can't fail a registration that already succeeded; `partial: true` opts out for batching clients.

2. **`deleteEntity` now purges.** It was a bare `deleteMany` on the entity row. `purgeEntity` drops mappings, evicts buckets (by key, or by `entityPk` when the row is already gone), and releases BM25 docs nothing else references.

3. **`rebuildIndex` now replaces instead of merging.** Buckets were created only when absent and never cleared, so it could not recover from this state either — restart was the only cure, by virtue of starting from an empty map.

## The layer under it

`rebuildIndex` seeded BM25 from `platosToolDefinition.findMany()` **unfiltered** — every definition ever registered. Definition rows are shared and deliberately outlive their mappings, so the index held **32 tools against 9 dispatchable**. `find_tools` could hand the model a tool with no mapping, which then fails at dispatch. It also undid the eviction work: both reconcile and purge drop a BM25 doc when its last mapping goes, and every restart put them all back.

Now seeded from the mappings loop. `BM25Index.clear()` added — `addDocument` is idempotent per id, so the index could only ever grow.

## Verification

Live on test.platos, from the agent's own logs:

- before: `Index rebuilt: 32 tools, 552 terms`
- after: `Index rebuilt: 9 tools, 353 terms, 1 (scope,entity) buckets`
- `registered 9 tools (+0 new, 0 updated, -0 pruned)` — new counter reporting

`vitest run src/tool-gateway/` — 65 passed. 3 of those were failing before this branch on a stale test double (`bm25.test.ts` lacked `platosConnectedEntity` and `platosToolDefinition.findFirst`); fixed, so the suite is green rather than green-except-three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ2P5P9kCF2ihh6YipRmzM