### PR TITLE
fix(agents): coerce modelRoutes like the other array columns

### DIFF
--- a/apps/agent/src/agent-runtime/agent-crud.service.ts
+++ b/apps/agent/src/agent-runtime/agent-crud.service.ts
@@ -461,7 +461,10 @@ export class AgentCrudService {
   private buildSnapshot(agent: any): AgentVersionSnapshot {
     return {
       model: agent.model,
-      modelRoutes: (agent.modelRoutes as ModelRoute[] | null) ?? null,
+      // Coerced like the block lists below — a row already carrying a
+      // double-encoded string must not reach the runtime's route resolver,
+      // which does `(modelRoutes ?? []).map(...)` and would throw on a string.
+      modelRoutes: coerceBlockList(agent.modelRoutes) as ModelRoute[] | null,
       systemPrompt: agent.systemPrompt ?? null,
       promptBlocks: coerceBlockList(agent.promptBlocks) as PromptBlock[] | null,
       dynamicBlocks: coerceBlockList(agent.dynamicBlocks) as DynamicBlockTemplate[] | null,
@@ -780,8 +783,13 @@ export class AgentCrudService {
           providerKeyId: dto.providerKeyId,
         }),
         // Per-request model routing table. Null clears; undefined leaves.
+        // Coerced for the same reason as the block lists (PIFSP-19): this wrote
+        // the DTO value through unchecked, so a client sending
+        // `JSON.stringify(routes)` stored a JSON string in an array column. The
+        // read side then hit `.map` on a string and the agent detail page died
+        // with "(h ?? []).map is not a function".
         ...(dto.modelRoutes !== undefined && {
-          modelRoutes: (dto.modelRoutes as any) ?? null,
+          modelRoutes: coerceBlockList(dto.modelRoutes) as any,
         }),
         ...(dto.isActive !== undefined && { isActive: dto.isActive }),
       },

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId._index/route.tsx
@@ -297,7 +297,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     cacheRange,
     providerKeys,
     agentProviderKeyId: agentRow?.providerKeyId ?? null,
-    agentModelRoutes: (agentRow?.modelRoutes as any[] | null) ?? null,
+    // `modelRoutes` is the same array-column shape as promptBlocks/dynamicBlocks
+    // and was missed by the PIFSP-19 read-side defense above. A double-encoded
+    // write left a JSON string in the column; `?? []` only guards null, so the
+    // truthy string reached `.map` and took out the whole agent page with
+    // "(h ?? []).map is not a function". Null stays null so the editor's
+    // "no routes configured" state is unchanged.
+    agentModelRoutes:
+      agentRow?.modelRoutes == null ? null : asBlockArray<any>(agentRow.modelRoutes),
     agentRetryRules: ((agentRow as any)?.agentRetryConfig?.rules ?? null) as RetryRule[] | null,
     agentClusteringId: agentRow?.clusteringId ?? null,
     agentEnableThreading: agentRow?.enableThreading ?? false,


### PR DESCRIPTION
## Symptom

The agent detail page white-screened with `TypeError: (h ?? []).map is not a function`.

## Cause

`modelRoutes` on the affected row holds a JSON **string** containing an array, not an array:

```
select jsonb_typeof("modelRoutes"::jsonb) → string
```

`?? []` only guards null/undefined, so a truthy string goes straight into `.map`.

## Why this is a clean miss

**The defense already existed and this column was never added to it.** PIFSP-19 introduced exactly this coercion for the same bug class:

- `asBlockArray` in the route loader
- `coerceBlockList` in `agent-crud.service.ts`

Both were applied to `promptBlocks` and `dynamicBlocks`. `modelRoutes` is the same array-column shape and was covered by neither, so the write path stored whatever the DTO carried and both read paths handed it to `.map`.

## Fix

Coerced in all three places:

1. **Webapp loader** — the crash site.
2. **Agent-side read** (`agent-crud.service.ts:464`) — this feeds the runtime's route resolver, which does `(modelRoutes ?? []).map(...)`. A string there breaks model routing itself, not just the page.
3. **Write path** — so it cannot recur.

Null stays null everywhere, so the editor's "no routes configured" state is unchanged. `coerceBlockList` already returns `null` for a non-array, preserving "null clears".

## Scope on test.platos

1 of 4 agents affected. `promptBlocks` clean across all rows.

## Not included

The existing bad row. It needs a one-off `UPDATE` — the code fix prevents recurrence and stops the crash, but does not rewrite stored data:

```sql
update "PlatosAgent"
   set "modelRoutes" = (("modelRoutes"::jsonb) #>> '{}')::jsonb
 where jsonb_typeof("modelRoutes"::jsonb) = 'string';
```

Dry-run confirmed it yields a proper 3-element array with no data loss.

## Test plan

`tsc --noEmit` clean in the touched files (3 pre-existing TS2307s elsewhere from an uninstalled MCP SDK). `src/agent-runtime/artifact-meta.test.ts` has 3 failures that reproduce with this change stashed — pre-existing, unrelated to this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EJ2P5P9kCF2ihh6YipRmzM