### PR TITLE
WIN-119: Author Platos-domain Prisma schema

### DIFF
--- a/internal-packages/tenancy-database/README.md
+++ b/internal-packages/tenancy-database/README.md
@@ -1,13 +1,26 @@
 # Platos tenancy database
 
-This package is the clean-slate Prisma boundary for the Platos tenancy core. It
-does not import, migrate, or modify the inherited database schema.
+This package is the clean-slate Prisma boundary for Platos tenancy and domain
+data. It does not import, migrate, or modify the inherited database schema.
 
 - `prisma/schema.prisma` is the authoritative control-plane schema.
 - `prisma/end-user.prisma` generates a restricted data-plane projection with
   no operator or shared-tenancy relation paths.
 - `src/end-user.ts` further removes raw SQL and transaction escape hatches from
   the data-plane client surface.
+- `src/source-model-manifest.ts` accounts exactly once for all 54 legacy
+  `Platos*` sources. Those sources map to 59 distinct normalized targets;
+  `Credential` and `AgentToolPolicy` are independent support models. The final
+  schema therefore has 61 domain/capability models plus 10 tenancy-only models,
+  for 71 generated control-plane models.
+- `src/json.ts` documents and validates every retained Json field. Values are
+  persisted with native object/array roots; only `promptBlocks`,
+  `dynamicBlocks`, `modelRoutes`, and `toolsBlockConfig` accept one legacy
+  encoded layer, and no field accepts double encoding.
+- Agent tool availability is represented by typed `AgentToolPolicy` rows.
+  `enabledTools` is rejected at both the helper and database boundaries, while
+  `AgentVersion.toolDefaultPolicy` makes zero-row `NONE` and `ALL` behavior
+  explicit for tools registered after the version was created.
 - `prisma/migrations/00000000000000_initial` is the single migration generated
   from an empty PostgreSQL database, followed by tier and parent-chain checks
   that Prisma cannot express in its schema language.

--- a/internal-packages/tenancy-database/prisma/end-user.prisma
+++ b/internal-packages/tenancy-database/prisma/end-user.prisma
@@ -14,8 +14,23 @@ enum PrincipalTier {
   END_USER
 }
 
-/// Restricted data-plane projection. Organization and all operator models are
-/// intentionally absent, so generated relation queries cannot traverse them.
+enum WorkStatus {
+  PENDING
+  ACTIVE
+  SUCCEEDED
+  FAILED
+  CANCELLED
+}
+
+enum ApprovalStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  EXPIRED
+}
+
+/// Restricted data-plane projection. Environment, Agent, Tool, credentials,
+/// policy, and every operator/configuration model are intentionally absent.
 model EndUser {
   id             String    @id @default(uuid()) @db.Uuid
   organizationId String    @db.Uuid
@@ -24,7 +39,13 @@ model EndUser {
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  identities EndUserIdentity[]
+  identities          EndUserIdentity[]
+  threads             Thread[]
+  memories            Memory[]
+  memoryEntities      MemoryEntity[]
+  memoryRelationships MemoryRelationship[]
+  messageAttachments  MessageAttachment[]
+  messageRatings      MessageRating[]
 
   @@unique([id, organizationId])
   @@index([organizationId, disabledAt])
@@ -66,4 +87,267 @@ model EndUserSession {
   @@index([identityId, expiresAt])
   @@index([environmentId, expiresAt])
   @@index([expiresAt])
+}
+
+model Thread {
+  id             String     @id @default(uuid()) @db.Uuid
+  environmentId  String     @db.Uuid
+  agentId        String     @db.Uuid
+  endUserId      String     @db.Uuid
+  clusterId      String?    @db.Uuid
+  parentThreadId String?    @db.Uuid
+  title          String?
+  status         WorkStatus @default(ACTIVE)
+  summary        String?
+  sessionContext Json?
+  tags           String[]   @default([])
+  pinnedAt       DateTime?
+  archivedAt     DateTime?
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+
+  endUser      EndUser         @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  parentThread Thread?         @relation("ThreadFork", fields: [parentThreadId], references: [id], onDelete: SetNull)
+  forks        Thread[]        @relation("ThreadFork")
+  turns        Turn[]
+  artifacts    Artifact[]
+  approvals    AgentApproval[]
+
+  @@index([environmentId, endUserId, updatedAt])
+  @@index([agentId, status])
+  @@index([clusterId])
+  @@index([parentThreadId])
+}
+
+model Turn {
+  id                String     @id @default(uuid()) @db.Uuid
+  threadId          String     @db.Uuid
+  parentTurnId      String?    @db.Uuid
+  sequence          Int
+  inputText         String?
+  outputText        String?
+  input             Json?
+  output            Json?
+  thinkingContent   String?
+  status            WorkStatus @default(PENDING)
+  externalRuntimeId String?
+  startedAt         DateTime?
+  completedAt       DateTime?
+  createdAt         DateTime   @default(now())
+
+  thread         Thread              @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  parentTurn     Turn?               @relation("TurnRevision", fields: [parentTurnId], references: [id], onDelete: SetNull)
+  revisions      Turn[]              @relation("TurnRevision")
+  steps          Step[]
+  attachments    MessageAttachment[]
+  artifacts      Artifact[]
+  approvals      AgentApproval[]
+  messageRatings MessageRating[]
+
+  @@unique([threadId, sequence])
+  @@index([parentTurnId])
+  @@index([threadId, status])
+}
+
+model Step {
+  id           String     @id @default(uuid()) @db.Uuid
+  turnId       String     @db.Uuid
+  sequence     Int
+  model        String
+  status       WorkStatus @default(PENDING)
+  retryCount   Int        @default(0)
+  inputTokens  Int?
+  outputTokens Int?
+  error        String?
+  startedAt    DateTime?
+  completedAt  DateTime?
+  createdAt    DateTime   @default(now())
+
+  turn      Turn       @relation(fields: [turnId], references: [id], onDelete: Cascade)
+  toolCalls ToolCall[]
+
+  @@unique([turnId, sequence])
+}
+
+model ToolCall {
+  id          String     @id @default(uuid()) @db.Uuid
+  stepId      String     @db.Uuid
+  toolId      String?    @db.Uuid
+  sequence    Int
+  toolName    String
+  arguments   Json
+  result      Json?
+  status      WorkStatus @default(PENDING)
+  retryCount  Int        @default(0)
+  error       String?
+  latencyMs   Int?
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime   @default(now())
+
+  step Step @relation(fields: [stepId], references: [id], onDelete: Cascade)
+
+  @@unique([stepId, sequence])
+  @@index([toolId])
+}
+
+model Artifact {
+  id               String   @id @default(uuid()) @db.Uuid
+  environmentId    String   @db.Uuid
+  threadId         String   @db.Uuid
+  producedByTurnId String?  @db.Uuid
+  artifactKey      String
+  revision         Int      @default(1)
+  kind             String
+  title            String?
+  mimeType         String?
+  content          String
+  metadata         Json?
+  createdBy        String
+  createdAt        DateTime @default(now())
+
+  thread         Thread @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  producedByTurn Turn?  @relation(fields: [producedByTurnId], references: [id], onDelete: SetNull)
+
+  @@unique([threadId, artifactKey, revision])
+  @@index([environmentId, createdAt])
+  @@index([producedByTurnId])
+}
+
+model MessageAttachment {
+  id            String    @id @default(uuid()) @db.Uuid
+  environmentId String    @db.Uuid
+  endUserId     String    @db.Uuid
+  turnId        String?   @db.Uuid
+  kind          String
+  mimeType      String
+  bytes         Int
+  width         Int?
+  height        Int?
+  durationSec   Int?
+  storageKey    String
+  originalName  String?
+  contentHash   String?
+  createdAt     DateTime  @default(now())
+  expiresAt     DateTime?
+
+  endUser EndUser @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  turn    Turn?   @relation(fields: [turnId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, endUserId, createdAt])
+  @@index([turnId])
+}
+
+model AgentApproval {
+  id             String         @id @default(uuid()) @db.Uuid
+  environmentId  String         @db.Uuid
+  agentId        String?        @db.Uuid
+  threadId       String?        @db.Uuid
+  turnId         String?        @db.Uuid
+  action         String
+  details        String?
+  status         ApprovalStatus @default(PENDING)
+  timeoutSeconds Int            @default(300)
+  resolvedAt     DateTime?
+  respondedBy    String?
+  comment        String?
+  toolName       String?
+  arguments      Json?
+  resolution     Json?
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+
+  thread Thread? @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  turn   Turn?   @relation(fields: [turnId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, status, createdAt])
+  @@index([threadId])
+  @@index([turnId])
+}
+
+model Memory {
+  id             String    @id @default(uuid()) @db.Uuid
+  environmentId  String    @db.Uuid
+  endUserId      String    @db.Uuid
+  agentId        String?   @db.Uuid
+  kind           String
+  content        String
+  metadata       Json?
+  agentVisible   Boolean   @default(true)
+  visibility     String
+  source         String
+  sourceThreadId String?
+  sourceTurnIds  String[]  @default([])
+  contentHash    String?
+  confidence     Float?
+  lastAccessedAt DateTime?
+  archivedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  endUser EndUser @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, endUserId, archivedAt])
+  @@index([agentId])
+}
+
+model MemoryEntity {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  endUserId     String   @db.Uuid
+  entityKey     String
+  entityType    String
+  label         String
+  aliases       String[] @default([])
+  metadata      Json?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  endUser           EndUser              @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  fromRelationships MemoryRelationship[] @relation("MemoryRelationshipFrom")
+  toRelationships   MemoryRelationship[] @relation("MemoryRelationshipTo")
+
+  @@unique([environmentId, endUserId, entityKey])
+}
+
+model MemoryRelationship {
+  id               String   @id @default(uuid()) @db.Uuid
+  environmentId    String   @db.Uuid
+  endUserId        String   @db.Uuid
+  fromEntityId     String   @db.Uuid
+  toEntityId       String   @db.Uuid
+  relationshipType String
+  weight           Float?
+  metadata         Json?
+  sourceMemoryId   String?
+  createdAt        DateTime @default(now())
+
+  endUser    EndUser      @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  fromEntity MemoryEntity @relation("MemoryRelationshipFrom", fields: [fromEntityId], references: [id], onDelete: Cascade)
+  toEntity   MemoryEntity @relation("MemoryRelationshipTo", fields: [toEntityId], references: [id], onDelete: Cascade)
+
+  @@unique([fromEntityId, toEntityId, relationshipType])
+  @@index([environmentId, endUserId])
+  @@index([toEntityId])
+}
+
+model MessageRating {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  turnId         String   @db.Uuid
+  agentId        String   @db.Uuid
+  agentVersionId String?  @db.Uuid
+  endUserId      String   @db.Uuid
+  rating         Int
+  comment        String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  turn    Turn    @relation(fields: [turnId], references: [id], onDelete: Cascade)
+  endUser EndUser @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+
+  @@unique([turnId, endUserId])
+  @@index([environmentId, createdAt])
+  @@index([agentId])
+  @@index([agentVersionId])
 }

--- a/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
+++ b/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
@@ -10,6 +10,27 @@ CREATE TYPE "public"."OrganizationRole" AS ENUM ('OWNER', 'ADMIN', 'MEMBER');
 -- CreateEnum
 CREATE TYPE "public"."ProjectRole" AS ENUM ('ADMIN', 'EDITOR', 'VIEWER');
 
+-- CreateEnum
+CREATE TYPE "public"."CredentialKind" AS ENUM ('SECRET_REFERENCE', 'CHANNEL_SECRET', 'ENTITY_SECRET', 'SERVICE_CREDENTIAL');
+
+-- CreateEnum
+CREATE TYPE "public"."PolicyEffect" AS ENUM ('ALLOW', 'DENY');
+
+-- CreateEnum
+CREATE TYPE "public"."ToolKind" AS ENUM ('ENTITY', 'RUNTIME', 'META');
+
+-- CreateEnum
+CREATE TYPE "public"."WorkStatus" AS ENUM ('PENDING', 'ACTIVE', 'SUCCEEDED', 'FAILED', 'CANCELLED');
+
+-- CreateEnum
+CREATE TYPE "public"."ApprovalStatus" AS ENUM ('PENDING', 'APPROVED', 'REJECTED', 'EXPIRED');
+
+-- CreateEnum
+CREATE TYPE "public"."AuthorizationScopeKind" AS ENUM ('GLOBAL', 'ORGANIZATION', 'PROJECT', 'ENVIRONMENT');
+
+-- CreateEnum
+CREATE TYPE "public"."AgentToolDefaultPolicy" AS ENUM ('NONE', 'ALL');
+
 -- CreateTable
 CREATE TABLE "public"."User" (
     "id" UUID NOT NULL,
@@ -175,6 +196,1039 @@ CREATE TABLE "public"."EndUserSession" (
     CONSTRAINT "EndUserSession_pkey" PRIMARY KEY ("id")
 );
 
+-- CreateTable
+CREATE TABLE "public"."Agent" (
+    "id" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Agent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentCluster" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "description" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentCluster_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentVersion" (
+    "id" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "versionNumber" INTEGER NOT NULL,
+    "model" TEXT NOT NULL,
+    "systemPrompt" TEXT,
+    "maxSteps" INTEGER NOT NULL DEFAULT 10,
+    "contextLimit" INTEGER NOT NULL DEFAULT 128000,
+    "toolDefaultPolicy" "public"."AgentToolDefaultPolicy" NOT NULL DEFAULT 'NONE',
+    "promptBlocks" JSONB NOT NULL DEFAULT '[]',
+    "dynamicBlocks" JSONB NOT NULL DEFAULT '[]',
+    "toolsBlockConfig" JSONB NOT NULL DEFAULT '{}',
+    "modelRoutes" JSONB NOT NULL DEFAULT '[]',
+    "memoryConfig" JSONB NOT NULL DEFAULT '{}',
+    "outputSchema" JSONB,
+    "note" TEXT,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentBinding" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "activeAgentVersionId" UUID NOT NULL,
+    "canaryAgentVersionId" UUID,
+    "clusterId" UUID,
+    "canaryPercent" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentBinding_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Credential" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "kind" "public"."CredentialKind" NOT NULL,
+    "name" TEXT NOT NULL,
+    "prefix" TEXT,
+    "secretHash" TEXT,
+    "encryptedReference" TEXT,
+    "permissions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "allowedOrigins" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "provider" TEXT,
+    "externalClientId" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Credential_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AccessKey" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "keyPrefix" TEXT NOT NULL,
+    "keyHash" TEXT NOT NULL,
+    "allowedOrigins" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AccessKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProviderKey" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "provider" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "environmentKeyName" TEXT NOT NULL,
+    "encryptedReference" TEXT,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT NOT NULL,
+    "lastUsedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProviderKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."McpToken" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "mintedByUserId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "permissions" TEXT[],
+    "tier" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "revokedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "McpToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PersonalAccessToken" (
+    "id" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "scopeKind" "public"."AuthorizationScopeKind" NOT NULL,
+    "organizationId" UUID,
+    "projectId" UUID,
+    "environmentId" UUID,
+    "tokenHash" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "permissions" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PersonalAccessToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OAuthAccessToken" (
+    "id" UUID NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "clientId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "scopeKind" "public"."AuthorizationScopeKind" NOT NULL,
+    "organizationId" UUID,
+    "projectId" UUID,
+    "environmentId" UUID,
+    "scopes" TEXT[],
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OAuthAccessToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OAuthRefreshToken" (
+    "id" UUID NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "accessTokenId" UUID,
+    "clientId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "scopeKind" "public"."AuthorizationScopeKind" NOT NULL,
+    "organizationId" UUID,
+    "projectId" UUID,
+    "environmentId" UUID,
+    "scopes" TEXT[],
+    "rotationFamilyId" UUID NOT NULL,
+    "parentRefreshTokenId" UUID,
+    "issuedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "replayDetectedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OAuthRefreshToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."McpBearerToken" (
+    "id" UUID NOT NULL,
+    "entityId" UUID NOT NULL,
+    "createdByUserId" UUID NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "mcpUserId" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "McpBearerToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."PostmanTemplate" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "simulateUserId" TEXT NOT NULL,
+    "sessionContext" JSONB,
+    "createdBy" TEXT NOT NULL,
+    "isDefault" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PostmanTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Thread" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "endUserId" UUID NOT NULL,
+    "clusterId" UUID,
+    "parentThreadId" UUID,
+    "title" TEXT,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'ACTIVE',
+    "summary" TEXT,
+    "sessionContext" JSONB,
+    "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "pinnedAt" TIMESTAMP(3),
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Thread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Turn" (
+    "id" UUID NOT NULL,
+    "threadId" UUID NOT NULL,
+    "parentTurnId" UUID,
+    "sequence" INTEGER NOT NULL,
+    "inputText" TEXT,
+    "outputText" TEXT,
+    "input" JSONB,
+    "output" JSONB,
+    "thinkingContent" TEXT,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'PENDING',
+    "externalRuntimeId" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Turn_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Step" (
+    "id" UUID NOT NULL,
+    "turnId" UUID NOT NULL,
+    "sequence" INTEGER NOT NULL,
+    "model" TEXT NOT NULL,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'PENDING',
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "inputTokens" INTEGER,
+    "outputTokens" INTEGER,
+    "error" TEXT,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Step_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ToolCall" (
+    "id" UUID NOT NULL,
+    "stepId" UUID NOT NULL,
+    "toolId" UUID,
+    "sequence" INTEGER NOT NULL,
+    "toolName" TEXT NOT NULL,
+    "arguments" JSONB NOT NULL,
+    "result" JSONB,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'PENDING',
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "error" TEXT,
+    "latencyMs" INTEGER,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ToolCall_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Artifact" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "threadId" UUID NOT NULL,
+    "producedByTurnId" UUID,
+    "artifactKey" TEXT NOT NULL,
+    "revision" INTEGER NOT NULL DEFAULT 1,
+    "kind" TEXT NOT NULL,
+    "title" TEXT,
+    "mimeType" TEXT,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Artifact_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MessageAttachment" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "endUserId" UUID NOT NULL,
+    "turnId" UUID,
+    "kind" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "bytes" INTEGER NOT NULL,
+    "width" INTEGER,
+    "height" INTEGER,
+    "durationSec" INTEGER,
+    "storageKey" TEXT NOT NULL,
+    "originalName" TEXT,
+    "contentHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "MessageAttachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Entity" (
+    "id" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "connectionStatus" TEXT NOT NULL,
+    "connectionKind" TEXT NOT NULL,
+    "mcpUrls" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "allowedOrigins" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "capabilities" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "lastConnectedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Entity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChannelConnection" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "entityId" UUID,
+    "provider" TEXT NOT NULL,
+    "displayName" TEXT,
+    "defaultAgentId" UUID,
+    "agentRouting" JSONB NOT NULL DEFAULT '[]',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "credentialId" UUID,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelConnection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChannelThread" (
+    "id" UUID NOT NULL,
+    "connectionId" UUID NOT NULL,
+    "threadId" UUID NOT NULL,
+    "channelThreadKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelThread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChannelApp" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "provider" TEXT NOT NULL,
+    "displayName" TEXT,
+    "clientId" TEXT NOT NULL,
+    "credentialId" UUID,
+    "scopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "distribution" TEXT NOT NULL,
+    "defaultAgentId" UUID,
+    "agentRouting" JSONB NOT NULL DEFAULT '[]',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelApp_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChannelInstallation" (
+    "id" UUID NOT NULL,
+    "appId" UUID NOT NULL,
+    "externalInstallationId" TEXT NOT NULL,
+    "displayName" TEXT,
+    "credentialId" UUID,
+    "grantedScopes" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "defaultAgentId" UUID,
+    "agentRouting" JSONB NOT NULL DEFAULT '[]',
+    "status" TEXT NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "lastEventAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelInstallation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ChannelAppThread" (
+    "id" UUID NOT NULL,
+    "installationId" UUID NOT NULL,
+    "threadId" UUID NOT NULL,
+    "channelThreadKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ChannelAppThread_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EntityMcpConfig" (
+    "entityId" UUID NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT false,
+    "identityMode" TEXT NOT NULL,
+    "identityProviders" JSONB NOT NULL DEFAULT '[]',
+    "branding" JSONB NOT NULL DEFAULT '{}',
+    "toolAllowlist" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "redirectUriAllowlist" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "rateLimitPerMinute" INTEGER NOT NULL DEFAULT 60,
+    "injectMcpContext" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EntityMcpConfig_pkey" PRIMARY KEY ("entityId")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EntityMcpClient" (
+    "entityId" UUID NOT NULL,
+    "transport" TEXT NOT NULL,
+    "url" TEXT,
+    "credentialId" UUID,
+    "headersTemplate" JSONB NOT NULL DEFAULT '{}',
+    "lastDiscoveryAt" TIMESTAMP(3),
+    "discoveryError" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EntityMcpClient_pkey" PRIMARY KEY ("entityId")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Tool" (
+    "id" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "kind" "public"."ToolKind" NOT NULL DEFAULT 'ENTITY',
+    "paramSchema" JSONB NOT NULL,
+    "category" TEXT,
+    "schemaHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Tool_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EnvironmentEntityTool" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "entityId" UUID NOT NULL,
+    "toolId" UUID NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "callbackUrl" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EnvironmentEntityTool_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ToolHealth" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "toolId" UUID NOT NULL,
+    "entityExternalId" TEXT,
+    "lastCalledAt" TIMESTAMP(3),
+    "lastStatus" TEXT,
+    "failCount" INTEGER NOT NULL DEFAULT 0,
+    "totalCalls" INTEGER NOT NULL DEFAULT 0,
+    "totalFailures" INTEGER NOT NULL DEFAULT 0,
+    "p95LatencyMs" INTEGER,
+    "avgLatencyMs" INTEGER,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ToolHealth_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ToolCallAudit" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "toolId" UUID,
+    "endUserId" UUID,
+    "agentId" UUID,
+    "threadId" UUID,
+    "toolName" TEXT NOT NULL,
+    "arguments" JSONB NOT NULL,
+    "result" JSONB,
+    "error" TEXT,
+    "status" "public"."WorkStatus" NOT NULL,
+    "latencyMs" INTEGER NOT NULL,
+    "costCents" DECIMAL(18,6),
+    "traceId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ToolCallAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AdminAudit" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "actorUserId" TEXT,
+    "action" TEXT NOT NULL,
+    "subjectType" TEXT NOT NULL,
+    "subjectId" TEXT,
+    "before" JSONB,
+    "after" JSONB,
+    "reason" TEXT,
+    "source" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AdminAudit_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentApproval" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID,
+    "threadId" UUID,
+    "turnId" UUID,
+    "action" TEXT NOT NULL,
+    "details" TEXT,
+    "status" "public"."ApprovalStatus" NOT NULL DEFAULT 'PENDING',
+    "timeoutSeconds" INTEGER NOT NULL DEFAULT 300,
+    "resolvedAt" TIMESTAMP(3),
+    "respondedBy" TEXT,
+    "comment" TEXT,
+    "toolName" TEXT,
+    "arguments" JSONB,
+    "resolution" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentApproval_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EnvironmentProvider" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "providerId" TEXT NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "linkedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EnvironmentProvider_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Budget" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID,
+    "scope" TEXT NOT NULL,
+    "period" TEXT NOT NULL,
+    "limitCents" INTEGER NOT NULL,
+    "turnsLimit" INTEGER,
+    "alertThresholds" JSONB NOT NULL DEFAULT '[]',
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "overrideUntil" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Budget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."SafetyEvent" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID,
+    "threadId" UUID,
+    "turnId" UUID,
+    "endUserId" UUID,
+    "detector" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "severity" TEXT NOT NULL,
+    "detail" TEXT,
+    "metadata" JSONB,
+    "toolName" TEXT,
+    "toolCallId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "SafetyEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MessageRating" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "turnId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "agentVersionId" UUID,
+    "endUserId" UUID NOT NULL,
+    "rating" INTEGER NOT NULL,
+    "comment" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MessageRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EvalCriterion" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "judgePrompt" TEXT NOT NULL,
+    "rubric" TEXT,
+    "judgeModel" TEXT,
+    "scoreScaleMin" INTEGER NOT NULL DEFAULT 0,
+    "scoreScaleMax" INTEGER NOT NULL DEFAULT 1,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EvalCriterion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentEval" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "agentVersionId" UUID,
+    "threadId" UUID NOT NULL,
+    "turnId" UUID,
+    "criterionId" UUID NOT NULL,
+    "criterionSnapshot" JSONB NOT NULL,
+    "judgeModel" TEXT NOT NULL,
+    "judgePromptUsed" TEXT NOT NULL,
+    "rawResponse" TEXT,
+    "score" DOUBLE PRECISION NOT NULL,
+    "rationale" TEXT,
+    "passed" BOOLEAN NOT NULL,
+    "costCents" DECIMAL(18,6),
+    "latencyMs" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentEval_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."GoldenSet" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "agentId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "threadIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "criterionIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "GoldenSet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Job" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "externalId" TEXT,
+    "displayName" TEXT NOT NULL,
+    "description" TEXT,
+    "triggerType" TEXT NOT NULL,
+    "scheduleCron" TEXT,
+    "scheduleTimezone" TEXT,
+    "allowedAgentIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "payloadSchema" JSONB,
+    "handler" TEXT NOT NULL,
+    "timeoutSeconds" INTEGER NOT NULL DEFAULT 300,
+    "maxRetries" INTEGER NOT NULL DEFAULT 0,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdBy" TEXT NOT NULL,
+    "lastStartedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Skill" (
+    "id" UUID NOT NULL,
+    "organizationId" UUID NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "author" TEXT,
+    "origin" TEXT NOT NULL,
+    "isOfficial" BOOLEAN NOT NULL DEFAULT false,
+    "tags" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "source" TEXT NOT NULL,
+    "manifest" JSONB NOT NULL,
+    "promptBlock" TEXT NOT NULL,
+    "providesTools" JSONB NOT NULL DEFAULT '[]',
+    "requiredEnvironmentKeys" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "optionalEnvironmentKeys" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Skill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ProjectSkill" (
+    "id" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "skillId" UUID NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProjectSkill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EnvironmentSkill" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "projectSkillId" UUID NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "config" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EnvironmentSkill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentSkill" (
+    "id" UUID NOT NULL,
+    "agentVersionId" UUID NOT NULL,
+    "environmentSkillId" UUID NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "config" JSONB NOT NULL DEFAULT '{}',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AgentSkill_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."AgentToolPolicy" (
+    "id" UUID NOT NULL,
+    "agentVersionId" UUID NOT NULL,
+    "toolId" UUID NOT NULL,
+    "effect" "public"."PolicyEffect" NOT NULL,
+    "priority" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AgentToolPolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Memory" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "endUserId" UUID NOT NULL,
+    "agentId" UUID,
+    "kind" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "agentVisible" BOOLEAN NOT NULL DEFAULT true,
+    "visibility" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "sourceThreadId" TEXT,
+    "sourceTurnIds" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "contentHash" TEXT,
+    "confidence" DOUBLE PRECISION,
+    "lastAccessedAt" TIMESTAMP(3),
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Memory_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MemoryEntity" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "endUserId" UUID NOT NULL,
+    "entityKey" TEXT NOT NULL,
+    "entityType" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "aliases" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MemoryEntity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."MemoryRelationship" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "endUserId" UUID NOT NULL,
+    "fromEntityId" UUID NOT NULL,
+    "toEntityId" UUID NOT NULL,
+    "relationshipType" TEXT NOT NULL,
+    "weight" DOUBLE PRECISION,
+    "metadata" JSONB,
+    "sourceMemoryId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MemoryRelationship_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OrganizationMcpPolicy" (
+    "id" UUID NOT NULL,
+    "organizationId" UUID NOT NULL,
+    "pattern" TEXT NOT NULL,
+    "effect" "public"."PolicyEffect" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrganizationMcpPolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Macro" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "steps" JSONB NOT NULL,
+    "paramSchema" JSONB,
+    "sharedWithOrganization" BOOLEAN NOT NULL DEFAULT false,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Macro_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."Event" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "subjectId" TEXT,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Event_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."NotificationRule" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "name" TEXT NOT NULL,
+    "filters" JSONB NOT NULL,
+    "delivery" JSONB NOT NULL,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "NotificationRule_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OAuthClient" (
+    "id" UUID NOT NULL,
+    "organizationId" UUID NOT NULL,
+    "clientId" TEXT NOT NULL,
+    "clientSecretHash" TEXT,
+    "clientName" TEXT NOT NULL,
+    "redirectUris" TEXT[],
+    "tokenEndpointAuthMethod" TEXT NOT NULL,
+    "grantTypes" TEXT[],
+    "scopes" TEXT[],
+    "registeredByUserId" UUID NOT NULL,
+    "entityId" UUID,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deletedAt" TIMESTAMP(3),
+
+    CONSTRAINT "OAuthClient_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."OAuthAuthorizationCode" (
+    "id" UUID NOT NULL,
+    "scopeKind" "public"."AuthorizationScopeKind" NOT NULL,
+    "organizationId" UUID,
+    "projectId" UUID,
+    "environmentId" UUID,
+    "clientId" UUID NOT NULL,
+    "userId" UUID NOT NULL,
+    "codeHash" TEXT NOT NULL,
+    "codeChallenge" TEXT NOT NULL,
+    "codeChallengeMethod" TEXT NOT NULL,
+    "redirectUri" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "usedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OAuthAuthorizationCode_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."McpAnonymousSession" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "entityId" UUID NOT NULL,
+    "mcpUserId" TEXT NOT NULL,
+    "firstSeenIp" TEXT,
+    "userAgent" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastUsedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "McpAnonymousSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."McpOidcSession" (
+    "id" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "entityId" UUID NOT NULL,
+    "mcpUserId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "email" TEXT,
+    "emailVerified" BOOLEAN NOT NULL DEFAULT false,
+    "externalSubject" TEXT NOT NULL,
+    "displayName" TEXT,
+    "avatarUrl" TEXT,
+    "credentialId" UUID,
+    "firstLoginAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastLoginAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+
+    CONSTRAINT "McpOidcSession_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."EntityToolPolicy" (
+    "id" UUID NOT NULL,
+    "entityId" UUID NOT NULL,
+    "toolId" UUID NOT NULL,
+    "effect" "public"."PolicyEffect" NOT NULL,
+    "minIdentityMode" TEXT NOT NULL,
+    "scopeLabels" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "addedBy" TEXT NOT NULL,
+    "addedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastReviewedAt" TIMESTAMP(3),
+
+    CONSTRAINT "EntityToolPolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."ErasureOperation" (
+    "id" UUID NOT NULL,
+    "organizationId" UUID NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "subjectKeyHash" TEXT NOT NULL,
+    "status" "public"."WorkStatus" NOT NULL DEFAULT 'PENDING',
+    "scopes" JSONB NOT NULL,
+    "stores" JSONB NOT NULL,
+    "inventory" JSONB,
+    "policyVersion" TEXT NOT NULL,
+    "legalHoldPolicyId" TEXT,
+    "retryCount" INTEGER NOT NULL DEFAULT 0,
+    "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3),
+    "completedAt" TIMESTAMP(3),
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ErasureOperation_pkey" PRIMARY KEY ("id")
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "public"."User"("email");
 
@@ -271,6 +1325,387 @@ CREATE INDEX "EndUserSession_environmentId_expiresAt_idx" ON "public"."EndUserSe
 -- CreateIndex
 CREATE INDEX "EndUserSession_expiresAt_idx" ON "public"."EndUserSession"("expiresAt");
 
+-- CreateIndex
+CREATE INDEX "Agent_projectId_isActive_idx" ON "public"."Agent"("projectId", "isActive");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Agent_projectId_slug_key" ON "public"."Agent"("projectId", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentCluster_environmentId_slug_key" ON "public"."AgentCluster"("environmentId", "slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentVersion_agentId_versionNumber_key" ON "public"."AgentVersion"("agentId", "versionNumber");
+
+-- CreateIndex
+CREATE INDEX "AgentBinding_activeAgentVersionId_idx" ON "public"."AgentBinding"("activeAgentVersionId");
+
+-- CreateIndex
+CREATE INDEX "AgentBinding_canaryAgentVersionId_idx" ON "public"."AgentBinding"("canaryAgentVersionId");
+
+-- CreateIndex
+CREATE INDEX "AgentBinding_clusterId_idx" ON "public"."AgentBinding"("clusterId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentBinding_environmentId_agentId_key" ON "public"."AgentBinding"("environmentId", "agentId");
+
+-- CreateIndex
+CREATE INDEX "Credential_environmentId_kind_revokedAt_idx" ON "public"."Credential"("environmentId", "kind", "revokedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Credential_environmentId_kind_name_key" ON "public"."Credential"("environmentId", "kind", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccessKey_keyHash_key" ON "public"."AccessKey"("keyHash");
+
+-- CreateIndex
+CREATE INDEX "AccessKey_environmentId_revokedAt_idx" ON "public"."AccessKey"("environmentId", "revokedAt");
+
+-- CreateIndex
+CREATE INDEX "ProviderKey_environmentId_provider_isDefault_idx" ON "public"."ProviderKey"("environmentId", "provider", "isDefault");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProviderKey_environmentId_provider_label_key" ON "public"."ProviderKey"("environmentId", "provider", "label");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "McpToken_tokenHash_key" ON "public"."McpToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "McpToken_environmentId_revokedAt_expiresAt_idx" ON "public"."McpToken"("environmentId", "revokedAt", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "McpToken_mintedByUserId_idx" ON "public"."McpToken"("mintedByUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PersonalAccessToken_tokenHash_key" ON "public"."PersonalAccessToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "PersonalAccessToken_userId_revokedAt_expiresAt_idx" ON "public"."PersonalAccessToken"("userId", "revokedAt", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "PersonalAccessToken_organizationId_idx" ON "public"."PersonalAccessToken"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "PersonalAccessToken_projectId_idx" ON "public"."PersonalAccessToken"("projectId");
+
+-- CreateIndex
+CREATE INDEX "PersonalAccessToken_environmentId_idx" ON "public"."PersonalAccessToken"("environmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthAccessToken_tokenHash_key" ON "public"."OAuthAccessToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "OAuthAccessToken_clientId_userId_revokedAt_expiresAt_idx" ON "public"."OAuthAccessToken"("clientId", "userId", "revokedAt", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthAccessToken_organizationId_idx" ON "public"."OAuthAccessToken"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "OAuthAccessToken_projectId_idx" ON "public"."OAuthAccessToken"("projectId");
+
+-- CreateIndex
+CREATE INDEX "OAuthAccessToken_environmentId_idx" ON "public"."OAuthAccessToken"("environmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthRefreshToken_tokenHash_key" ON "public"."OAuthRefreshToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_clientId_userId_rotationFamilyId_idx" ON "public"."OAuthRefreshToken"("clientId", "userId", "rotationFamilyId");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_accessTokenId_idx" ON "public"."OAuthRefreshToken"("accessTokenId");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_parentRefreshTokenId_idx" ON "public"."OAuthRefreshToken"("parentRefreshTokenId");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_organizationId_idx" ON "public"."OAuthRefreshToken"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_projectId_idx" ON "public"."OAuthRefreshToken"("projectId");
+
+-- CreateIndex
+CREATE INDEX "OAuthRefreshToken_environmentId_idx" ON "public"."OAuthRefreshToken"("environmentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "McpBearerToken_tokenHash_key" ON "public"."McpBearerToken"("tokenHash");
+
+-- CreateIndex
+CREATE INDEX "McpBearerToken_entityId_mcpUserId_revokedAt_expiresAt_idx" ON "public"."McpBearerToken"("entityId", "mcpUserId", "revokedAt", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "McpBearerToken_createdByUserId_idx" ON "public"."McpBearerToken"("createdByUserId");
+
+-- CreateIndex
+CREATE INDEX "PostmanTemplate_agentId_idx" ON "public"."PostmanTemplate"("agentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostmanTemplate_environmentId_agentId_name_key" ON "public"."PostmanTemplate"("environmentId", "agentId", "name");
+
+-- CreateIndex
+CREATE INDEX "Thread_environmentId_endUserId_updatedAt_idx" ON "public"."Thread"("environmentId", "endUserId", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "Thread_agentId_status_idx" ON "public"."Thread"("agentId", "status");
+
+-- CreateIndex
+CREATE INDEX "Thread_clusterId_idx" ON "public"."Thread"("clusterId");
+
+-- CreateIndex
+CREATE INDEX "Thread_parentThreadId_idx" ON "public"."Thread"("parentThreadId");
+
+-- CreateIndex
+CREATE INDEX "Turn_parentTurnId_idx" ON "public"."Turn"("parentTurnId");
+
+-- CreateIndex
+CREATE INDEX "Turn_threadId_status_idx" ON "public"."Turn"("threadId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Turn_threadId_sequence_key" ON "public"."Turn"("threadId", "sequence");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Step_turnId_sequence_key" ON "public"."Step"("turnId", "sequence");
+
+-- CreateIndex
+CREATE INDEX "ToolCall_toolId_idx" ON "public"."ToolCall"("toolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ToolCall_stepId_sequence_key" ON "public"."ToolCall"("stepId", "sequence");
+
+-- CreateIndex
+CREATE INDEX "Artifact_environmentId_createdAt_idx" ON "public"."Artifact"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Artifact_producedByTurnId_idx" ON "public"."Artifact"("producedByTurnId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Artifact_threadId_artifactKey_revision_key" ON "public"."Artifact"("threadId", "artifactKey", "revision");
+
+-- CreateIndex
+CREATE INDEX "MessageAttachment_environmentId_endUserId_createdAt_idx" ON "public"."MessageAttachment"("environmentId", "endUserId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MessageAttachment_turnId_idx" ON "public"."MessageAttachment"("turnId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Entity_projectId_externalId_key" ON "public"."Entity"("projectId", "externalId");
+
+-- CreateIndex
+CREATE INDEX "ChannelConnection_environmentId_enabled_idx" ON "public"."ChannelConnection"("environmentId", "enabled");
+
+-- CreateIndex
+CREATE INDEX "ChannelConnection_entityId_idx" ON "public"."ChannelConnection"("entityId");
+
+-- CreateIndex
+CREATE INDEX "ChannelThread_threadId_idx" ON "public"."ChannelThread"("threadId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChannelThread_connectionId_channelThreadKey_key" ON "public"."ChannelThread"("connectionId", "channelThreadKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChannelApp_environmentId_provider_clientId_key" ON "public"."ChannelApp"("environmentId", "provider", "clientId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChannelInstallation_appId_externalInstallationId_key" ON "public"."ChannelInstallation"("appId", "externalInstallationId");
+
+-- CreateIndex
+CREATE INDEX "ChannelAppThread_threadId_idx" ON "public"."ChannelAppThread"("threadId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChannelAppThread_installationId_channelThreadKey_key" ON "public"."ChannelAppThread"("installationId", "channelThreadKey");
+
+-- CreateIndex
+CREATE INDEX "Tool_kind_name_idx" ON "public"."Tool"("kind", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Tool_name_schemaHash_key" ON "public"."Tool"("name", "schemaHash");
+
+-- CreateIndex
+CREATE INDEX "EnvironmentEntityTool_toolId_idx" ON "public"."EnvironmentEntityTool"("toolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EnvironmentEntityTool_environmentId_entityId_toolId_key" ON "public"."EnvironmentEntityTool"("environmentId", "entityId", "toolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ToolHealth_environmentId_toolId_entityExternalId_key" ON "public"."ToolHealth"("environmentId", "toolId", "entityExternalId");
+
+-- CreateIndex
+CREATE INDEX "ToolCallAudit_environmentId_createdAt_idx" ON "public"."ToolCallAudit"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ToolCallAudit_endUserId_createdAt_idx" ON "public"."ToolCallAudit"("endUserId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "ToolCallAudit_toolId_idx" ON "public"."ToolCallAudit"("toolId");
+
+-- CreateIndex
+CREATE INDEX "AdminAudit_environmentId_createdAt_idx" ON "public"."AdminAudit"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentApproval_environmentId_status_createdAt_idx" ON "public"."AgentApproval"("environmentId", "status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentApproval_threadId_idx" ON "public"."AgentApproval"("threadId");
+
+-- CreateIndex
+CREATE INDEX "AgentApproval_turnId_idx" ON "public"."AgentApproval"("turnId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EnvironmentProvider_environmentId_providerId_key" ON "public"."EnvironmentProvider"("environmentId", "providerId");
+
+-- CreateIndex
+CREATE INDEX "Budget_environmentId_enabled_idx" ON "public"."Budget"("environmentId", "enabled");
+
+-- CreateIndex
+CREATE INDEX "Budget_agentId_idx" ON "public"."Budget"("agentId");
+
+-- CreateIndex
+CREATE INDEX "SafetyEvent_environmentId_createdAt_idx" ON "public"."SafetyEvent"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "SafetyEvent_endUserId_idx" ON "public"."SafetyEvent"("endUserId");
+
+-- CreateIndex
+CREATE INDEX "MessageRating_environmentId_createdAt_idx" ON "public"."MessageRating"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "MessageRating_agentId_idx" ON "public"."MessageRating"("agentId");
+
+-- CreateIndex
+CREATE INDEX "MessageRating_agentVersionId_idx" ON "public"."MessageRating"("agentVersionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MessageRating_turnId_endUserId_key" ON "public"."MessageRating"("turnId", "endUserId");
+
+-- CreateIndex
+CREATE INDEX "EvalCriterion_agentId_idx" ON "public"."EvalCriterion"("agentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EvalCriterion_environmentId_name_key" ON "public"."EvalCriterion"("environmentId", "name");
+
+-- CreateIndex
+CREATE INDEX "AgentEval_environmentId_createdAt_idx" ON "public"."AgentEval"("environmentId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "AgentEval_agentId_agentVersionId_idx" ON "public"."AgentEval"("agentId", "agentVersionId");
+
+-- CreateIndex
+CREATE INDEX "AgentEval_threadId_idx" ON "public"."AgentEval"("threadId");
+
+-- CreateIndex
+CREATE INDEX "AgentEval_turnId_idx" ON "public"."AgentEval"("turnId");
+
+-- CreateIndex
+CREATE INDEX "AgentEval_criterionId_idx" ON "public"."AgentEval"("criterionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "GoldenSet_environmentId_agentId_name_key" ON "public"."GoldenSet"("environmentId", "agentId", "name");
+
+-- CreateIndex
+CREATE INDEX "Job_environmentId_status_idx" ON "public"."Job"("environmentId", "status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Job_environmentId_externalId_key" ON "public"."Job"("environmentId", "externalId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Skill_organizationId_slug_version_key" ON "public"."Skill"("organizationId", "slug", "version");
+
+-- CreateIndex
+CREATE INDEX "ProjectSkill_skillId_idx" ON "public"."ProjectSkill"("skillId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectSkill_projectId_skillId_key" ON "public"."ProjectSkill"("projectId", "skillId");
+
+-- CreateIndex
+CREATE INDEX "EnvironmentSkill_projectSkillId_idx" ON "public"."EnvironmentSkill"("projectSkillId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EnvironmentSkill_environmentId_projectSkillId_key" ON "public"."EnvironmentSkill"("environmentId", "projectSkillId");
+
+-- CreateIndex
+CREATE INDEX "AgentSkill_environmentSkillId_idx" ON "public"."AgentSkill"("environmentSkillId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentSkill_agentVersionId_environmentSkillId_key" ON "public"."AgentSkill"("agentVersionId", "environmentSkillId");
+
+-- CreateIndex
+CREATE INDEX "AgentToolPolicy_toolId_idx" ON "public"."AgentToolPolicy"("toolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AgentToolPolicy_agentVersionId_toolId_key" ON "public"."AgentToolPolicy"("agentVersionId", "toolId");
+
+-- CreateIndex
+CREATE INDEX "Memory_environmentId_endUserId_archivedAt_idx" ON "public"."Memory"("environmentId", "endUserId", "archivedAt");
+
+-- CreateIndex
+CREATE INDEX "Memory_agentId_idx" ON "public"."Memory"("agentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemoryEntity_environmentId_endUserId_entityKey_key" ON "public"."MemoryEntity"("environmentId", "endUserId", "entityKey");
+
+-- CreateIndex
+CREATE INDEX "MemoryRelationship_environmentId_endUserId_idx" ON "public"."MemoryRelationship"("environmentId", "endUserId");
+
+-- CreateIndex
+CREATE INDEX "MemoryRelationship_toEntityId_idx" ON "public"."MemoryRelationship"("toEntityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "MemoryRelationship_fromEntityId_toEntityId_relationshipType_key" ON "public"."MemoryRelationship"("fromEntityId", "toEntityId", "relationshipType");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrganizationMcpPolicy_organizationId_pattern_key" ON "public"."OrganizationMcpPolicy"("organizationId", "pattern");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Macro_environmentId_name_key" ON "public"."Macro"("environmentId", "name");
+
+-- CreateIndex
+CREATE INDEX "Event_environmentId_eventType_createdAt_idx" ON "public"."Event"("environmentId", "eventType", "createdAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "NotificationRule_environmentId_name_key" ON "public"."NotificationRule"("environmentId", "name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthClient_clientId_key" ON "public"."OAuthClient"("clientId");
+
+-- CreateIndex
+CREATE INDEX "OAuthClient_organizationId_deletedAt_idx" ON "public"."OAuthClient"("organizationId", "deletedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthAuthorizationCode_codeHash_key" ON "public"."OAuthAuthorizationCode"("codeHash");
+
+-- CreateIndex
+CREATE INDEX "OAuthAuthorizationCode_organizationId_expiresAt_idx" ON "public"."OAuthAuthorizationCode"("organizationId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthAuthorizationCode_projectId_expiresAt_idx" ON "public"."OAuthAuthorizationCode"("projectId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthAuthorizationCode_environmentId_expiresAt_idx" ON "public"."OAuthAuthorizationCode"("environmentId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthAuthorizationCode_clientId_idx" ON "public"."OAuthAuthorizationCode"("clientId");
+
+-- CreateIndex
+CREATE INDEX "OAuthAuthorizationCode_userId_idx" ON "public"."OAuthAuthorizationCode"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "McpAnonymousSession_environmentId_entityId_mcpUserId_key" ON "public"."McpAnonymousSession"("environmentId", "entityId", "mcpUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "McpOidcSession_environmentId_entityId_provider_externalSubj_key" ON "public"."McpOidcSession"("environmentId", "entityId", "provider", "externalSubject");
+
+-- CreateIndex
+CREATE INDEX "EntityToolPolicy_toolId_idx" ON "public"."EntityToolPolicy"("toolId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EntityToolPolicy_entityId_toolId_key" ON "public"."EntityToolPolicy"("entityId", "toolId");
+
+-- CreateIndex
+CREATE INDEX "ErasureOperation_organizationId_subjectKeyHash_requestedAt_idx" ON "public"."ErasureOperation"("organizationId", "subjectKeyHash", "requestedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ErasureOperation_organizationId_idempotencyKey_key" ON "public"."ErasureOperation"("organizationId", "idempotencyKey");
+
 -- AddForeignKey
 ALTER TABLE "public"."OperatorSession" ADD CONSTRAINT "OperatorSession_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
@@ -316,137 +1751,894 @@ ALTER TABLE "public"."EndUserSession" ADD CONSTRAINT "EndUserSession_identityId_
 -- AddForeignKey
 ALTER TABLE "public"."EndUserSession" ADD CONSTRAINT "EndUserSession_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
--- Enforce the principal tier in the database rather than trusting callers to
--- preserve each session table's control-plane/data-plane meaning.
+-- AddForeignKey
+ALTER TABLE "public"."Agent" ADD CONSTRAINT "Agent_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentCluster" ADD CONSTRAINT "AgentCluster_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentBinding" ADD CONSTRAINT "AgentBinding_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentBinding" ADD CONSTRAINT "AgentBinding_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentBinding" ADD CONSTRAINT "AgentBinding_activeAgentVersionId_fkey" FOREIGN KEY ("activeAgentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentBinding" ADD CONSTRAINT "AgentBinding_canaryAgentVersionId_fkey" FOREIGN KEY ("canaryAgentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentBinding" ADD CONSTRAINT "AgentBinding_clusterId_fkey" FOREIGN KEY ("clusterId") REFERENCES "public"."AgentCluster"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Credential" ADD CONSTRAINT "Credential_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AccessKey" ADD CONSTRAINT "AccessKey_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProviderKey" ADD CONSTRAINT "ProviderKey_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpToken" ADD CONSTRAINT "McpToken_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpToken" ADD CONSTRAINT "McpToken_mintedByUserId_fkey" FOREIGN KEY ("mintedByUserId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PersonalAccessToken" ADD CONSTRAINT "PersonalAccessToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PersonalAccessToken" ADD CONSTRAINT "PersonalAccessToken_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PersonalAccessToken" ADD CONSTRAINT "PersonalAccessToken_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PersonalAccessToken" ADD CONSTRAINT "PersonalAccessToken_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "public"."OAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_accessTokenId_fkey" FOREIGN KEY ("accessTokenId") REFERENCES "public"."OAuthAccessToken"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "public"."OAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_parentRefreshTokenId_fkey" FOREIGN KEY ("parentRefreshTokenId") REFERENCES "public"."OAuthRefreshToken"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpBearerToken" ADD CONSTRAINT "McpBearerToken_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpBearerToken" ADD CONSTRAINT "McpBearerToken_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PostmanTemplate" ADD CONSTRAINT "PostmanTemplate_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."PostmanTemplate" ADD CONSTRAINT "PostmanTemplate_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_clusterId_fkey" FOREIGN KEY ("clusterId") REFERENCES "public"."AgentCluster"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_parentThreadId_fkey" FOREIGN KEY ("parentThreadId") REFERENCES "public"."Thread"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Turn" ADD CONSTRAINT "Turn_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Turn" ADD CONSTRAINT "Turn_parentTurnId_fkey" FOREIGN KEY ("parentTurnId") REFERENCES "public"."Turn"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Step" ADD CONSTRAINT "Step_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCall" ADD CONSTRAINT "ToolCall_stepId_fkey" FOREIGN KEY ("stepId") REFERENCES "public"."Step"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCall" ADD CONSTRAINT "ToolCall_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Artifact" ADD CONSTRAINT "Artifact_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Artifact" ADD CONSTRAINT "Artifact_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Artifact" ADD CONSTRAINT "Artifact_producedByTurnId_fkey" FOREIGN KEY ("producedByTurnId") REFERENCES "public"."Turn"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageAttachment" ADD CONSTRAINT "MessageAttachment_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageAttachment" ADD CONSTRAINT "MessageAttachment_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageAttachment" ADD CONSTRAINT "MessageAttachment_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Entity" ADD CONSTRAINT "Entity_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelConnection" ADD CONSTRAINT "ChannelConnection_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelConnection" ADD CONSTRAINT "ChannelConnection_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelConnection" ADD CONSTRAINT "ChannelConnection_defaultAgentId_fkey" FOREIGN KEY ("defaultAgentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelConnection" ADD CONSTRAINT "ChannelConnection_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "public"."Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelThread" ADD CONSTRAINT "ChannelThread_connectionId_fkey" FOREIGN KEY ("connectionId") REFERENCES "public"."ChannelConnection"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelThread" ADD CONSTRAINT "ChannelThread_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelApp" ADD CONSTRAINT "ChannelApp_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelApp" ADD CONSTRAINT "ChannelApp_defaultAgentId_fkey" FOREIGN KEY ("defaultAgentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelApp" ADD CONSTRAINT "ChannelApp_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "public"."Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelInstallation" ADD CONSTRAINT "ChannelInstallation_appId_fkey" FOREIGN KEY ("appId") REFERENCES "public"."ChannelApp"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelInstallation" ADD CONSTRAINT "ChannelInstallation_defaultAgentId_fkey" FOREIGN KEY ("defaultAgentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelInstallation" ADD CONSTRAINT "ChannelInstallation_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "public"."Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelAppThread" ADD CONSTRAINT "ChannelAppThread_installationId_fkey" FOREIGN KEY ("installationId") REFERENCES "public"."ChannelInstallation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ChannelAppThread" ADD CONSTRAINT "ChannelAppThread_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EntityMcpConfig" ADD CONSTRAINT "EntityMcpConfig_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EntityMcpClient" ADD CONSTRAINT "EntityMcpClient_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EntityMcpClient" ADD CONSTRAINT "EntityMcpClient_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "public"."Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentEntityTool" ADD CONSTRAINT "EnvironmentEntityTool_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentEntityTool" ADD CONSTRAINT "EnvironmentEntityTool_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentEntityTool" ADD CONSTRAINT "EnvironmentEntityTool_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolHealth" ADD CONSTRAINT "ToolHealth_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolHealth" ADD CONSTRAINT "ToolHealth_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AdminAudit" ADD CONSTRAINT "AdminAudit_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentProvider" ADD CONSTRAINT "EnvironmentProvider_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Budget" ADD CONSTRAINT "Budget_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Budget" ADD CONSTRAINT "Budget_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageRating" ADD CONSTRAINT "MessageRating_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageRating" ADD CONSTRAINT "MessageRating_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageRating" ADD CONSTRAINT "MessageRating_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageRating" ADD CONSTRAINT "MessageRating_agentVersionId_fkey" FOREIGN KEY ("agentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MessageRating" ADD CONSTRAINT "MessageRating_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EvalCriterion" ADD CONSTRAINT "EvalCriterion_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EvalCriterion" ADD CONSTRAINT "EvalCriterion_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_agentVersionId_fkey" FOREIGN KEY ("agentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_threadId_fkey" FOREIGN KEY ("threadId") REFERENCES "public"."Thread"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_turnId_fkey" FOREIGN KEY ("turnId") REFERENCES "public"."Turn"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_criterionId_fkey" FOREIGN KEY ("criterionId") REFERENCES "public"."EvalCriterion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."GoldenSet" ADD CONSTRAINT "GoldenSet_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."GoldenSet" ADD CONSTRAINT "GoldenSet_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Job" ADD CONSTRAINT "Job_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Skill" ADD CONSTRAINT "Skill_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProjectSkill" ADD CONSTRAINT "ProjectSkill_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ProjectSkill" ADD CONSTRAINT "ProjectSkill_skillId_fkey" FOREIGN KEY ("skillId") REFERENCES "public"."Skill"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentSkill" ADD CONSTRAINT "EnvironmentSkill_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EnvironmentSkill" ADD CONSTRAINT "EnvironmentSkill_projectSkillId_fkey" FOREIGN KEY ("projectSkillId") REFERENCES "public"."ProjectSkill"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentSkill" ADD CONSTRAINT "AgentSkill_agentVersionId_fkey" FOREIGN KEY ("agentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentSkill" ADD CONSTRAINT "AgentSkill_environmentSkillId_fkey" FOREIGN KEY ("environmentSkillId") REFERENCES "public"."EnvironmentSkill"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentToolPolicy" ADD CONSTRAINT "AgentToolPolicy_agentVersionId_fkey" FOREIGN KEY ("agentVersionId") REFERENCES "public"."AgentVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."AgentToolPolicy" ADD CONSTRAINT "AgentToolPolicy_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Memory" ADD CONSTRAINT "Memory_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Memory" ADD CONSTRAINT "Memory_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Memory" ADD CONSTRAINT "Memory_agentId_fkey" FOREIGN KEY ("agentId") REFERENCES "public"."Agent"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryEntity" ADD CONSTRAINT "MemoryEntity_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryEntity" ADD CONSTRAINT "MemoryEntity_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryRelationship" ADD CONSTRAINT "MemoryRelationship_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryRelationship" ADD CONSTRAINT "MemoryRelationship_endUserId_fkey" FOREIGN KEY ("endUserId") REFERENCES "public"."EndUser"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryRelationship" ADD CONSTRAINT "MemoryRelationship_fromEntityId_fkey" FOREIGN KEY ("fromEntityId") REFERENCES "public"."MemoryEntity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."MemoryRelationship" ADD CONSTRAINT "MemoryRelationship_toEntityId_fkey" FOREIGN KEY ("toEntityId") REFERENCES "public"."MemoryEntity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OrganizationMcpPolicy" ADD CONSTRAINT "OrganizationMcpPolicy_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Macro" ADD CONSTRAINT "Macro_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."Event" ADD CONSTRAINT "Event_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."NotificationRule" ADD CONSTRAINT "NotificationRule_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthClient" ADD CONSTRAINT "OAuthClient_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthClient" ADD CONSTRAINT "OAuthClient_registeredByUserId_fkey" FOREIGN KEY ("registeredByUserId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthClient" ADD CONSTRAINT "OAuthClient_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "public"."OAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpAnonymousSession" ADD CONSTRAINT "McpAnonymousSession_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpAnonymousSession" ADD CONSTRAINT "McpAnonymousSession_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpOidcSession" ADD CONSTRAINT "McpOidcSession_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpOidcSession" ADD CONSTRAINT "McpOidcSession_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpOidcSession" ADD CONSTRAINT "McpOidcSession_credentialId_fkey" FOREIGN KEY ("credentialId") REFERENCES "public"."Credential"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EntityToolPolicy" ADD CONSTRAINT "EntityToolPolicy_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."EntityToolPolicy" ADD CONSTRAINT "EntityToolPolicy_toolId_fkey" FOREIGN KEY ("toolId") REFERENCES "public"."Tool"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."ErasureOperation" ADD CONSTRAINT "ErasureOperation_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+
+-- Prisma-inexpressible value constraints.
 ALTER TABLE "public"."OperatorSession"
-ADD CONSTRAINT "OperatorSession_tier_check" CHECK ("tier" = 'OPERATOR');
-
+  ADD CONSTRAINT "OperatorSession_tier_check" CHECK ("tier" = 'OPERATOR');
 ALTER TABLE "public"."EnvironmentSession"
-ADD CONSTRAINT "EnvironmentSession_tier_check" CHECK ("tier" = 'OPERATOR');
-
+  ADD CONSTRAINT "EnvironmentSession_tier_check" CHECK ("tier" = 'OPERATOR');
 ALTER TABLE "public"."EndUserSession"
-ADD CONSTRAINT "EndUserSession_tier_check" CHECK ("tier" = 'END_USER');
+  ADD CONSTRAINT "EndUserSession_tier_check" CHECK ("tier" = 'END_USER');
+ALTER TABLE "public"."AgentBinding"
+  ADD CONSTRAINT "AgentBinding_canaryPercent_check" CHECK ("canaryPercent" BETWEEN 0 AND 100);
+ALTER TABLE "public"."MessageRating"
+  ADD CONSTRAINT "MessageRating_rating_check" CHECK ("rating" BETWEEN 1 AND 5);
+ALTER TABLE "public"."AgentVersion"
+  ADD CONSTRAINT "AgentVersion_toolsBlockConfig_enabledTools_check"
+  CHECK (NOT ("toolsBlockConfig" ? 'enabledTools'));
 
--- End users are organization-owned while sessions are environment-pinned.
--- Verify the derived parent chain without storing an independent scope tuple.
-CREATE FUNCTION "public"."enforce_end_user_session_organization"()
+-- Json columns store their native documented root. This blocks encoded strings
+-- even when a caller bypasses the TypeScript write-boundary helpers.
+ALTER TABLE "public"."EndUserIdentity" ADD CONSTRAINT "EndUserIdentity_profile_json_root" CHECK ("profile" IS NULL OR jsonb_typeof("profile") = 'object');
+ALTER TABLE "public"."AgentCluster" ADD CONSTRAINT "AgentCluster_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_promptBlocks_json_root" CHECK (jsonb_typeof("promptBlocks") = 'array');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_dynamicBlocks_json_root" CHECK (jsonb_typeof("dynamicBlocks") = 'array');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_toolsBlockConfig_json_root" CHECK (jsonb_typeof("toolsBlockConfig") = 'object');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_modelRoutes_json_root" CHECK (jsonb_typeof("modelRoutes") = 'array');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_memoryConfig_json_root" CHECK (jsonb_typeof("memoryConfig") = 'object');
+ALTER TABLE "public"."AgentVersion" ADD CONSTRAINT "AgentVersion_outputSchema_json_root" CHECK ("outputSchema" IS NULL OR jsonb_typeof("outputSchema") = 'object');
+ALTER TABLE "public"."PostmanTemplate" ADD CONSTRAINT "PostmanTemplate_sessionContext_json_root" CHECK ("sessionContext" IS NULL OR jsonb_typeof("sessionContext") = 'object');
+ALTER TABLE "public"."Thread" ADD CONSTRAINT "Thread_sessionContext_json_root" CHECK ("sessionContext" IS NULL OR jsonb_typeof("sessionContext") = 'object');
+ALTER TABLE "public"."Turn" ADD CONSTRAINT "Turn_input_json_root" CHECK ("input" IS NULL OR jsonb_typeof("input") = 'object');
+ALTER TABLE "public"."Turn" ADD CONSTRAINT "Turn_output_json_root" CHECK ("output" IS NULL OR jsonb_typeof("output") = 'object');
+ALTER TABLE "public"."ToolCall" ADD CONSTRAINT "ToolCall_arguments_json_root" CHECK (jsonb_typeof("arguments") = 'object');
+ALTER TABLE "public"."ToolCall" ADD CONSTRAINT "ToolCall_result_json_root" CHECK ("result" IS NULL OR jsonb_typeof("result") IN ('object', 'array'));
+ALTER TABLE "public"."Artifact" ADD CONSTRAINT "Artifact_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."ChannelConnection" ADD CONSTRAINT "ChannelConnection_agentRouting_json_root" CHECK (jsonb_typeof("agentRouting") = 'array');
+ALTER TABLE "public"."ChannelApp" ADD CONSTRAINT "ChannelApp_agentRouting_json_root" CHECK (jsonb_typeof("agentRouting") = 'array');
+ALTER TABLE "public"."ChannelInstallation" ADD CONSTRAINT "ChannelInstallation_agentRouting_json_root" CHECK (jsonb_typeof("agentRouting") = 'array');
+ALTER TABLE "public"."EntityMcpConfig" ADD CONSTRAINT "EntityMcpConfig_identityProviders_json_root" CHECK (jsonb_typeof("identityProviders") = 'array');
+ALTER TABLE "public"."EntityMcpConfig" ADD CONSTRAINT "EntityMcpConfig_branding_json_root" CHECK (jsonb_typeof("branding") = 'object');
+ALTER TABLE "public"."EntityMcpClient" ADD CONSTRAINT "EntityMcpClient_headersTemplate_json_root" CHECK (jsonb_typeof("headersTemplate") = 'object');
+ALTER TABLE "public"."Tool" ADD CONSTRAINT "Tool_paramSchema_json_root" CHECK (jsonb_typeof("paramSchema") = 'object');
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_arguments_json_root" CHECK (jsonb_typeof("arguments") = 'object');
+ALTER TABLE "public"."ToolCallAudit" ADD CONSTRAINT "ToolCallAudit_result_json_root" CHECK ("result" IS NULL OR jsonb_typeof("result") IN ('object', 'array'));
+ALTER TABLE "public"."AdminAudit" ADD CONSTRAINT "AdminAudit_before_json_root" CHECK ("before" IS NULL OR jsonb_typeof("before") = 'object');
+ALTER TABLE "public"."AdminAudit" ADD CONSTRAINT "AdminAudit_after_json_root" CHECK ("after" IS NULL OR jsonb_typeof("after") = 'object');
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_arguments_json_root" CHECK ("arguments" IS NULL OR jsonb_typeof("arguments") = 'object');
+ALTER TABLE "public"."AgentApproval" ADD CONSTRAINT "AgentApproval_resolution_json_root" CHECK ("resolution" IS NULL OR jsonb_typeof("resolution") = 'object');
+ALTER TABLE "public"."Budget" ADD CONSTRAINT "Budget_alertThresholds_json_root" CHECK (jsonb_typeof("alertThresholds") = 'array');
+ALTER TABLE "public"."SafetyEvent" ADD CONSTRAINT "SafetyEvent_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."AgentEval" ADD CONSTRAINT "AgentEval_criterionSnapshot_json_root" CHECK (jsonb_typeof("criterionSnapshot") = 'object');
+ALTER TABLE "public"."Job" ADD CONSTRAINT "Job_payloadSchema_json_root" CHECK ("payloadSchema" IS NULL OR jsonb_typeof("payloadSchema") = 'object');
+ALTER TABLE "public"."Skill" ADD CONSTRAINT "Skill_manifest_json_root" CHECK (jsonb_typeof("manifest") = 'object');
+ALTER TABLE "public"."Skill" ADD CONSTRAINT "Skill_providesTools_json_root" CHECK (jsonb_typeof("providesTools") = 'array');
+ALTER TABLE "public"."EnvironmentSkill" ADD CONSTRAINT "EnvironmentSkill_config_json_root" CHECK (jsonb_typeof("config") = 'object');
+ALTER TABLE "public"."AgentSkill" ADD CONSTRAINT "AgentSkill_config_json_root" CHECK (jsonb_typeof("config") = 'object');
+ALTER TABLE "public"."Memory" ADD CONSTRAINT "Memory_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."MemoryEntity" ADD CONSTRAINT "MemoryEntity_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."MemoryRelationship" ADD CONSTRAINT "MemoryRelationship_metadata_json_root" CHECK ("metadata" IS NULL OR jsonb_typeof("metadata") = 'object');
+ALTER TABLE "public"."Macro" ADD CONSTRAINT "Macro_steps_json_root" CHECK (jsonb_typeof("steps") = 'array');
+ALTER TABLE "public"."Macro" ADD CONSTRAINT "Macro_paramSchema_json_root" CHECK ("paramSchema" IS NULL OR jsonb_typeof("paramSchema") = 'object');
+ALTER TABLE "public"."Event" ADD CONSTRAINT "Event_payload_json_root" CHECK (jsonb_typeof("payload") = 'object');
+ALTER TABLE "public"."NotificationRule" ADD CONSTRAINT "NotificationRule_filters_json_root" CHECK (jsonb_typeof("filters") = 'object');
+ALTER TABLE "public"."NotificationRule" ADD CONSTRAINT "NotificationRule_delivery_json_root" CHECK (jsonb_typeof("delivery") = 'object');
+ALTER TABLE "public"."ErasureOperation" ADD CONSTRAINT "ErasureOperation_scopes_json_root" CHECK (jsonb_typeof("scopes") = 'array');
+ALTER TABLE "public"."ErasureOperation" ADD CONSTRAINT "ErasureOperation_stores_json_root" CHECK (jsonb_typeof("stores") = 'array');
+ALTER TABLE "public"."ErasureOperation" ADD CONSTRAINT "ErasureOperation_inventory_json_root" CHECK ("inventory" IS NULL OR jsonb_typeof("inventory") = 'object');
+
+-- Canonical owner keys are immutable. Moving a record between isolation roots
+-- would otherwise invalidate descendants without touching their rows.
+CREATE FUNCTION "public"."reject_canonical_owner_change"()
 RETURNS TRIGGER AS $$
+DECLARE
+  owner_key TEXT;
 BEGIN
-    IF NOT EXISTS (
-        SELECT 1
-        FROM "public"."EndUserIdentity" AS identity
-        INNER JOIN "public"."EndUser" AS end_user
-            ON end_user."id" = identity."endUserId"
-           AND end_user."organizationId" = identity."organizationId"
-        INNER JOIN "public"."Environment" AS environment
-            ON environment."id" = NEW."environmentId"
-        INNER JOIN "public"."Project" AS project
-            ON project."id" = environment."projectId"
-        WHERE identity."id" = NEW."identityId"
-          AND end_user."organizationId" = project."organizationId"
-    ) THEN
-        RAISE EXCEPTION 'End-user identity and environment must belong to the same organization'
-            USING ERRCODE = '23514';
+  FOREACH owner_key IN ARRAY TG_ARGV LOOP
+    IF to_jsonb(OLD) -> owner_key IS DISTINCT FROM to_jsonb(NEW) -> owner_key THEN
+      RAISE EXCEPTION '% ownership/authorization key % is immutable', TG_TABLE_NAME, owner_key
+        USING ERRCODE = '23514';
     END IF;
-
-    RETURN NEW;
+  END LOOP;
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER "EndUserSession_organization_check"
-BEFORE INSERT OR UPDATE OF "identityId", "environmentId"
-ON "public"."EndUserSession"
-FOR EACH ROW
-EXECUTE FUNCTION "public"."enforce_end_user_session_organization"();
+CREATE TRIGGER "Project_owner_immutable" BEFORE UPDATE ON "public"."Project" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('organizationId');
+CREATE TRIGGER "Environment_owner_immutable" BEFORE UPDATE ON "public"."Environment" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('projectId');
+CREATE TRIGGER "EndUser_owner_immutable" BEFORE UPDATE ON "public"."EndUser" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('organizationId');
+CREATE TRIGGER "Agent_owner_immutable" BEFORE UPDATE ON "public"."Agent" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('projectId');
+CREATE TRIGGER "AgentVersion_owner_immutable" BEFORE UPDATE ON "public"."AgentVersion" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('agentId');
+CREATE TRIGGER "AgentCluster_owner_immutable" BEFORE UPDATE ON "public"."AgentCluster" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "Credential_owner_immutable" BEFORE UPDATE ON "public"."Credential" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "Thread_owner_immutable" BEFORE UPDATE ON "public"."Thread" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "Turn_owner_immutable" BEFORE UPDATE ON "public"."Turn" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('threadId');
+CREATE TRIGGER "Entity_owner_immutable" BEFORE UPDATE ON "public"."Entity" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('projectId');
+CREATE TRIGGER "ChannelConnection_owner_immutable" BEFORE UPDATE ON "public"."ChannelConnection" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "ChannelApp_owner_immutable" BEFORE UPDATE ON "public"."ChannelApp" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "Skill_owner_immutable" BEFORE UPDATE ON "public"."Skill" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('organizationId');
+CREATE TRIGGER "ProjectSkill_owner_immutable" BEFORE UPDATE ON "public"."ProjectSkill" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('projectId');
+CREATE TRIGGER "EnvironmentSkill_owner_immutable" BEFORE UPDATE ON "public"."EnvironmentSkill" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "MemoryEntity_owner_immutable" BEFORE UPDATE ON "public"."MemoryEntity" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "EndUserIdentity_owner_immutable" BEFORE UPDATE ON "public"."EndUserIdentity" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('endUserId', 'organizationId');
+CREATE TRIGGER "Thread_subject_immutable" BEFORE UPDATE ON "public"."Thread" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('endUserId');
+CREATE TRIGGER "MessageAttachment_owner_immutable" BEFORE UPDATE ON "public"."MessageAttachment" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId', 'endUserId');
+CREATE TRIGGER "ChannelInstallation_owner_immutable" BEFORE UPDATE ON "public"."ChannelInstallation" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('appId');
+CREATE TRIGGER "OAuthClient_owner_immutable" BEFORE UPDATE ON "public"."OAuthClient" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('organizationId');
+CREATE TRIGGER "MemoryEntity_subject_immutable" BEFORE UPDATE ON "public"."MemoryEntity" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('endUserId');
+CREATE TRIGGER "AccessKey_owner_immutable" BEFORE UPDATE ON "public"."AccessKey" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "ProviderKey_owner_immutable" BEFORE UPDATE ON "public"."ProviderKey" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId');
+CREATE TRIGGER "McpToken_owner_immutable" BEFORE UPDATE ON "public"."McpToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId', 'mintedByUserId');
+CREATE TRIGGER "PersonalAccessToken_scope_immutable" BEFORE UPDATE ON "public"."PersonalAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
+CREATE TRIGGER "OAuthAuthorizationCode_scope_immutable" BEFORE UPDATE ON "public"."OAuthAuthorizationCode" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
+CREATE TRIGGER "OAuthAccessToken_scope_immutable" BEFORE UPDATE ON "public"."OAuthAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
+CREATE TRIGGER "OAuthRefreshToken_scope_immutable" BEFORE UPDATE ON "public"."OAuthRefreshToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId', 'rotationFamilyId', 'parentRefreshTokenId');
+CREATE TRIGGER "McpBearerToken_owner_immutable" BEFORE UPDATE ON "public"."McpBearerToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('entityId', 'createdByUserId');
 
--- A session's organization can also change indirectly when one of the parent
--- links in its derived scope is repointed. Reject those changes before they
--- can make an already-valid session cross an organization boundary.
-CREATE FUNCTION "public"."enforce_environment_end_user_session_organization"()
+-- Typed authorization scope records use exactly one target at the selected
+-- level. GLOBAL is valid only for operator PATs and has no tenant target.
+ALTER TABLE "public"."PersonalAccessToken" ADD CONSTRAINT "PersonalAccessToken_scope_shape_check" CHECK (
+  ("scopeKind" = 'GLOBAL' AND "organizationId" IS NULL AND "projectId" IS NULL AND "environmentId" IS NULL) OR
+  ("scopeKind" = 'ORGANIZATION' AND "organizationId" IS NOT NULL AND "projectId" IS NULL AND "environmentId" IS NULL) OR
+  ("scopeKind" = 'PROJECT' AND "organizationId" IS NULL AND "projectId" IS NOT NULL AND "environmentId" IS NULL) OR
+  ("scopeKind" = 'ENVIRONMENT' AND "organizationId" IS NULL AND "projectId" IS NULL AND "environmentId" IS NOT NULL)
+);
+ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_scope_shape_check" CHECK (
+  "scopeKind" <> 'GLOBAL' AND (
+    ("scopeKind" = 'ORGANIZATION' AND "organizationId" IS NOT NULL AND "projectId" IS NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'PROJECT' AND "organizationId" IS NULL AND "projectId" IS NOT NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'ENVIRONMENT' AND "organizationId" IS NULL AND "projectId" IS NULL AND "environmentId" IS NOT NULL)
+  )
+);
+ALTER TABLE "public"."OAuthAccessToken" ADD CONSTRAINT "OAuthAccessToken_scope_shape_check" CHECK (
+  "scopeKind" <> 'GLOBAL' AND (
+    ("scopeKind" = 'ORGANIZATION' AND "organizationId" IS NOT NULL AND "projectId" IS NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'PROJECT' AND "organizationId" IS NULL AND "projectId" IS NOT NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'ENVIRONMENT' AND "organizationId" IS NULL AND "projectId" IS NULL AND "environmentId" IS NOT NULL)
+  )
+);
+ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_scope_shape_check" CHECK (
+  "scopeKind" <> 'GLOBAL' AND (
+    ("scopeKind" = 'ORGANIZATION' AND "organizationId" IS NOT NULL AND "projectId" IS NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'PROJECT' AND "organizationId" IS NULL AND "projectId" IS NOT NULL AND "environmentId" IS NULL) OR
+    ("scopeKind" = 'ENVIRONMENT' AND "organizationId" IS NULL AND "projectId" IS NULL AND "environmentId" IS NOT NULL)
+  )
+);
+
+-- Cross-owner ancestry cannot be represented by Prisma relations without
+-- copying organization/project scope tuples onto every record. Resolve each
+-- canonical owner chain in the database instead.
+CREATE FUNCTION "public"."enforce_domain_ancestry"()
 RETURNS TRIGGER AS $$
+DECLARE
+  valid BOOLEAN := FALSE;
 BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM "public"."EndUserSession" AS session
-        INNER JOIN "public"."EndUserIdentity" AS identity
-            ON identity."id" = session."identityId"
-        INNER JOIN "public"."EndUser" AS end_user
-            ON end_user."id" = identity."endUserId"
-           AND end_user."organizationId" = identity."organizationId"
-        INNER JOIN "public"."Project" AS project
-            ON project."id" = NEW."projectId"
-        WHERE session."environmentId" = NEW."id"
-          AND end_user."organizationId" <> project."organizationId"
-    ) THEN
-        RAISE EXCEPTION 'Environment project and end-user sessions must belong to the same organization'
-            USING ERRCODE = '23514';
-    END IF;
+  CASE TG_TABLE_NAME
+    WHEN 'EndUserSession' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "EndUserIdentity" i
+        JOIN "EndUser" u ON u.id = i."endUserId" AND u."organizationId" = i."organizationId"
+        JOIN "Environment" e ON e.id = NEW."environmentId"
+        JOIN "Project" p ON p.id = e."projectId"
+        WHERE i.id = NEW."identityId" AND u."organizationId" = p."organizationId"
+      ) INTO valid;
+    WHEN 'AgentBinding' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = e."projectId"
+        JOIN "AgentVersion" active ON active.id = NEW."activeAgentVersionId" AND active."agentId" = a.id
+        LEFT JOIN "AgentVersion" canary ON canary.id = NEW."canaryAgentVersionId" AND canary."agentId" = a.id
+        LEFT JOIN "AgentCluster" cluster ON cluster.id = NEW."clusterId" AND cluster."environmentId" = e.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."canaryAgentVersionId" IS NULL OR canary.id IS NOT NULL)
+          AND (NEW."clusterId" IS NULL OR cluster.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'PostmanTemplate' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "Agent" a ON a."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND a.id = NEW."agentId") INTO valid;
+    WHEN 'Thread' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        JOIN "Project" p ON p.id = e."projectId"
+        JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = p.id
+        JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        LEFT JOIN "AgentCluster" c ON c.id = NEW."clusterId" AND c."environmentId" = e.id
+        LEFT JOIN "Thread" parent ON parent.id = NEW."parentThreadId" AND parent."environmentId" = e.id AND parent."endUserId" = u.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."clusterId" IS NULL OR c.id IS NOT NULL)
+          AND (NEW."parentThreadId" IS NULL OR parent.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'Artifact' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Thread" t
+        LEFT JOIN "Turn" turn ON turn.id = NEW."producedByTurnId" AND turn."threadId" = t.id
+        WHERE t.id = NEW."threadId" AND t."environmentId" = NEW."environmentId"
+          AND (NEW."producedByTurnId" IS NULL OR turn.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'MessageAttachment' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        JOIN "Project" p ON p.id = e."projectId"
+        JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        LEFT JOIN "Turn" turn ON turn.id = NEW."turnId"
+        LEFT JOIN "Thread" t ON t.id = turn."threadId" AND t."environmentId" = e.id AND t."endUserId" = u.id
+        WHERE e.id = NEW."environmentId" AND (NEW."turnId" IS NULL OR t.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'ChannelConnection' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        LEFT JOIN "Entity" entity ON entity.id = NEW."entityId" AND entity."projectId" = e."projectId"
+        LEFT JOIN "Agent" agent ON agent.id = NEW."defaultAgentId" AND agent."projectId" = e."projectId"
+        LEFT JOIN "Credential" credential ON credential.id = NEW."credentialId" AND credential."environmentId" = e.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."entityId" IS NULL OR entity.id IS NOT NULL)
+          AND (NEW."defaultAgentId" IS NULL OR agent.id IS NOT NULL)
+          AND (NEW."credentialId" IS NULL OR credential.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'ChannelThread' THEN
+      SELECT EXISTS (SELECT 1 FROM "ChannelConnection" c JOIN "Thread" t ON t."environmentId" = c."environmentId" WHERE c.id = NEW."connectionId" AND t.id = NEW."threadId") INTO valid;
+    WHEN 'ChannelApp' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        LEFT JOIN "Agent" a ON a.id = NEW."defaultAgentId" AND a."projectId" = e."projectId"
+        LEFT JOIN "Credential" c ON c.id = NEW."credentialId" AND c."environmentId" = e.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."defaultAgentId" IS NULL OR a.id IS NOT NULL)
+          AND (NEW."credentialId" IS NULL OR c.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'ChannelInstallation' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "ChannelApp" app JOIN "Environment" e ON e.id = app."environmentId"
+        LEFT JOIN "Agent" a ON a.id = NEW."defaultAgentId" AND a."projectId" = e."projectId"
+        LEFT JOIN "Credential" c ON c.id = NEW."credentialId" AND c."environmentId" = e.id
+        WHERE app.id = NEW."appId"
+          AND (NEW."defaultAgentId" IS NULL OR a.id IS NOT NULL)
+          AND (NEW."credentialId" IS NULL OR c.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'ChannelAppThread' THEN
+      SELECT EXISTS (SELECT 1 FROM "ChannelInstallation" i JOIN "ChannelApp" app ON app.id = i."appId" JOIN "Thread" t ON t."environmentId" = app."environmentId" WHERE i.id = NEW."installationId" AND t.id = NEW."threadId") INTO valid;
+    WHEN 'EntityMcpClient' THEN
+      SELECT NEW."credentialId" IS NULL OR EXISTS (
+        SELECT 1 FROM "Entity" entity JOIN "Credential" c ON c.id = NEW."credentialId" JOIN "Environment" e ON e.id = c."environmentId"
+        WHERE entity.id = NEW."entityId" AND entity."projectId" = e."projectId"
+      ) INTO valid;
+    WHEN 'EnvironmentEntityTool' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "Entity" entity ON entity."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND entity.id = NEW."entityId") INTO valid;
+    WHEN 'ToolCallAudit' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId"
+        LEFT JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = p.id
+        LEFT JOIN "Thread" t ON t.id = NEW."threadId" AND t."environmentId" = e.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."endUserId" IS NULL OR u.id IS NOT NULL)
+          AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)
+          AND (NEW."threadId" IS NULL OR t.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'AgentApproval' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e
+        LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = e."projectId"
+        LEFT JOIN "Thread" t ON t.id = NEW."threadId" AND t."environmentId" = e.id
+        LEFT JOIN "Turn" turn ON turn.id = NEW."turnId" AND turn."threadId" = t.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)
+          AND (NEW."threadId" IS NULL OR t.id IS NOT NULL)
+          AND (NEW."turnId" IS NULL OR turn.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'Budget' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)) INTO valid;
+    WHEN 'SafetyEvent' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId"
+        LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = p.id
+        LEFT JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        LEFT JOIN "Thread" t ON t.id = NEW."threadId" AND t."environmentId" = e.id
+        LEFT JOIN "Turn" turn ON turn.id = NEW."turnId" AND turn."threadId" = t.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)
+          AND (NEW."endUserId" IS NULL OR u.id IS NOT NULL)
+          AND (NEW."threadId" IS NULL OR t.id IS NOT NULL)
+          AND (NEW."turnId" IS NULL OR turn.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'MessageRating' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId"
+        JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = p.id
+        JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        JOIN "Turn" turn ON turn.id = NEW."turnId" JOIN "Thread" t ON t.id = turn."threadId" AND t."environmentId" = e.id AND t."endUserId" = u.id
+        LEFT JOIN "AgentVersion" version ON version.id = NEW."agentVersionId" AND version."agentId" = a.id
+        WHERE e.id = NEW."environmentId" AND (NEW."agentVersionId" IS NULL OR version.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'EvalCriterion' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)) INTO valid;
+    WHEN 'AgentEval' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = e."projectId"
+        JOIN "Thread" t ON t.id = NEW."threadId" AND t."environmentId" = e.id
+        JOIN "EvalCriterion" criterion ON criterion.id = NEW."criterionId" AND criterion."environmentId" = e.id
+        LEFT JOIN "AgentVersion" version ON version.id = NEW."agentVersionId" AND version."agentId" = a.id
+        LEFT JOIN "Turn" turn ON turn.id = NEW."turnId" AND turn."threadId" = t.id
+        WHERE e.id = NEW."environmentId"
+          AND (NEW."agentVersionId" IS NULL OR version.id IS NOT NULL)
+          AND (NEW."turnId" IS NULL OR turn.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'GoldenSet' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "Agent" a ON a."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND a.id = NEW."agentId") INTO valid;
+    WHEN 'ProjectSkill' THEN
+      SELECT EXISTS (SELECT 1 FROM "Project" p JOIN "Skill" s ON s."organizationId" = p."organizationId" WHERE p.id = NEW."projectId" AND s.id = NEW."skillId") INTO valid;
+    WHEN 'EnvironmentSkill' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "ProjectSkill" ps ON ps."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND ps.id = NEW."projectSkillId") INTO valid;
+    WHEN 'AgentSkill' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "AgentVersion" v JOIN "Agent" a ON a.id = v."agentId"
+        JOIN "EnvironmentSkill" es ON es.id = NEW."environmentSkillId" JOIN "Environment" e ON e.id = es."environmentId" AND e."projectId" = a."projectId"
+        WHERE v.id = NEW."agentVersionId"
+      ) INTO valid;
+    WHEN 'Memory' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" JOIN "EndUser" u ON u.id = NEW."endUserId" AND u."organizationId" = p."organizationId"
+        LEFT JOIN "Agent" a ON a.id = NEW."agentId" AND a."projectId" = p.id
+        WHERE e.id = NEW."environmentId" AND (NEW."agentId" IS NULL OR a.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'MemoryEntity' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" JOIN "EndUser" u ON u."organizationId" = p."organizationId" WHERE e.id = NEW."environmentId" AND u.id = NEW."endUserId") INTO valid;
+    WHEN 'MemoryRelationship' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "MemoryEntity" source JOIN "MemoryEntity" target ON target.id = NEW."toEntityId"
+        WHERE source.id = NEW."fromEntityId" AND source."environmentId" = NEW."environmentId" AND source."endUserId" = NEW."endUserId"
+          AND target."environmentId" = NEW."environmentId" AND target."endUserId" = NEW."endUserId"
+      ) INTO valid;
+    WHEN 'OAuthClient' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "OrganizationMembership" membership
+        LEFT JOIN "Entity" entity ON entity.id = NEW."entityId" LEFT JOIN "Project" p ON p.id = entity."projectId" AND p."organizationId" = NEW."organizationId"
+        WHERE membership."organizationId" = NEW."organizationId" AND membership."userId" = NEW."registeredByUserId"
+          AND membership."deactivatedAt" IS NULL AND (NEW."entityId" IS NULL OR p.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'OAuthAuthorizationCode' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "OAuthClient" client
+        JOIN "OrganizationMembership" membership ON membership."organizationId" = client."organizationId"
+          AND membership."userId" = NEW."userId" AND membership."deactivatedAt" IS NULL
+        WHERE client.id = NEW."clientId" AND client."organizationId" = CASE NEW."scopeKind"
+          WHEN 'ORGANIZATION' THEN NEW."organizationId"
+          WHEN 'PROJECT' THEN (SELECT p."organizationId" FROM "Project" p WHERE p.id = NEW."projectId")
+          WHEN 'ENVIRONMENT' THEN (SELECT p."organizationId" FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" WHERE e.id = NEW."environmentId")
+        END
+      ) INTO valid;
+    WHEN 'McpAnonymousSession' THEN
+      SELECT EXISTS (SELECT 1 FROM "Environment" e JOIN "Entity" entity ON entity."projectId" = e."projectId" WHERE e.id = NEW."environmentId" AND entity.id = NEW."entityId") INTO valid;
+    WHEN 'McpOidcSession' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Entity" entity ON entity.id = NEW."entityId" AND entity."projectId" = e."projectId"
+        LEFT JOIN "Credential" c ON c.id = NEW."credentialId" AND c."environmentId" = e.id
+        WHERE e.id = NEW."environmentId" AND (NEW."credentialId" IS NULL OR c.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'McpToken' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Environment" e JOIN "Project" p ON p.id = e."projectId"
+        JOIN "OrganizationMembership" membership ON membership."organizationId" = p."organizationId"
+          AND membership."userId" = NEW."mintedByUserId" AND membership."deactivatedAt" IS NULL
+        WHERE e.id = NEW."environmentId"
+      ) INTO valid;
+    WHEN 'PersonalAccessToken' THEN
+      IF NEW."scopeKind" = 'GLOBAL' THEN
+        valid := TRUE;
+      ELSE
+        SELECT EXISTS (
+          SELECT 1
+          FROM "OrganizationMembership" membership
+          WHERE membership."userId" = NEW."userId" AND membership."deactivatedAt" IS NULL
+            AND membership."organizationId" = CASE NEW."scopeKind"
+              WHEN 'ORGANIZATION' THEN NEW."organizationId"
+              WHEN 'PROJECT' THEN (SELECT p."organizationId" FROM "Project" p WHERE p.id = NEW."projectId")
+              WHEN 'ENVIRONMENT' THEN (SELECT p."organizationId" FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" WHERE e.id = NEW."environmentId")
+            END
+        ) INTO valid;
+      END IF;
+    WHEN 'OAuthAccessToken' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "OAuthClient" client
+        JOIN "OrganizationMembership" membership ON membership."organizationId" = client."organizationId"
+          AND membership."userId" = NEW."userId" AND membership."deactivatedAt" IS NULL
+        WHERE client.id = NEW."clientId" AND client."organizationId" = CASE NEW."scopeKind"
+          WHEN 'ORGANIZATION' THEN NEW."organizationId"
+          WHEN 'PROJECT' THEN (SELECT p."organizationId" FROM "Project" p WHERE p.id = NEW."projectId")
+          WHEN 'ENVIRONMENT' THEN (SELECT p."organizationId" FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" WHERE e.id = NEW."environmentId")
+        END
+      ) INTO valid;
+    WHEN 'OAuthRefreshToken' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "OAuthClient" client
+        JOIN "OrganizationMembership" membership ON membership."organizationId" = client."organizationId"
+          AND membership."userId" = NEW."userId" AND membership."deactivatedAt" IS NULL
+        LEFT JOIN "OAuthAccessToken" access ON access.id = NEW."accessTokenId"
+          AND access."clientId" = client.id AND access."userId" = NEW."userId"
+        LEFT JOIN "OAuthRefreshToken" parent ON parent.id = NEW."parentRefreshTokenId"
+          AND parent."clientId" = client.id AND parent."userId" = NEW."userId"
+          AND parent."rotationFamilyId" = NEW."rotationFamilyId"
+        WHERE client.id = NEW."clientId" AND client."organizationId" = CASE NEW."scopeKind"
+          WHEN 'ORGANIZATION' THEN NEW."organizationId"
+          WHEN 'PROJECT' THEN (SELECT p."organizationId" FROM "Project" p WHERE p.id = NEW."projectId")
+          WHEN 'ENVIRONMENT' THEN (SELECT p."organizationId" FROM "Environment" e JOIN "Project" p ON p.id = e."projectId" WHERE e.id = NEW."environmentId")
+        END
+          AND (NEW."accessTokenId" IS NULL OR access.id IS NOT NULL)
+          AND (NEW."parentRefreshTokenId" IS NULL OR parent.id IS NOT NULL)
+      ) INTO valid;
+    WHEN 'McpBearerToken' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "Entity" entity JOIN "Project" p ON p.id = entity."projectId"
+        JOIN "OrganizationMembership" membership ON membership."organizationId" = p."organizationId"
+          AND membership."userId" = NEW."createdByUserId" AND membership."deactivatedAt" IS NULL
+        WHERE entity.id = NEW."entityId"
+      ) INTO valid;
+    ELSE
+      RAISE EXCEPTION 'No ancestry rule for %', TG_TABLE_NAME USING ERRCODE = '23514';
+  END CASE;
 
-    RETURN NEW;
+  IF NOT valid THEN
+    RAISE EXCEPTION '% crosses its canonical owner ancestry', TG_TABLE_NAME
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER "Environment_end_user_session_organization_check"
-BEFORE UPDATE OF "projectId"
-ON "public"."Environment"
-FOR EACH ROW
-EXECUTE FUNCTION "public"."enforce_environment_end_user_session_organization"();
-
-CREATE FUNCTION "public"."enforce_project_end_user_session_organization"()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM "public"."Environment" AS environment
-        INNER JOIN "public"."EndUserSession" AS session
-            ON session."environmentId" = environment."id"
-        INNER JOIN "public"."EndUserIdentity" AS identity
-            ON identity."id" = session."identityId"
-        INNER JOIN "public"."EndUser" AS end_user
-            ON end_user."id" = identity."endUserId"
-           AND end_user."organizationId" = identity."organizationId"
-        WHERE environment."projectId" = NEW."id"
-          AND end_user."organizationId" <> NEW."organizationId"
-    ) THEN
-        RAISE EXCEPTION 'Project organization and end-user sessions must belong to the same organization'
-            USING ERRCODE = '23514';
-    END IF;
-
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER "Project_end_user_session_organization_check"
-BEFORE UPDATE OF "organizationId"
-ON "public"."Project"
-FOR EACH ROW
-EXECUTE FUNCTION "public"."enforce_project_end_user_session_organization"();
-
-CREATE FUNCTION "public"."enforce_end_user_session_organization_reparent"()
-RETURNS TRIGGER AS $$
-BEGIN
-    IF EXISTS (
-        SELECT 1
-        FROM "public"."EndUserIdentity" AS identity
-        INNER JOIN "public"."EndUserSession" AS session
-            ON session."identityId" = identity."id"
-        INNER JOIN "public"."Environment" AS environment
-            ON environment."id" = session."environmentId"
-        INNER JOIN "public"."Project" AS project
-            ON project."id" = environment."projectId"
-        WHERE identity."endUserId" = NEW."id"
-          AND project."organizationId" <> NEW."organizationId"
-    ) THEN
-        RAISE EXCEPTION 'End-user organization and sessions must belong to the same organization'
-            USING ERRCODE = '23514';
-    END IF;
-
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER "EndUser_session_organization_reparent_check"
-BEFORE UPDATE OF "organizationId"
-ON "public"."EndUser"
-FOR EACH ROW
-EXECUTE FUNCTION "public"."enforce_end_user_session_organization_reparent"();
+CREATE TRIGGER "EndUserSession_ancestry" BEFORE INSERT OR UPDATE ON "public"."EndUserSession" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "AgentBinding_ancestry" BEFORE INSERT OR UPDATE ON "public"."AgentBinding" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "PostmanTemplate_ancestry" BEFORE INSERT OR UPDATE ON "public"."PostmanTemplate" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "Thread_ancestry" BEFORE INSERT OR UPDATE ON "public"."Thread" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "Artifact_ancestry" BEFORE INSERT OR UPDATE ON "public"."Artifact" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "MessageAttachment_ancestry" BEFORE INSERT OR UPDATE ON "public"."MessageAttachment" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ChannelConnection_ancestry" BEFORE INSERT OR UPDATE ON "public"."ChannelConnection" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ChannelThread_ancestry" BEFORE INSERT OR UPDATE ON "public"."ChannelThread" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ChannelApp_ancestry" BEFORE INSERT OR UPDATE ON "public"."ChannelApp" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ChannelInstallation_ancestry" BEFORE INSERT OR UPDATE ON "public"."ChannelInstallation" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ChannelAppThread_ancestry" BEFORE INSERT OR UPDATE ON "public"."ChannelAppThread" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "EntityMcpClient_ancestry" BEFORE INSERT OR UPDATE ON "public"."EntityMcpClient" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "EnvironmentEntityTool_ancestry" BEFORE INSERT OR UPDATE ON "public"."EnvironmentEntityTool" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ToolCallAudit_ancestry" BEFORE INSERT OR UPDATE ON "public"."ToolCallAudit" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "AgentApproval_ancestry" BEFORE INSERT OR UPDATE ON "public"."AgentApproval" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "Budget_ancestry" BEFORE INSERT OR UPDATE ON "public"."Budget" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "SafetyEvent_ancestry" BEFORE INSERT OR UPDATE ON "public"."SafetyEvent" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "MessageRating_ancestry" BEFORE INSERT OR UPDATE ON "public"."MessageRating" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "EvalCriterion_ancestry" BEFORE INSERT OR UPDATE ON "public"."EvalCriterion" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "AgentEval_ancestry" BEFORE INSERT OR UPDATE ON "public"."AgentEval" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "GoldenSet_ancestry" BEFORE INSERT OR UPDATE ON "public"."GoldenSet" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "ProjectSkill_ancestry" BEFORE INSERT OR UPDATE ON "public"."ProjectSkill" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "EnvironmentSkill_ancestry" BEFORE INSERT OR UPDATE ON "public"."EnvironmentSkill" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "AgentSkill_ancestry" BEFORE INSERT OR UPDATE ON "public"."AgentSkill" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "Memory_ancestry" BEFORE INSERT OR UPDATE ON "public"."Memory" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "MemoryEntity_ancestry" BEFORE INSERT OR UPDATE ON "public"."MemoryEntity" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "MemoryRelationship_ancestry" BEFORE INSERT OR UPDATE ON "public"."MemoryRelationship" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "OAuthClient_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthClient" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "OAuthAuthorizationCode_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthAuthorizationCode" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "McpAnonymousSession_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpAnonymousSession" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "McpOidcSession_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpOidcSession" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "McpToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "PersonalAccessToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."PersonalAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "OAuthAccessToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "OAuthRefreshToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthRefreshToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "McpBearerToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpBearerToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();

--- a/internal-packages/tenancy-database/prisma/schema.prisma
+++ b/internal-packages/tenancy-database/prisma/schema.prisma
@@ -26,6 +26,51 @@ enum ProjectRole {
   VIEWER
 }
 
+enum CredentialKind {
+  SECRET_REFERENCE
+  CHANNEL_SECRET
+  ENTITY_SECRET
+  SERVICE_CREDENTIAL
+}
+
+enum PolicyEffect {
+  ALLOW
+  DENY
+}
+
+enum ToolKind {
+  ENTITY
+  RUNTIME
+  META
+}
+
+enum WorkStatus {
+  PENDING
+  ACTIVE
+  SUCCEEDED
+  FAILED
+  CANCELLED
+}
+
+enum ApprovalStatus {
+  PENDING
+  APPROVED
+  REJECTED
+  EXPIRED
+}
+
+enum AuthorizationScopeKind {
+  GLOBAL
+  ORGANIZATION
+  PROJECT
+  ENVIRONMENT
+}
+
+enum AgentToolDefaultPolicy {
+  NONE
+  ALL
+}
+
 model User {
   id          String    @id @default(uuid()) @db.Uuid
   email       String    @unique
@@ -37,6 +82,13 @@ model User {
   organizationMemberships OrganizationMembership[]
   invitationsSent         OrganizationInvitation[] @relation("OrganizationInvitationInviter")
   operatorSessions        OperatorSession[]
+  oauthAuthorizationCodes OAuthAuthorizationCode[]
+  oauthClientsRegistered  OAuthClient[]
+  mcpTokensMinted         McpToken[]
+  personalAccessTokens    PersonalAccessToken[]
+  oauthAccessTokens       OAuthAccessToken[]
+  oauthRefreshTokens      OAuthRefreshToken[]
+  mcpBearerTokensCreated  McpBearerToken[]
 }
 
 model OperatorSession {
@@ -64,10 +116,18 @@ model Organization {
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
-  memberships OrganizationMembership[]
-  invitations OrganizationInvitation[]
-  projects    Project[]
-  endUsers    EndUser[]
+  memberships             OrganizationMembership[]
+  invitations             OrganizationInvitation[]
+  projects                Project[]
+  endUsers                EndUser[]
+  skills                  Skill[]
+  mcpPolicies             OrganizationMcpPolicy[]
+  oauthClients            OAuthClient[]
+  erasureOperations       ErasureOperation[]
+  personalAccessTokens    PersonalAccessToken[]
+  oauthAccessTokens       OAuthAccessToken[]
+  oauthRefreshTokens      OAuthRefreshToken[]
+  oauthAuthorizationCodes OAuthAuthorizationCode[]
 
   @@index([archivedAt])
 }
@@ -120,9 +180,16 @@ model Project {
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  organization Organization        @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  memberships  ProjectMembership[]
-  environments Environment[]
+  organization            Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  memberships             ProjectMembership[]
+  environments            Environment[]
+  agents                  Agent[]
+  entities                Entity[]
+  projectSkills           ProjectSkill[]
+  personalAccessTokens    PersonalAccessToken[]
+  oauthAccessTokens       OAuthAccessToken[]
+  oauthRefreshTokens      OAuthRefreshToken[]
+  oauthAuthorizationCodes OAuthAuthorizationCode[]
 
   @@unique([organizationId, slug])
   @@unique([id, organizationId])
@@ -156,9 +223,47 @@ model Environment {
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @updatedAt
 
-  project             Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  environmentSessions EnvironmentSession[]
-  endUserSessions     EndUserSession[]
+  project                 Project                  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environmentSessions     EnvironmentSession[]
+  endUserSessions         EndUserSession[]
+  agentClusters           AgentCluster[]
+  agentBindings           AgentBinding[]
+  credentials             Credential[]
+  postmanTemplates        PostmanTemplate[]
+  threads                 Thread[]
+  artifacts               Artifact[]
+  messageAttachments      MessageAttachment[]
+  channelConnections      ChannelConnection[]
+  channelApps             ChannelApp[]
+  entityTools             EnvironmentEntityTool[]
+  toolHealth              ToolHealth[]
+  toolCallAudits          ToolCallAudit[]
+  adminAudits             AdminAudit[]
+  approvals               AgentApproval[]
+  providers               EnvironmentProvider[]
+  budgets                 Budget[]
+  safetyEvents            SafetyEvent[]
+  messageRatings          MessageRating[]
+  evalCriteria            EvalCriterion[]
+  agentEvals              AgentEval[]
+  goldenSets              GoldenSet[]
+  jobs                    Job[]
+  environmentSkills       EnvironmentSkill[]
+  memories                Memory[]
+  memoryEntities          MemoryEntity[]
+  memoryRelationships     MemoryRelationship[]
+  macros                  Macro[]
+  events                  Event[]
+  notificationRules       NotificationRule[]
+  oauthAuthorizationCodes OAuthAuthorizationCode[]
+  mcpAnonymousSessions    McpAnonymousSession[]
+  mcpOidcSessions         McpOidcSession[]
+  accessKeys              AccessKey[]
+  providerKeys            ProviderKey[]
+  mcpTokens               McpToken[]
+  personalAccessTokens    PersonalAccessToken[]
+  oauthAccessTokens       OAuthAccessToken[]
+  oauthRefreshTokens      OAuthRefreshToken[]
 
   @@unique([projectId, slug])
   @@index([projectId, archivedAt])
@@ -190,8 +295,16 @@ model EndUser {
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 
-  organization Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  identities   EndUserIdentity[]
+  organization        Organization         @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  identities          EndUserIdentity[]
+  threads             Thread[]
+  memories            Memory[]
+  toolCallAudits      ToolCallAudit[]
+  safetyEvents        SafetyEvent[]
+  messageRatings      MessageRating[]
+  memoryEntities      MemoryEntity[]
+  memoryRelationships MemoryRelationship[]
+  messageAttachments  MessageAttachment[]
 
   @@unique([id, organizationId])
   @@index([organizationId, disabledAt])
@@ -205,6 +318,7 @@ model EndUserIdentity {
   issuer         String
   channel        String
   subject        String
+  /// Object root containing verified identity profile attributes; validated by jsonShapeRegistry.
   profile        Json?
   verifiedAt     DateTime?
   disabledAt     DateTime?
@@ -237,4 +351,1363 @@ model EndUserSession {
   @@index([identityId, expiresAt])
   @@index([environmentId, expiresAt])
   @@index([expiresAt])
+}
+
+model Agent {
+  id          String   @id @default(uuid()) @db.Uuid
+  projectId   String   @db.Uuid
+  name        String
+  slug        String
+  description String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  project              Project               @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  versions             AgentVersion[]
+  bindings             AgentBinding[]
+  postmanTemplates     PostmanTemplate[]
+  threads              Thread[]
+  approvals            AgentApproval[]
+  budgets              Budget[]
+  safetyEvents         SafetyEvent[]
+  messageRatings       MessageRating[]
+  evalCriteria         EvalCriterion[]
+  agentEvals           AgentEval[]
+  goldenSets           GoldenSet[]
+  memories             Memory[]
+  channelConnections   ChannelConnection[]
+  channelApps          ChannelApp[]
+  channelInstallations ChannelInstallation[]
+  toolCallAudits       ToolCallAudit[]
+
+  @@unique([projectId, slug])
+  @@index([projectId, isActive])
+}
+
+model AgentCluster {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  name          String
+  slug          String
+  description   String?
+  /// Object root. Arbitrary non-secret cluster labels; validated by jsonShapeRegistry.
+  metadata      Json?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment    @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  bindings    AgentBinding[]
+  threads     Thread[]
+
+  @@unique([environmentId, slug])
+}
+
+model AgentVersion {
+  id                String                 @id @default(uuid()) @db.Uuid
+  agentId           String                 @db.Uuid
+  versionNumber     Int
+  model             String
+  systemPrompt      String?
+  maxSteps          Int                    @default(10)
+  contextLimit      Int                    @default(128000)
+  /// Default for tools without an AgentToolPolicy row. NONE exposes no unlisted tools; ALL exposes every unlisted tool.
+  toolDefaultPolicy AgentToolDefaultPolicy @default(NONE)
+  /// Array root of PromptBlock objects. One legacy encoded layer is accepted by normalizePromptBlocks.
+  promptBlocks      Json                   @default("[]")
+  /// Array root of DynamicBlock objects. One legacy encoded layer is accepted by normalizeDynamicBlocks.
+  dynamicBlocks     Json                   @default("[]")
+  /// Object root containing typed tool-router settings. One legacy encoded layer is accepted by normalizeToolsBlockConfig.
+  toolsBlockConfig  Json                   @default("{}")
+  /// Array root of ModelRoute objects. One legacy encoded layer is accepted by normalizeModelRoutes.
+  modelRoutes       Json                   @default("[]")
+  /// Object root containing memory limits and visibility defaults; validated by jsonShapeRegistry.
+  memoryConfig      Json                   @default("{}")
+  /// Object root containing a JSON Schema for structured output; validated by jsonShapeRegistry.
+  outputSchema      Json?
+  note              String?
+  createdBy         String
+  createdAt         DateTime               @default(now())
+
+  agent          Agent             @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  activeBindings AgentBinding[]    @relation("ActiveAgentVersion")
+  canaryBindings AgentBinding[]    @relation("CanaryAgentVersion")
+  toolPolicies   AgentToolPolicy[]
+  skills         AgentSkill[]
+  messageRatings MessageRating[]
+  agentEvals     AgentEval[]
+
+  @@unique([agentId, versionNumber])
+}
+
+model AgentBinding {
+  id                   String   @id @default(uuid()) @db.Uuid
+  environmentId        String   @db.Uuid
+  agentId              String   @db.Uuid
+  activeAgentVersionId String   @db.Uuid
+  canaryAgentVersionId String?  @db.Uuid
+  clusterId            String?  @db.Uuid
+  canaryPercent        Int      @default(0)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  environment        Environment   @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent              Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  activeAgentVersion AgentVersion  @relation("ActiveAgentVersion", fields: [activeAgentVersionId], references: [id], onDelete: Restrict)
+  canaryAgentVersion AgentVersion? @relation("CanaryAgentVersion", fields: [canaryAgentVersionId], references: [id], onDelete: Restrict)
+  cluster            AgentCluster? @relation(fields: [clusterId], references: [id], onDelete: SetNull)
+
+  @@unique([environmentId, agentId])
+  @@index([activeAgentVersionId])
+  @@index([canaryAgentVersionId])
+  @@index([clusterId])
+}
+
+model Credential {
+  id                 String         @id @default(uuid()) @db.Uuid
+  environmentId      String         @db.Uuid
+  kind               CredentialKind
+  name               String
+  prefix             String?
+  secretHash         String?
+  encryptedReference String?
+  permissions        String[]       @default([])
+  allowedOrigins     String[]       @default([])
+  provider           String?
+  externalClientId   String?
+  expiresAt          DateTime?
+  lastUsedAt         DateTime?
+  revokedAt          DateTime?
+  createdBy          String?
+  createdAt          DateTime       @default(now())
+  updatedAt          DateTime       @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  channelConnections   ChannelConnection[]
+  channelApps          ChannelApp[]
+  channelInstallations ChannelInstallation[]
+  entityMcpClients     EntityMcpClient[]
+  mcpOidcSessions      McpOidcSession[]
+
+  @@unique([environmentId, kind, name])
+  @@index([environmentId, kind, revokedAt])
+}
+
+model AccessKey {
+  id             String    @id @default(uuid()) @db.Uuid
+  environmentId  String    @db.Uuid
+  keyPrefix      String
+  keyHash        String    @unique
+  allowedOrigins String[]  @default([])
+  lastUsedAt     DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, revokedAt])
+}
+
+model ProviderKey {
+  id                 String    @id @default(uuid()) @db.Uuid
+  environmentId      String    @db.Uuid
+  provider           String
+  label              String
+  environmentKeyName String
+  encryptedReference String?
+  isDefault          Boolean   @default(false)
+  createdBy          String
+  lastUsedAt         DateTime?
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, provider, label])
+  @@index([environmentId, provider, isDefault])
+}
+
+model McpToken {
+  id             String    @id @default(uuid()) @db.Uuid
+  environmentId  String    @db.Uuid
+  mintedByUserId String    @db.Uuid
+  name           String
+  tokenHash      String    @unique
+  permissions    String[]
+  tier           String
+  expiresAt      DateTime?
+  lastUsedAt     DateTime?
+  revokedAt      DateTime?
+  revokedBy      String?
+  createdAt      DateTime  @default(now())
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  mintedBy    User        @relation(fields: [mintedByUserId], references: [id], onDelete: Restrict)
+
+  @@index([environmentId, revokedAt, expiresAt])
+  @@index([mintedByUserId])
+}
+
+model PersonalAccessToken {
+  id             String                 @id @default(uuid()) @db.Uuid
+  userId         String                 @db.Uuid
+  scopeKind      AuthorizationScopeKind
+  organizationId String?                @db.Uuid
+  projectId      String?                @db.Uuid
+  environmentId  String?                @db.Uuid
+  tokenHash      String                 @unique
+  name           String
+  role           String
+  permissions    String[]               @default([])
+  lastUsedAt     DateTime?
+  expiresAt      DateTime?
+  revokedAt      DateTime?
+  createdAt      DateTime               @default(now())
+
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project?      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environment  Environment?  @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@index([userId, revokedAt, expiresAt])
+  @@index([organizationId])
+  @@index([projectId])
+  @@index([environmentId])
+}
+
+model OAuthAccessToken {
+  id             String                 @id @default(uuid()) @db.Uuid
+  tokenHash      String                 @unique
+  clientId       String                 @db.Uuid
+  userId         String                 @db.Uuid
+  scopeKind      AuthorizationScopeKind
+  organizationId String?                @db.Uuid
+  projectId      String?                @db.Uuid
+  environmentId  String?                @db.Uuid
+  scopes         String[]
+  issuedAt       DateTime               @default(now())
+  expiresAt      DateTime
+  revokedAt      DateTime?
+
+  client        OAuthClient         @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  user          User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization  Organization?       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project       Project?            @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environment   Environment?        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  refreshTokens OAuthRefreshToken[]
+
+  @@index([clientId, userId, revokedAt, expiresAt])
+  @@index([organizationId])
+  @@index([projectId])
+  @@index([environmentId])
+}
+
+model OAuthRefreshToken {
+  id                   String                 @id @default(uuid()) @db.Uuid
+  tokenHash            String                 @unique
+  accessTokenId        String?                @db.Uuid
+  clientId             String                 @db.Uuid
+  userId               String                 @db.Uuid
+  scopeKind            AuthorizationScopeKind
+  organizationId       String?                @db.Uuid
+  projectId            String?                @db.Uuid
+  environmentId        String?                @db.Uuid
+  scopes               String[]
+  rotationFamilyId     String                 @db.Uuid
+  parentRefreshTokenId String?                @db.Uuid
+  issuedAt             DateTime               @default(now())
+  expiresAt            DateTime
+  consumedAt           DateTime?
+  replayDetectedAt     DateTime?
+  revokedAt            DateTime?
+
+  accessToken  OAuthAccessToken?   @relation(fields: [accessTokenId], references: [id], onDelete: SetNull)
+  client       OAuthClient         @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  user         User                @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization?       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project?            @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environment  Environment?        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  parent       OAuthRefreshToken?  @relation("OAuthRefreshRotation", fields: [parentRefreshTokenId], references: [id], onDelete: Restrict)
+  replacements OAuthRefreshToken[] @relation("OAuthRefreshRotation")
+
+  @@index([clientId, userId, rotationFamilyId])
+  @@index([accessTokenId])
+  @@index([parentRefreshTokenId])
+  @@index([organizationId])
+  @@index([projectId])
+  @@index([environmentId])
+}
+
+model McpBearerToken {
+  id              String    @id @default(uuid()) @db.Uuid
+  entityId        String    @db.Uuid
+  createdByUserId String    @db.Uuid
+  tokenHash       String    @unique
+  label           String
+  mcpUserId       String
+  scopes          String[]
+  createdAt       DateTime  @default(now())
+  lastUsedAt      DateTime?
+  expiresAt       DateTime?
+  revokedAt       DateTime?
+
+  entity    Entity @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  createdBy User   @relation(fields: [createdByUserId], references: [id], onDelete: Restrict)
+
+  @@index([entityId, mcpUserId, revokedAt, expiresAt])
+  @@index([createdByUserId])
+}
+
+model PostmanTemplate {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  agentId        String   @db.Uuid
+  name           String
+  simulateUserId String
+  /// Object root containing request/session variables; validated by jsonShapeRegistry.
+  sessionContext Json?
+  createdBy      String
+  isDefault      Boolean  @default(false)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent       @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, agentId, name])
+  @@index([agentId])
+}
+
+model Thread {
+  id             String     @id @default(uuid()) @db.Uuid
+  environmentId  String     @db.Uuid
+  agentId        String     @db.Uuid
+  endUserId      String     @db.Uuid
+  clusterId      String?    @db.Uuid
+  parentThreadId String?    @db.Uuid
+  title          String?
+  status         WorkStatus @default(ACTIVE)
+  summary        String?
+  /// Object root containing verified, non-authoritative channel context; validated by jsonShapeRegistry.
+  sessionContext Json?
+  tags           String[]   @default([])
+  pinnedAt       DateTime?
+  archivedAt     DateTime?
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
+
+  environment       Environment        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent             Agent              @relation(fields: [agentId], references: [id], onDelete: Restrict)
+  endUser           EndUser            @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  cluster           AgentCluster?      @relation(fields: [clusterId], references: [id], onDelete: SetNull)
+  parentThread      Thread?            @relation("ThreadFork", fields: [parentThreadId], references: [id], onDelete: SetNull)
+  forks             Thread[]           @relation("ThreadFork")
+  turns             Turn[]
+  artifacts         Artifact[]
+  channelThreads    ChannelThread[]
+  channelAppThreads ChannelAppThread[]
+  approvals         AgentApproval[]
+  safetyEvents      SafetyEvent[]
+  agentEvals        AgentEval[]
+  toolCallAudits    ToolCallAudit[]
+
+  @@index([environmentId, endUserId, updatedAt])
+  @@index([agentId, status])
+  @@index([clusterId])
+  @@index([parentThreadId])
+}
+
+model Turn {
+  id                String     @id @default(uuid()) @db.Uuid
+  threadId          String     @db.Uuid
+  parentTurnId      String?    @db.Uuid
+  sequence          Int
+  inputText         String?
+  outputText        String?
+  /// Object root containing structured accepted input; validated by jsonShapeRegistry.
+  input             Json?
+  /// Object root containing structured final output; validated by jsonShapeRegistry.
+  output            Json?
+  thinkingContent   String?
+  status            WorkStatus @default(PENDING)
+  externalRuntimeId String?
+  startedAt         DateTime?
+  completedAt       DateTime?
+  createdAt         DateTime   @default(now())
+
+  thread         Thread              @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  parentTurn     Turn?               @relation("TurnRevision", fields: [parentTurnId], references: [id], onDelete: SetNull)
+  revisions      Turn[]              @relation("TurnRevision")
+  steps          Step[]
+  attachments    MessageAttachment[]
+  artifacts      Artifact[]
+  approvals      AgentApproval[]
+  safetyEvents   SafetyEvent[]
+  messageRatings MessageRating[]
+  agentEvals     AgentEval[]
+
+  @@unique([threadId, sequence])
+  @@index([parentTurnId])
+  @@index([threadId, status])
+}
+
+model Step {
+  id           String     @id @default(uuid()) @db.Uuid
+  turnId       String     @db.Uuid
+  sequence     Int
+  model        String
+  status       WorkStatus @default(PENDING)
+  retryCount   Int        @default(0)
+  inputTokens  Int?
+  outputTokens Int?
+  error        String?
+  startedAt    DateTime?
+  completedAt  DateTime?
+  createdAt    DateTime   @default(now())
+
+  turn      Turn       @relation(fields: [turnId], references: [id], onDelete: Cascade)
+  toolCalls ToolCall[]
+
+  @@unique([turnId, sequence])
+}
+
+model ToolCall {
+  id          String     @id @default(uuid()) @db.Uuid
+  stepId      String     @db.Uuid
+  toolId      String?    @db.Uuid
+  sequence    Int
+  toolName    String
+  /// Object root containing validated tool arguments; validated by jsonShapeRegistry.
+  arguments   Json
+  /// Object or array root containing the tool result; validated by jsonShapeRegistry.
+  result      Json?
+  status      WorkStatus @default(PENDING)
+  retryCount  Int        @default(0)
+  error       String?
+  latencyMs   Int?
+  startedAt   DateTime?
+  completedAt DateTime?
+  createdAt   DateTime   @default(now())
+
+  step Step  @relation(fields: [stepId], references: [id], onDelete: Cascade)
+  tool Tool? @relation(fields: [toolId], references: [id], onDelete: SetNull)
+
+  @@unique([stepId, sequence])
+  @@index([toolId])
+}
+
+model Artifact {
+  id               String   @id @default(uuid()) @db.Uuid
+  environmentId    String   @db.Uuid
+  threadId         String   @db.Uuid
+  producedByTurnId String?  @db.Uuid
+  artifactKey      String
+  revision         Int      @default(1)
+  kind             String
+  title            String?
+  mimeType         String?
+  content          String
+  /// Object root containing non-secret artifact attributes; validated by jsonShapeRegistry.
+  metadata         Json?
+  createdBy        String
+  createdAt        DateTime @default(now())
+
+  environment    Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  thread         Thread      @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  producedByTurn Turn?       @relation(fields: [producedByTurnId], references: [id], onDelete: SetNull)
+
+  @@unique([threadId, artifactKey, revision])
+  @@index([environmentId, createdAt])
+  @@index([producedByTurnId])
+}
+
+model MessageAttachment {
+  id            String    @id @default(uuid()) @db.Uuid
+  environmentId String    @db.Uuid
+  endUserId     String    @db.Uuid
+  turnId        String?   @db.Uuid
+  kind          String
+  mimeType      String
+  bytes         Int
+  width         Int?
+  height        Int?
+  durationSec   Int?
+  storageKey    String
+  originalName  String?
+  contentHash   String?
+  createdAt     DateTime  @default(now())
+  expiresAt     DateTime?
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  endUser     EndUser     @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  turn        Turn?       @relation(fields: [turnId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, endUserId, createdAt])
+  @@index([turnId])
+}
+
+model Entity {
+  id               String    @id @default(uuid()) @db.Uuid
+  projectId        String    @db.Uuid
+  externalId       String
+  displayName      String
+  connectionStatus String
+  connectionKind   String
+  mcpUrls          String[]  @default([])
+  allowedOrigins   String[]  @default([])
+  capabilities     String[]  @default([])
+  lastConnectedAt  DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  project              Project                 @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  channelConnections   ChannelConnection[]
+  mcpConfig            EntityMcpConfig?
+  mcpClient            EntityMcpClient?
+  environmentTools     EnvironmentEntityTool[]
+  toolPolicies         EntityToolPolicy[]
+  mcpAnonymousSessions McpAnonymousSession[]
+  mcpOidcSessions      McpOidcSession[]
+  oauthClients         OAuthClient[]
+  mcpBearerTokens      McpBearerToken[]
+
+  @@unique([projectId, externalId])
+}
+
+model ChannelConnection {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  entityId       String?  @db.Uuid
+  provider       String
+  displayName    String?
+  defaultAgentId String?  @db.Uuid
+  /// Array root of typed channel-routing rules; validated by jsonShapeRegistry.
+  agentRouting   Json     @default("[]")
+  enabled        Boolean  @default(true)
+  credentialId   String?  @db.Uuid
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  environment  Environment     @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  entity       Entity?         @relation(fields: [entityId], references: [id], onDelete: SetNull)
+  defaultAgent Agent?          @relation(fields: [defaultAgentId], references: [id], onDelete: SetNull)
+  credential   Credential?     @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+  threads      ChannelThread[]
+
+  @@index([environmentId, enabled])
+  @@index([entityId])
+}
+
+model ChannelThread {
+  id               String   @id @default(uuid()) @db.Uuid
+  connectionId     String   @db.Uuid
+  threadId         String   @db.Uuid
+  channelThreadKey String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  connection ChannelConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  thread     Thread            @relation(fields: [threadId], references: [id], onDelete: Cascade)
+
+  @@unique([connectionId, channelThreadKey])
+  @@index([threadId])
+}
+
+model ChannelApp {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  provider       String
+  displayName    String?
+  clientId       String
+  credentialId   String?  @db.Uuid
+  scopes         String[] @default([])
+  distribution   String
+  defaultAgentId String?  @db.Uuid
+  /// Array root of typed channel-routing rules; validated by jsonShapeRegistry.
+  agentRouting   Json     @default("[]")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  environment   Environment           @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  defaultAgent  Agent?                @relation(fields: [defaultAgentId], references: [id], onDelete: SetNull)
+  credential    Credential?           @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+  installations ChannelInstallation[]
+
+  @@unique([environmentId, provider, clientId])
+}
+
+model ChannelInstallation {
+  id                     String    @id @default(uuid()) @db.Uuid
+  appId                  String    @db.Uuid
+  externalInstallationId String
+  displayName            String?
+  credentialId           String?   @db.Uuid
+  grantedScopes          String[]  @default([])
+  defaultAgentId         String?   @db.Uuid
+  /// Array root of typed channel-routing rules; validated by jsonShapeRegistry.
+  agentRouting           Json      @default("[]")
+  status                 String
+  revokedAt              DateTime?
+  lastEventAt            DateTime?
+  createdAt              DateTime  @default(now())
+  updatedAt              DateTime  @updatedAt
+
+  app          ChannelApp         @relation(fields: [appId], references: [id], onDelete: Cascade)
+  defaultAgent Agent?             @relation(fields: [defaultAgentId], references: [id], onDelete: SetNull)
+  credential   Credential?        @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+  threads      ChannelAppThread[]
+
+  @@unique([appId, externalInstallationId])
+}
+
+model ChannelAppThread {
+  id               String   @id @default(uuid()) @db.Uuid
+  installationId   String   @db.Uuid
+  threadId         String   @db.Uuid
+  channelThreadKey String
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  installation ChannelInstallation @relation(fields: [installationId], references: [id], onDelete: Cascade)
+  thread       Thread              @relation(fields: [threadId], references: [id], onDelete: Cascade)
+
+  @@unique([installationId, channelThreadKey])
+  @@index([threadId])
+}
+
+model EntityMcpConfig {
+  entityId             String   @id @db.Uuid
+  enabled              Boolean  @default(false)
+  identityMode         String
+  /// Array root of typed identity-provider descriptors; validated by jsonShapeRegistry.
+  identityProviders    Json     @default("[]")
+  /// Object root containing public branding values; validated by jsonShapeRegistry.
+  branding             Json     @default("{}")
+  toolAllowlist        String[] @default([])
+  redirectUriAllowlist String[] @default([])
+  rateLimitPerMinute   Int      @default(60)
+  injectMcpContext     Boolean  @default(false)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  entity Entity @relation(fields: [entityId], references: [id], onDelete: Cascade)
+}
+
+model EntityMcpClient {
+  entityId        String    @id @db.Uuid
+  transport       String
+  url             String?
+  credentialId    String?   @db.Uuid
+  /// Object root of non-secret outbound header templates; validated by jsonShapeRegistry.
+  headersTemplate Json      @default("{}")
+  lastDiscoveryAt DateTime?
+  discoveryError  String?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  entity     Entity      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  credential Credential? @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+}
+
+model Tool {
+  id          String   @id @default(uuid()) @db.Uuid
+  name        String
+  description String
+  kind        ToolKind @default(ENTITY)
+  /// Object root containing a JSON Schema for tool parameters; validated by jsonShapeRegistry.
+  paramSchema Json
+  category    String?
+  schemaHash  String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  environmentEntities EnvironmentEntityTool[]
+  health              ToolHealth[]
+  calls               ToolCall[]
+  auditEvents         ToolCallAudit[]
+  agentPolicies       AgentToolPolicy[]
+  entityPolicies      EntityToolPolicy[]
+
+  @@unique([name, schemaHash])
+  @@index([kind, name])
+}
+
+model EnvironmentEntityTool {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  entityId      String   @db.Uuid
+  toolId        String   @db.Uuid
+  enabled       Boolean  @default(true)
+  callbackUrl   String?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  entity      Entity      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  tool        Tool        @relation(fields: [toolId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, entityId, toolId])
+  @@index([toolId])
+}
+
+model ToolHealth {
+  id               String    @id @default(uuid()) @db.Uuid
+  environmentId    String    @db.Uuid
+  toolId           String    @db.Uuid
+  entityExternalId String?
+  lastCalledAt     DateTime?
+  lastStatus       String?
+  failCount        Int       @default(0)
+  totalCalls       Int       @default(0)
+  totalFailures    Int       @default(0)
+  p95LatencyMs     Int?
+  avgLatencyMs     Int?
+  updatedAt        DateTime  @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  tool        Tool        @relation(fields: [toolId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, toolId, entityExternalId])
+}
+
+model ToolCallAudit {
+  id            String     @id @default(uuid()) @db.Uuid
+  environmentId String     @db.Uuid
+  toolId        String?    @db.Uuid
+  endUserId     String?    @db.Uuid
+  agentId       String?    @db.Uuid
+  threadId      String?    @db.Uuid
+  toolName      String
+  /// Object root containing redacted call arguments; validated by jsonShapeRegistry.
+  arguments     Json
+  /// Object or array root containing a redacted result; validated by jsonShapeRegistry.
+  result        Json?
+  error         String?
+  status        WorkStatus
+  latencyMs     Int
+  costCents     Decimal?   @db.Decimal(18, 6)
+  traceId       String?
+  createdAt     DateTime   @default(now())
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  tool        Tool?       @relation(fields: [toolId], references: [id], onDelete: SetNull)
+  endUser     EndUser?    @relation(fields: [endUserId], references: [id], onDelete: SetNull)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
+  thread      Thread?     @relation(fields: [threadId], references: [id], onDelete: SetNull)
+
+  @@index([environmentId, createdAt])
+  @@index([endUserId, createdAt])
+  @@index([toolId])
+}
+
+model AdminAudit {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  actorUserId   String?
+  action        String
+  subjectType   String
+  subjectId     String?
+  /// Object root containing the redacted previous state; validated by jsonShapeRegistry.
+  before        Json?
+  /// Object root containing the redacted resulting state; validated by jsonShapeRegistry.
+  after         Json?
+  reason        String?
+  source        String?
+  createdAt     DateTime @default(now())
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, createdAt])
+}
+
+model AgentApproval {
+  id             String         @id @default(uuid()) @db.Uuid
+  environmentId  String         @db.Uuid
+  agentId        String?        @db.Uuid
+  threadId       String?        @db.Uuid
+  turnId         String?        @db.Uuid
+  action         String
+  details        String?
+  status         ApprovalStatus @default(PENDING)
+  timeoutSeconds Int            @default(300)
+  resolvedAt     DateTime?
+  respondedBy    String?
+  comment        String?
+  toolName       String?
+  /// Object root containing proposed arguments; validated by jsonShapeRegistry.
+  arguments      Json?
+  /// Object root containing the approval resolution; validated by jsonShapeRegistry.
+  resolution     Json?
+  createdAt      DateTime       @default(now())
+  updatedAt      DateTime       @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
+  thread      Thread?     @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  turn        Turn?       @relation(fields: [turnId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, status, createdAt])
+  @@index([threadId])
+  @@index([turnId])
+}
+
+model EnvironmentProvider {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  providerId    String
+  enabled       Boolean  @default(true)
+  linkedAt      DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, providerId])
+}
+
+model Budget {
+  id              String    @id @default(uuid()) @db.Uuid
+  environmentId   String    @db.Uuid
+  agentId         String?   @db.Uuid
+  scope           String
+  period          String
+  limitCents      Int
+  turnsLimit      Int?
+  /// Array root of integer percentage thresholds; validated by jsonShapeRegistry.
+  alertThresholds Json      @default("[]")
+  enabled         Boolean   @default(true)
+  overrideUntil   DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, enabled])
+  @@index([agentId])
+}
+
+model SafetyEvent {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  agentId       String?  @db.Uuid
+  threadId      String?  @db.Uuid
+  turnId        String?  @db.Uuid
+  endUserId     String?  @db.Uuid
+  detector      String
+  action        String
+  severity      String
+  detail        String?
+  /// Object root containing redacted detector attributes; validated by jsonShapeRegistry.
+  metadata      Json?
+  toolName      String?
+  toolCallId    String?
+  createdAt     DateTime @default(now())
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
+  thread      Thread?     @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  turn        Turn?       @relation(fields: [turnId], references: [id], onDelete: Cascade)
+  endUser     EndUser?    @relation(fields: [endUserId], references: [id], onDelete: SetNull)
+
+  @@index([environmentId, createdAt])
+  @@index([endUserId])
+}
+
+model MessageRating {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  turnId         String   @db.Uuid
+  agentId        String   @db.Uuid
+  agentVersionId String?  @db.Uuid
+  endUserId      String   @db.Uuid
+  rating         Int
+  comment        String?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  environment  Environment   @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  turn         Turn          @relation(fields: [turnId], references: [id], onDelete: Cascade)
+  agent        Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  agentVersion AgentVersion? @relation(fields: [agentVersionId], references: [id], onDelete: SetNull)
+  endUser      EndUser       @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+
+  @@unique([turnId, endUserId])
+  @@index([environmentId, createdAt])
+  @@index([agentId])
+  @@index([agentVersionId])
+}
+
+model EvalCriterion {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  agentId       String?  @db.Uuid
+  name          String
+  description   String?
+  judgePrompt   String
+  rubric        String?
+  judgeModel    String?
+  scoreScaleMin Int      @default(0)
+  scoreScaleMax Int      @default(1)
+  isActive      Boolean  @default(true)
+  createdBy     String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  evals       AgentEval[]
+
+  @@unique([environmentId, name])
+  @@index([agentId])
+}
+
+model AgentEval {
+  id                String   @id @default(uuid()) @db.Uuid
+  environmentId     String   @db.Uuid
+  agentId           String   @db.Uuid
+  agentVersionId    String?  @db.Uuid
+  threadId          String   @db.Uuid
+  turnId            String?  @db.Uuid
+  criterionId       String   @db.Uuid
+  /// Object root containing the immutable criterion used; validated by jsonShapeRegistry.
+  criterionSnapshot Json
+  judgeModel        String
+  judgePromptUsed   String
+  rawResponse       String?
+  score             Float
+  rationale         String?
+  passed            Boolean
+  costCents         Decimal? @db.Decimal(18, 6)
+  latencyMs         Int?
+  createdAt         DateTime @default(now())
+
+  environment  Environment   @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent        Agent         @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  agentVersion AgentVersion? @relation(fields: [agentVersionId], references: [id], onDelete: SetNull)
+  thread       Thread        @relation(fields: [threadId], references: [id], onDelete: Cascade)
+  turn         Turn?         @relation(fields: [turnId], references: [id], onDelete: SetNull)
+  criterion    EvalCriterion @relation(fields: [criterionId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, createdAt])
+  @@index([agentId, agentVersionId])
+  @@index([threadId])
+  @@index([turnId])
+  @@index([criterionId])
+}
+
+model GoldenSet {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  agentId       String   @db.Uuid
+  name          String
+  description   String?
+  threadIds     String[] @default([])
+  criterionIds  String[] @default([])
+  createdBy     String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  agent       Agent       @relation(fields: [agentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, agentId, name])
+}
+
+model Job {
+  id               String     @id @default(uuid()) @db.Uuid
+  environmentId    String     @db.Uuid
+  externalId       String?
+  displayName      String
+  description      String?
+  triggerType      String
+  scheduleCron     String?
+  scheduleTimezone String?
+  allowedAgentIds  String[]   @default([])
+  /// Object root containing a JSON Schema for job input; validated by jsonShapeRegistry.
+  payloadSchema    Json?
+  handler          String
+  timeoutSeconds   Int        @default(300)
+  maxRetries       Int        @default(0)
+  status           WorkStatus @default(ACTIVE)
+  createdBy        String
+  lastStartedAt    DateTime?
+  createdAt        DateTime   @default(now())
+  updatedAt        DateTime   @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, externalId])
+  @@index([environmentId, status])
+}
+
+model Skill {
+  id                      String   @id @default(uuid()) @db.Uuid
+  organizationId          String   @db.Uuid
+  slug                    String
+  name                    String
+  description             String
+  version                 String
+  author                  String?
+  origin                  String
+  isOfficial              Boolean  @default(false)
+  tags                    String[] @default([])
+  source                  String
+  /// Object root containing the typed skill manifest; validated by jsonShapeRegistry.
+  manifest                Json
+  promptBlock             String
+  /// Array root of tool descriptors supplied by the skill; validated by jsonShapeRegistry.
+  providesTools           Json     @default("[]")
+  requiredEnvironmentKeys String[] @default([])
+  optionalEnvironmentKeys String[] @default([])
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  organization Organization   @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  projects     ProjectSkill[]
+
+  @@unique([organizationId, slug, version])
+}
+
+model ProjectSkill {
+  id        String   @id @default(uuid()) @db.Uuid
+  projectId String   @db.Uuid
+  skillId   String   @db.Uuid
+  enabled   Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  project      Project            @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  skill        Skill              @relation(fields: [skillId], references: [id], onDelete: Cascade)
+  environments EnvironmentSkill[]
+
+  @@unique([projectId, skillId])
+  @@index([skillId])
+}
+
+model EnvironmentSkill {
+  id             String   @id @default(uuid()) @db.Uuid
+  environmentId  String   @db.Uuid
+  projectSkillId String   @db.Uuid
+  enabled        Boolean  @default(true)
+  /// Object root containing environment-specific skill configuration; validated by jsonShapeRegistry.
+  config         Json     @default("{}")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  environment  Environment  @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  projectSkill ProjectSkill @relation(fields: [projectSkillId], references: [id], onDelete: Cascade)
+  agents       AgentSkill[]
+
+  @@unique([environmentId, projectSkillId])
+  @@index([projectSkillId])
+}
+
+model AgentSkill {
+  id                 String   @id @default(uuid()) @db.Uuid
+  agentVersionId     String   @db.Uuid
+  environmentSkillId String   @db.Uuid
+  enabled            Boolean  @default(true)
+  /// Object root containing agent-version skill configuration; validated by jsonShapeRegistry.
+  config             Json     @default("{}")
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  agentVersion     AgentVersion     @relation(fields: [agentVersionId], references: [id], onDelete: Cascade)
+  environmentSkill EnvironmentSkill @relation(fields: [environmentSkillId], references: [id], onDelete: Cascade)
+
+  @@unique([agentVersionId, environmentSkillId])
+  @@index([environmentSkillId])
+}
+
+model AgentToolPolicy {
+  id             String       @id @default(uuid()) @db.Uuid
+  agentVersionId String       @db.Uuid
+  toolId         String       @db.Uuid
+  effect         PolicyEffect
+  priority       Int          @default(0)
+  createdAt      DateTime     @default(now())
+
+  agentVersion AgentVersion @relation(fields: [agentVersionId], references: [id], onDelete: Cascade)
+  tool         Tool         @relation(fields: [toolId], references: [id], onDelete: Cascade)
+
+  @@unique([agentVersionId, toolId])
+  @@index([toolId])
+}
+
+model Memory {
+  id             String    @id @default(uuid()) @db.Uuid
+  environmentId  String    @db.Uuid
+  endUserId      String    @db.Uuid
+  agentId        String?   @db.Uuid
+  kind           String
+  content        String
+  /// Object root containing non-secret extraction/source attributes; validated by jsonShapeRegistry.
+  metadata       Json?
+  agentVisible   Boolean   @default(true)
+  visibility     String
+  source         String
+  sourceThreadId String?
+  sourceTurnIds  String[]  @default([])
+  contentHash    String?
+  confidence     Float?
+  lastAccessedAt DateTime?
+  archivedAt     DateTime?
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  endUser     EndUser     @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  agent       Agent?      @relation(fields: [agentId], references: [id], onDelete: SetNull)
+
+  @@index([environmentId, endUserId, archivedAt])
+  @@index([agentId])
+}
+
+model MemoryEntity {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  endUserId     String   @db.Uuid
+  entityKey     String
+  entityType    String
+  label         String
+  aliases       String[] @default([])
+  /// Object root containing extracted entity attributes; validated by jsonShapeRegistry.
+  metadata      Json?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment       Environment          @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  endUser           EndUser              @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  fromRelationships MemoryRelationship[] @relation("MemoryRelationshipFrom")
+  toRelationships   MemoryRelationship[] @relation("MemoryRelationshipTo")
+
+  @@unique([environmentId, endUserId, entityKey])
+}
+
+model MemoryRelationship {
+  id               String   @id @default(uuid()) @db.Uuid
+  environmentId    String   @db.Uuid
+  endUserId        String   @db.Uuid
+  fromEntityId     String   @db.Uuid
+  toEntityId       String   @db.Uuid
+  relationshipType String
+  weight           Float?
+  /// Object root containing extracted relationship attributes; validated by jsonShapeRegistry.
+  metadata         Json?
+  sourceMemoryId   String?
+  createdAt        DateTime @default(now())
+
+  environment Environment  @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  endUser     EndUser      @relation(fields: [endUserId], references: [id], onDelete: Cascade)
+  fromEntity  MemoryEntity @relation("MemoryRelationshipFrom", fields: [fromEntityId], references: [id], onDelete: Cascade)
+  toEntity    MemoryEntity @relation("MemoryRelationshipTo", fields: [toEntityId], references: [id], onDelete: Cascade)
+
+  @@unique([fromEntityId, toEntityId, relationshipType])
+  @@index([environmentId, endUserId])
+  @@index([toEntityId])
+}
+
+model OrganizationMcpPolicy {
+  id             String       @id @default(uuid()) @db.Uuid
+  organizationId String       @db.Uuid
+  pattern        String
+  effect         PolicyEffect
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, pattern])
+}
+
+model Macro {
+  id                     String   @id @default(uuid()) @db.Uuid
+  environmentId          String   @db.Uuid
+  name                   String
+  description            String?
+  /// Array root of typed macro-step objects; validated by jsonShapeRegistry.
+  steps                  Json
+  /// Object root containing a JSON Schema for macro parameters; validated by jsonShapeRegistry.
+  paramSchema            Json?
+  sharedWithOrganization Boolean  @default(false)
+  createdBy              String
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, name])
+}
+
+model Event {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  eventType     String
+  subjectId     String?
+  /// Object root containing the versioned event body; validated by jsonShapeRegistry.
+  payload       Json
+  createdAt     DateTime @default(now())
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@index([environmentId, eventType, createdAt])
+}
+
+model NotificationRule {
+  id            String   @id @default(uuid()) @db.Uuid
+  environmentId String   @db.Uuid
+  name          String
+  /// Object root containing typed event predicates; validated by jsonShapeRegistry.
+  filters       Json
+  /// Object root containing typed destination configuration without secrets; validated by jsonShapeRegistry.
+  delivery      Json
+  enabled       Boolean  @default(true)
+  createdBy     String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, name])
+}
+
+model OAuthClient {
+  id                      String    @id @default(uuid()) @db.Uuid
+  organizationId          String    @db.Uuid
+  clientId                String    @unique
+  clientSecretHash        String?
+  clientName              String
+  redirectUris            String[]
+  tokenEndpointAuthMethod String
+  grantTypes              String[]
+  scopes                  String[]
+  registeredByUserId      String    @db.Uuid
+  entityId                String?   @db.Uuid
+  createdAt               DateTime  @default(now())
+  deletedAt               DateTime?
+
+  organization       Organization             @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  registeredBy       User                     @relation(fields: [registeredByUserId], references: [id], onDelete: Restrict)
+  entity             Entity?                  @relation(fields: [entityId], references: [id], onDelete: SetNull)
+  authorizationCodes OAuthAuthorizationCode[]
+  accessTokens       OAuthAccessToken[]
+  refreshTokens      OAuthRefreshToken[]
+
+  @@index([organizationId, deletedAt])
+}
+
+model OAuthAuthorizationCode {
+  id                  String                 @id @default(uuid()) @db.Uuid
+  scopeKind           AuthorizationScopeKind
+  organizationId      String?                @db.Uuid
+  projectId           String?                @db.Uuid
+  environmentId       String?                @db.Uuid
+  clientId            String                 @db.Uuid
+  userId              String                 @db.Uuid
+  codeHash            String                 @unique
+  codeChallenge       String
+  codeChallengeMethod String
+  redirectUri         String
+  scopes              String[]
+  expiresAt           DateTime
+  usedAt              DateTime?
+  createdAt           DateTime               @default(now())
+
+  organization Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project?      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environment  Environment?  @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  client       OAuthClient   @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([organizationId, expiresAt])
+  @@index([projectId, expiresAt])
+  @@index([environmentId, expiresAt])
+  @@index([clientId])
+  @@index([userId])
+}
+
+model McpAnonymousSession {
+  id            String    @id @default(uuid()) @db.Uuid
+  environmentId String    @db.Uuid
+  entityId      String    @db.Uuid
+  mcpUserId     String
+  firstSeenIp   String?
+  userAgent     String?
+  createdAt     DateTime  @default(now())
+  lastUsedAt    DateTime?
+  revokedAt     DateTime?
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  entity      Entity      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+
+  @@unique([environmentId, entityId, mcpUserId])
+}
+
+model McpOidcSession {
+  id              String    @id @default(uuid()) @db.Uuid
+  environmentId   String    @db.Uuid
+  entityId        String    @db.Uuid
+  mcpUserId       String
+  provider        String
+  email           String?
+  emailVerified   Boolean   @default(false)
+  externalSubject String
+  displayName     String?
+  avatarUrl       String?
+  credentialId    String?   @db.Uuid
+  firstLoginAt    DateTime  @default(now())
+  lastLoginAt     DateTime?
+  revokedAt       DateTime?
+
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  entity      Entity      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  credential  Credential? @relation(fields: [credentialId], references: [id], onDelete: SetNull)
+
+  @@unique([environmentId, entityId, provider, externalSubject])
+}
+
+model EntityToolPolicy {
+  id              String       @id @default(uuid()) @db.Uuid
+  entityId        String       @db.Uuid
+  toolId          String       @db.Uuid
+  effect          PolicyEffect
+  minIdentityMode String
+  scopeLabels     String[]     @default([])
+  addedBy         String
+  addedAt         DateTime     @default(now())
+  lastReviewedAt  DateTime?
+
+  entity Entity @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  tool   Tool   @relation(fields: [toolId], references: [id], onDelete: Cascade)
+
+  @@unique([entityId, toolId])
+  @@index([toolId])
+}
+
+model ErasureOperation {
+  id                String     @id @default(uuid()) @db.Uuid
+  organizationId    String     @db.Uuid
+  idempotencyKey    String
+  subjectKeyHash    String
+  status            WorkStatus @default(PENDING)
+  /// Array root of normalized subject scope descriptors; validated by jsonShapeRegistry.
+  scopes            Json
+  /// Array root of storage-system erasure outcomes; validated by jsonShapeRegistry.
+  stores            Json
+  /// Object root containing a non-identifying row inventory; validated by jsonShapeRegistry.
+  inventory         Json?
+  policyVersion     String
+  legalHoldPolicyId String?
+  retryCount        Int        @default(0)
+  requestedAt       DateTime   @default(now())
+  startedAt         DateTime?
+  completedAt       DateTime?
+  updatedAt         DateTime   @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Restrict)
+
+  @@unique([organizationId, idempotencyKey])
+  @@index([organizationId, subjectKeyHash, requestedAt])
 }

--- a/internal-packages/tenancy-database/src/end-user.ts
+++ b/internal-packages/tenancy-database/src/end-user.ts
@@ -3,18 +3,37 @@ import {
   PrismaClient as GeneratedEndUserClient,
 } from "../generated/end-user";
 
-export type EndUserClient = Readonly<{
-  endUser: GeneratedEndUserClient["endUser"];
-  endUserIdentity: GeneratedEndUserClient["endUserIdentity"];
-  endUserSession: GeneratedEndUserClient["endUserSession"];
-  disconnect: () => Promise<void>;
-}>;
+export const endUserDelegateNames = [
+  "endUser",
+  "endUserIdentity",
+  "endUserSession",
+  "thread",
+  "turn",
+  "step",
+  "toolCall",
+  "artifact",
+  "messageAttachment",
+  "agentApproval",
+  "memory",
+  "memoryEntity",
+  "memoryRelationship",
+  "messageRating",
+] as const;
+
+type EndUserDelegateName = (typeof endUserDelegateNames)[number];
+
+export type EndUserClient = Readonly<
+  Pick<GeneratedEndUserClient, EndUserDelegateName> & {
+    disconnect: () => Promise<void>;
+  }
+>;
 
 /**
  * Creates the only client surface that data-plane request handlers should use.
  *
- * The generated schema contains no operator models or relations, and this
- * facade intentionally omits raw SQL and transaction escape hatches.
+ * The generated schema contains only subject-reachable data and relations. This
+ * frozen facade additionally omits raw SQL, transactions, extension hooks, and
+ * every operator/configuration delegate.
  */
 export function createEndUserClient(
   options?: EndUserPrisma.Subset<
@@ -23,11 +42,12 @@ export function createEndUserClient(
   >
 ): EndUserClient {
   const client = new GeneratedEndUserClient(options);
+  const delegates = Object.fromEntries(
+    endUserDelegateNames.map((name) => [name, client[name]])
+  ) as Pick<GeneratedEndUserClient, EndUserDelegateName>;
 
   return Object.freeze({
-    endUser: client.endUser,
-    endUserIdentity: client.endUserIdentity,
-    endUserSession: client.endUserSession,
+    ...delegates,
     disconnect: () => client.$disconnect(),
   });
 }

--- a/internal-packages/tenancy-database/src/index.ts
+++ b/internal-packages/tenancy-database/src/index.ts
@@ -1,2 +1,5 @@
 export * from "../generated/control";
 export { createEndUserClient, type EndUserClient } from "./end-user";
+export * from "./json";
+export * from "./source-model-manifest";
+export * from "./tool-policy";

--- a/internal-packages/tenancy-database/src/integration.test.ts
+++ b/internal-packages/tenancy-database/src/integration.test.ts
@@ -1,23 +1,33 @@
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import {
+  ApprovalStatus,
+  AgentToolDefaultPolicy,
+  AuthorizationScopeKind,
+  CredentialKind,
+  OrganizationRole,
+  PolicyEffect,
   Prisma,
   PrismaClient,
   PrincipalTier,
-  OrganizationRole,
   ProjectRole,
+  ToolKind,
+  WorkStatus,
 } from "../generated/control";
 import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
-import { createEndUserClient, type EndUserClient } from "./end-user";
+import { createEndUserClient, endUserDelegateNames, type EndUserClient } from "./end-user";
+import { resolveAgentToolIds } from "./tool-policy";
 
 const future = () => new Date(Date.now() + 60 * 60 * 1000);
+type UniqueWhere = Record<string, string>;
+type Registry = Map<string, UniqueWhere>;
 
-describe("tenancy schema integration", () => {
+describe("domain schema integration", () => {
   let container: StartedPostgreSqlContainer;
   let control: PrismaClient;
   let endUser: EndUserClient;
-  let records: Awaited<ReturnType<typeof seedEveryModel>>;
+  let seeded: Awaited<ReturnType<typeof seedEveryModel>>;
 
   beforeAll(async () => {
     container = await new PostgreSqlContainer("postgres:16-alpine").start();
@@ -36,7 +46,7 @@ describe("tenancy schema integration", () => {
 
     control = new PrismaClient({ datasources: { db: { url: databaseUrl } } });
     endUser = createEndUserClient({ datasources: { db: { url: databaseUrl } } });
-    records = await seedEveryModel(control);
+    seeded = await seedEveryModel(control);
   }, 120_000);
 
   afterAll(async () => {
@@ -45,314 +55,941 @@ describe("tenancy schema integration", () => {
     await container?.stop();
   });
 
-  test("round-trips every model in the authoritative schema", async () => {
-    const reads = {
-      User: await control.user.findUnique({ where: { id: records.user.id } }),
-      OperatorSession: await control.operatorSession.findUnique({
-        where: { id: records.operatorSession.id },
-      }),
-      Organization: await control.organization.findUnique({ where: { id: records.organization.id } }),
-      OrganizationMembership: await control.organizationMembership.findUnique({
-        where: { id: records.organizationMembership.id },
-      }),
-      OrganizationInvitation: await control.organizationInvitation.findUnique({
-        where: { id: records.organizationInvitation.id },
-      }),
-      Project: await control.project.findUnique({ where: { id: records.project.id } }),
-      ProjectMembership: await control.projectMembership.findUnique({
-        where: { id: records.projectMembership.id },
-      }),
-      Environment: await control.environment.findUnique({ where: { id: records.environment.id } }),
-      EnvironmentSession: await control.environmentSession.findUnique({
-        where: { id: records.environmentSession.id },
-      }),
-      EndUser: await control.endUser.findUnique({ where: { id: records.endUser.id } }),
-      EndUserIdentity: await control.endUserIdentity.findUnique({
-        where: { id: records.endUserIdentity.id },
-      }),
-      EndUserSession: await control.endUserSession.findUnique({
-        where: { id: records.endUserSession.id },
-      }),
-    };
+  test("round-trips every generated model and capability", async () => {
+    const modelNames = Prisma.dmmf.datamodel.models.map((model) => model.name);
+    expect(modelNames).toHaveLength(71);
+    expect([...seeded.registry.keys()].sort()).toEqual([...modelNames].sort());
 
-    expect(Object.keys(reads).sort()).toEqual(
-      Prisma.dmmf.datamodel.models.map((model) => model.name).sort()
-    );
-    for (const record of Object.values(reads)) {
-      expect(record).not.toBeNull();
+    for (const modelName of modelNames) {
+      const delegateName = `${modelName[0].toLowerCase()}${modelName.slice(1)}`;
+      const delegate = (control as unknown as Record<string, {
+        findUnique(args: { where: UniqueWhere }): Promise<unknown>;
+      }>)[delegateName];
+      expect(delegate, modelName).toBeDefined();
+      await expect(delegate.findUnique({ where: seeded.registry.get(modelName)! }), modelName)
+        .resolves.not.toBeNull();
     }
-
-    expect(reads.OrganizationMembership?.role).toBe(OrganizationRole.OWNER);
-    expect(reads.ProjectMembership?.role).toBe(ProjectRole.ADMIN);
-    expect(reads.OperatorSession?.tier).toBe(PrincipalTier.OPERATOR);
-    expect(reads.EnvironmentSession?.tier).toBe(PrincipalTier.OPERATOR);
-    expect(reads.EndUserSession?.tier).toBe(PrincipalTier.END_USER);
   });
 
-  test("exposes no operator query or raw SQL path from the end-user client", async () => {
-    expect(Object.keys(endUser).sort()).toEqual([
-      "disconnect",
-      "endUser",
-      "endUserIdentity",
-      "endUserSession",
-    ]);
-    expect("user" in endUser).toBe(false);
-    expect("organization" in endUser).toBe(false);
-    expect("$queryRaw" in endUser).toBe(false);
-    expect("$transaction" in endUser).toBe(false);
+  test("exposes only subject delegates and no operator, configuration, or raw SQL path", async () => {
+    expect(Object.keys(endUser).sort()).toEqual([...endUserDelegateNames, "disconnect"].sort());
+    for (const forbidden of [
+      "user",
+      "organization",
+      "project",
+      "environment",
+      "agent",
+      "agentVersion",
+      "credential",
+      "entity",
+      "tool",
+      "toolCallAudit",
+      "safetyEvent",
+      "adminAudit",
+      "erasureOperation",
+      "$queryRaw",
+      "$executeRaw",
+      "$transaction",
+      "$extends",
+    ]) {
+      expect(forbidden in endUser).toBe(false);
+    }
 
-    const visibleSession = await endUser.endUserSession.findUnique({
-      where: { id: records.endUserSession.id },
-      include: { identity: { include: { endUser: true } } },
+    const visible = await endUser.thread.findUnique({
+      where: { id: seeded.thread.id },
+      include: {
+        turns: { include: { steps: { include: { toolCalls: true } } } },
+        artifacts: true,
+        approvals: true,
+        endUser: { include: { identities: true } },
+      },
     });
-    expect(visibleSession?.identity.endUser.id).toBe(records.endUser.id);
-
-    await expect(
-      endUser.endUserSession.findMany({ include: { environment: true } } as never)
-    ).rejects.toThrow();
+    expect(visible?.endUser.id).toBe(seeded.endUser.id);
+    expect(visible?.turns[0]?.steps[0]?.toolCalls[0]?.toolName).toBe("remember");
 
     if (false) {
       // @ts-expect-error The restricted client has no operator delegate.
       endUser.user;
-      // @ts-expect-error Environment is deliberately not a data-plane relation.
-      endUser.endUserSession.findMany({ include: { environment: true } });
+      // @ts-expect-error Agent configuration is structurally unreachable.
+      endUser.agentVersion;
+      // @ts-expect-error Environment is a scalar scope pin, never a relation.
+      endUser.thread.findMany({ include: { environment: true } });
     }
   });
 
-  test("rejects a project grant whose membership belongs to another organization", async () => {
+  test("rejects cross-owner ancestry and canonical-owner reparenting", async () => {
     const otherOrganization = await control.organization.create({
       data: { slug: "other-organization", name: "Other organization" },
     });
     const otherProject = await control.project.create({
-      data: {
-        organizationId: otherOrganization.id,
-        slug: "other-project",
-        name: "Other project",
-      },
-    });
-
-    await expect(
-      control.projectMembership.create({
-        data: {
-          projectId: otherProject.id,
-          organizationMembershipId: records.organizationMembership.id,
-          organizationId: records.organization.id,
-          role: ProjectRole.VIEWER,
-        },
-      })
-    ).rejects.toThrow();
-  });
-
-  test("rejects end-user sessions outside the identity organization", async () => {
-    const otherOrganization = await control.organization.create({
-      data: { slug: "session-other-organization", name: "Session other organization" },
-    });
-    const otherProject = await control.project.create({
-      data: {
-        organizationId: otherOrganization.id,
-        slug: "session-other-project",
-        name: "Session other project",
-      },
+      data: { organizationId: otherOrganization.id, slug: "other", name: "Other" },
     });
     const otherEnvironment = await control.environment.create({
-      data: { projectId: otherProject.id, slug: "isolated", name: "Isolated" },
+      data: { projectId: otherProject.id, slug: "other", name: "Other" },
     });
 
-    await expect(
-      endUser.endUserSession.create({
-        data: {
-          identityId: records.endUserIdentity.id,
-          environmentId: otherEnvironment.id,
-          tokenHash: "cross-organization-session-token",
-          expiresAt: future(),
-        },
-      })
-    ).rejects.toThrow();
+    await expect(control.thread.create({
+      data: {
+        environmentId: otherEnvironment.id,
+        agentId: seeded.agent.id,
+        endUserId: seeded.endUser.id,
+        status: WorkStatus.ACTIVE,
+      },
+    })).rejects.toThrow(/ancestry/);
 
-    await expect(
-      control.endUserSession.findUnique({ where: { tokenHash: "cross-organization-session-token" } })
-    ).resolves.toBeNull();
-  });
+    await expect(control.environment.update({
+      where: { id: seeded.environment.id },
+      data: { projectId: otherProject.id },
+    })).rejects.toThrow(/immutable/);
 
-  test("rejects parent reparenting that would make an existing end-user session cross-organization", async () => {
-    const otherOrganization = await control.organization.create({
-      data: { slug: "reparent-other-organization", name: "Reparent other organization" },
+    await expect(control.agentBinding.create({
+      data: {
+        environmentId: otherEnvironment.id,
+        agentId: seeded.agent.id,
+        activeAgentVersionId: seeded.agentVersion.id,
+      },
+    })).rejects.toThrow(/ancestry/);
+
+    const sameOrganizationSubject = await control.endUser.create({
+      data: { organizationId: seeded.organization.id, displayName: "Other subject" },
     });
-    const otherProject = await control.project.create({
+    await expect(control.endUserIdentity.update({
+      where: { id: seeded.endUserIdentity.id },
+      data: { endUserId: sameOrganizationSubject.id },
+    })).rejects.toThrow(/immutable/);
+    await expect(control.endUserIdentity.findUnique({ where: { id: seeded.endUserIdentity.id } }))
+      .resolves.toMatchObject({ endUserId: seeded.endUser.id, organizationId: seeded.organization.id });
+    await expect(control.endUserSession.findFirst({
+      where: { identityId: seeded.endUserIdentity.id, revokedAt: null },
+    })).resolves.not.toBeNull();
+    const crossOrganizationSubject = await control.endUser.create({
+      data: { organizationId: otherOrganization.id, displayName: "Cross-organization subject" },
+    });
+    await expect(control.endUserIdentity.update({
+      where: { id: seeded.endUserIdentity.id },
+      data: {
+        endUserId: crossOrganizationSubject.id,
+        organizationId: otherOrganization.id,
+      },
+    })).rejects.toThrow(/immutable/);
+
+    const siblingApp = await control.channelApp.create({
+      data: {
+        environmentId: seeded.environment.id,
+        provider: "teams",
+        clientId: "sibling-client",
+        distribution: "private",
+        agentRouting: [],
+      },
+    });
+    await expect(control.channelInstallation.update({
+      where: { id: seeded.installation.id },
+      data: { appId: siblingApp.id },
+    })).rejects.toThrow(/immutable/);
+    await expect(control.channelInstallation.findUnique({ where: { id: seeded.installation.id } }))
+      .resolves.toMatchObject({ appId: seeded.installation.appId });
+
+    await control.organizationMembership.create({
       data: {
         organizationId: otherOrganization.id,
-        slug: "reparent-other-project",
-        name: "Reparent other project",
+        userId: seeded.user.id,
+        role: OrganizationRole.MEMBER,
       },
     });
-    const guardedProject = await control.project.create({
-      data: {
-        organizationId: records.organization.id,
-        slug: "guarded-project",
-        name: "Guarded project",
-      },
-    });
-    const sameOrganizationProject = await control.project.create({
-      data: {
-        organizationId: records.organization.id,
-        slug: "same-organization-project",
-        name: "Same organization project",
-      },
-    });
-    const guardedEnvironment = await control.environment.create({
-      data: { projectId: guardedProject.id, slug: "guarded", name: "Guarded" },
-    });
-    const guardedSession = await control.endUserSession.create({
-      data: {
-        identityId: records.endUserIdentity.id,
-        environmentId: guardedEnvironment.id,
-        tokenHash: "guarded-parent-chain-session",
-        expiresAt: future(),
-      },
-    });
+    await expect(control.oAuthClient.update({
+      where: { id: seeded.oauthClient.id },
+      data: { organizationId: otherOrganization.id, entityId: null },
+    })).rejects.toThrow(/immutable/);
+    await expect(control.oAuthClient.findUnique({ where: { id: seeded.oauthClient.id } }))
+      .resolves.toMatchObject({ organizationId: seeded.organization.id });
 
-    await expect(
-      control.environment.update({
-        where: { id: guardedEnvironment.id },
-        data: { projectId: otherProject.id },
-      })
-    ).rejects.toThrow();
-    await expect(
-      control.project.update({
-        where: { id: guardedProject.id },
-        data: { organizationId: otherOrganization.id },
-      })
-    ).rejects.toThrow();
-    await expect(
-      control.endUser.update({
-        where: { id: records.endUser.id },
-        data: { organizationId: otherOrganization.id },
-      })
-    ).rejects.toThrow();
-
-    await expect(
-      control.environment.update({
-        where: { id: guardedEnvironment.id },
-        data: { projectId: sameOrganizationProject.id },
-      })
-    ).resolves.toMatchObject({ projectId: sameOrganizationProject.id });
-
-    await expect(
-      control.endUserSession.findUnique({
-        where: { id: guardedSession.id },
-        include: { environment: { include: { project: true } }, identity: { include: { endUser: true } } },
-      })
-    ).resolves.toMatchObject({
-      environment: { project: { organizationId: records.organization.id } },
-      identity: { endUser: { organizationId: records.organization.id } },
+    const sameSubjectEntity = await control.memoryEntity.create({
+      data: {
+        environmentId: seeded.environment.id,
+        endUserId: sameOrganizationSubject.id,
+        entityKey: "other-subject-entity",
+        entityType: "person",
+        label: "Other",
+      },
     });
+    await expect(control.memoryEntity.update({
+      where: { id: seeded.memoryEntityA.id },
+      data: { endUserId: sameSubjectEntity.endUserId },
+    })).rejects.toThrow(/immutable/);
   });
 
-  test("enforces each session tier with database constraints", async () => {
-    await expect(
-      endUser.endUserSession.create({
-        data: {
-          identityId: records.endUserIdentity.id,
-          environmentId: records.environment.id,
-          tokenHash: "wrong-end-user-tier",
-          tier: PrincipalTier.OPERATOR,
-          expiresAt: future(),
-        },
-      })
-    ).rejects.toThrow();
+  test("represents global PAT, OAuth principal/rotation, and entity bearer semantics", async () => {
+    expect(seeded.personalAccessToken).toMatchObject({
+      userId: seeded.user.id,
+      scopeKind: AuthorizationScopeKind.GLOBAL,
+      organizationId: null,
+      projectId: null,
+      environmentId: null,
+    });
+    expect(seeded.oauthAccessToken).toMatchObject({
+      clientId: seeded.oauthClient.id,
+      userId: seeded.user.id,
+      scopeKind: AuthorizationScopeKind.ENVIRONMENT,
+      environmentId: seeded.environment.id,
+    });
+    expect(seeded.rotatedRefreshToken).toMatchObject({
+      parentRefreshTokenId: seeded.oauthRefreshToken.id,
+      rotationFamilyId: seeded.oauthRefreshToken.rotationFamilyId,
+    });
+    expect(seeded.mcpBearerToken).toMatchObject({
+      entityId: expect.any(String),
+      createdByUserId: seeded.user.id,
+      mcpUserId: "entity-user",
+      scopes: ["tools:call"],
+    });
 
-    await expect(
-      control.operatorSession.create({
-        data: {
-          userId: records.user.id,
-          tokenHash: "wrong-operator-tier",
-          tier: PrincipalTier.END_USER,
-          expiresAt: future(),
-        },
-      })
-    ).rejects.toThrow();
+    await expect(control.personalAccessToken.create({
+      data: {
+        userId: seeded.user.id,
+        scopeKind: AuthorizationScopeKind.GLOBAL,
+        organizationId: seeded.organization.id,
+        tokenHash: "invalid-global-pat",
+        name: "invalid",
+        role: "operator",
+      },
+    })).rejects.toThrow();
+  });
+
+  test("distinguishes zero-row no-tools and all-tools defaults", async () => {
+    const noTools = await control.agentVersion.create({
+      data: {
+        agentId: seeded.agent.id,
+        versionNumber: 10,
+        model: "test:model",
+        toolDefaultPolicy: AgentToolDefaultPolicy.NONE,
+        createdBy: seeded.user.id,
+      },
+      include: { toolPolicies: true },
+    });
+    const allTools = await control.agentVersion.create({
+      data: {
+        agentId: seeded.agent.id,
+        versionNumber: 11,
+        model: "test:model",
+        toolDefaultPolicy: AgentToolDefaultPolicy.ALL,
+        createdBy: seeded.user.id,
+      },
+      include: { toolPolicies: true },
+    });
+    const candidates = (await control.tool.findMany({ select: { id: true } })).map(({ id }) => id);
+
+    expect(noTools.toolPolicies).toHaveLength(0);
+    expect(allTools.toolPolicies).toHaveLength(0);
+    expect(resolveAgentToolIds(noTools.toolDefaultPolicy, noTools.toolPolicies, candidates)).toEqual([]);
+    expect(resolveAgentToolIds(allTools.toolDefaultPolicy, allTools.toolPolicies, candidates))
+      .toEqual([...candidates].sort());
+
+    const newlyRegistered = await control.tool.create({
+      data: {
+        name: "new-after-version",
+        description: "Registered later",
+        paramSchema: { type: "object" },
+        schemaHash: "new-after-version-v1",
+      },
+    });
+    expect(resolveAgentToolIds(noTools.toolDefaultPolicy, [], [newlyRegistered.id])).toEqual([]);
+    expect(resolveAgentToolIds(allTools.toolDefaultPolicy, [], [newlyRegistered.id]))
+      .toEqual([newlyRegistered.id]);
+  });
+
+  test("database constraints reject encoded Json roots and ambiguous enabledTools", async () => {
+    await expect(control.agentVersion.create({
+      data: {
+        agentId: seeded.agent.id,
+        versionNumber: 2,
+        model: "test:model",
+        promptBlocks: JSON.stringify([]),
+        dynamicBlocks: [],
+        toolsBlockConfig: {},
+        modelRoutes: [],
+        createdBy: seeded.user.id,
+      },
+    })).rejects.toThrow();
+
+    await expect(control.agentVersion.create({
+      data: {
+        agentId: seeded.agent.id,
+        versionNumber: 3,
+        model: "test:model",
+        promptBlocks: [],
+        dynamicBlocks: [],
+        toolsBlockConfig: { enabledTools: ["remember"] },
+        modelRoutes: [],
+        createdBy: seeded.user.id,
+      },
+    })).rejects.toThrow();
+  });
+
+  test("erases the subject graph while preserving pseudonymized audits and operators", async () => {
+    const subject = await control.endUser.create({
+      data: { organizationId: seeded.organization.id, displayName: "Erase me" },
+    });
+    const thread = await control.thread.create({
+      data: {
+        environmentId: seeded.environment.id,
+        agentId: seeded.agent.id,
+        endUserId: subject.id,
+      },
+    });
+    const turn = await control.turn.create({
+      data: { threadId: thread.id, sequence: 1, inputText: "private" },
+    });
+    const memory = await control.memory.create({
+      data: {
+        environmentId: seeded.environment.id,
+        endUserId: subject.id,
+        kind: "fact",
+        content: "private",
+        visibility: "subject",
+        source: "turn",
+      },
+    });
+    const audit = await control.toolCallAudit.create({
+      data: {
+        environmentId: seeded.environment.id,
+        endUserId: subject.id,
+        toolName: "remember",
+        arguments: {},
+        status: WorkStatus.SUCCEEDED,
+        latencyMs: 1,
+      },
+    });
+    const unattachedUpload = await control.messageAttachment.create({
+      data: {
+        environmentId: seeded.environment.id,
+        endUserId: subject.id,
+        kind: "file",
+        mimeType: "text/plain",
+        bytes: 7,
+        storageKey: "unattached-subject-upload",
+      },
+    });
+
+    await control.endUser.delete({ where: { id: subject.id } });
+
+    await expect(control.thread.findUnique({ where: { id: thread.id } })).resolves.toBeNull();
+    await expect(control.turn.findUnique({ where: { id: turn.id } })).resolves.toBeNull();
+    await expect(control.memory.findUnique({ where: { id: memory.id } })).resolves.toBeNull();
+    await expect(control.messageAttachment.findUnique({ where: { id: unattachedUpload.id } }))
+      .resolves.toBeNull();
+    await expect(control.toolCallAudit.findUnique({ where: { id: audit.id } }))
+      .resolves.toMatchObject({ endUserId: null });
+    await expect(control.user.findUnique({ where: { id: seeded.user.id } })).resolves.not.toBeNull();
+  });
+
+  test("enforces principal tiers in the database", async () => {
+    await expect(endUser.endUserSession.create({
+      data: {
+        identityId: seeded.endUserIdentity.id,
+        environmentId: seeded.environment.id,
+        tokenHash: "wrong-end-user-tier",
+        tier: PrincipalTier.OPERATOR,
+        expiresAt: future(),
+      },
+    })).rejects.toThrow();
+    await expect(control.operatorSession.create({
+      data: {
+        userId: seeded.user.id,
+        tokenHash: "wrong-operator-tier",
+        tier: PrincipalTier.END_USER,
+        expiresAt: future(),
+      },
+    })).rejects.toThrow();
   });
 });
 
 async function seedEveryModel(control: PrismaClient) {
-  const user = await control.user.create({
+  const registry: Registry = new Map();
+  const track = <T extends { id?: string; entityId?: string | null }>(model: string, record: T): T => {
+    registry.set(model, record.id ? { id: record.id } : { entityId: record.entityId! });
+    return record;
+  };
+
+  const user = track("User", await control.user.create({
     data: { email: "owner@example.test", displayName: "Owner" },
-  });
-  const operatorSession = await control.operatorSession.create({
-    data: { userId: user.id, tokenHash: "operator-session-token", expiresAt: future() },
-  });
-  const organization = await control.organization.create({
+  }));
+  const operatorSession = track("OperatorSession", await control.operatorSession.create({
+    data: { userId: user.id, tokenHash: "operator-session", expiresAt: future() },
+  }));
+  const organization = track("Organization", await control.organization.create({
     data: { slug: "round-trip-organization", name: "Round-trip organization" },
-  });
-  const organizationMembership = await control.organizationMembership.create({
+  }));
+  const organizationMembership = track("OrganizationMembership", await control.organizationMembership.create({
     data: { organizationId: organization.id, userId: user.id, role: OrganizationRole.OWNER },
-  });
-  const organizationInvitation = await control.organizationInvitation.create({
+  }));
+  track("OrganizationInvitation", await control.organizationInvitation.create({
     data: {
       organizationId: organization.id,
       inviterId: user.id,
       email: "invitee@example.test",
-      role: OrganizationRole.MEMBER,
-      tokenHash: "organization-invitation-token",
+      tokenHash: "organization-invitation",
       expiresAt: future(),
     },
-  });
-  const project = await control.project.create({
-    data: { organizationId: organization.id, slug: "round-trip-project", name: "Round-trip project" },
-  });
-  const projectMembership = await control.projectMembership.create({
+  }));
+  const project = track("Project", await control.project.create({
+    data: { organizationId: organization.id, slug: "round-trip-project", name: "Project" },
+  }));
+  track("ProjectMembership", await control.projectMembership.create({
     data: {
       projectId: project.id,
       organizationMembershipId: organizationMembership.id,
       organizationId: organization.id,
       role: ProjectRole.ADMIN,
     },
-  });
-  const environment = await control.environment.create({
+  }));
+  const environment = track("Environment", await control.environment.create({
     data: { projectId: project.id, slug: "isolated", name: "Isolated" },
-  });
-  const environmentSession = await control.environmentSession.create({
-    data: {
-      environmentId: environment.id,
-      operatorSessionId: operatorSession.id,
-      ipAddress: "127.0.0.1",
-      userAgent: "tenancy-integration-test",
-    },
-  });
-  const endUser = await control.endUser.create({
+  }));
+  track("EnvironmentSession", await control.environmentSession.create({
+    data: { environmentId: environment.id, operatorSessionId: operatorSession.id },
+  }));
+  const endUser = track("EndUser", await control.endUser.create({
     data: { organizationId: organization.id, displayName: "End user" },
-  });
-  const endUserIdentity = await control.endUserIdentity.create({
+  }));
+  const endUserIdentity = track("EndUserIdentity", await control.endUserIdentity.create({
     data: {
       endUserId: endUser.id,
       organizationId: organization.id,
       issuer: "integration-test",
       channel: "web",
       subject: "end-user-subject",
+      profile: { locale: "en" },
       verifiedAt: new Date(),
     },
-  });
-  const endUserSession = await control.endUserSession.create({
+  }));
+  track("EndUserSession", await control.endUserSession.create({
     data: {
       identityId: endUserIdentity.id,
       environmentId: environment.id,
-      tokenHash: "end-user-session-token",
+      tokenHash: "end-user-session",
+      expiresAt: future(),
+    },
+  }));
+
+  const agent = track("Agent", await control.agent.create({
+    data: { projectId: project.id, name: "Assistant", slug: "assistant" },
+  }));
+  const cluster = track("AgentCluster", await control.agentCluster.create({
+    data: { environmentId: environment.id, name: "Primary", slug: "primary", metadata: {} },
+  }));
+  const agentVersion = track("AgentVersion", await control.agentVersion.create({
+    data: {
+      agentId: agent.id,
+      versionNumber: 1,
+      model: "test:model",
+      promptBlocks: [],
+      dynamicBlocks: [],
+      toolsBlockConfig: { mode: "direct" },
+      modelRoutes: [],
+      memoryConfig: {},
+      createdBy: user.id,
+    },
+  }));
+  track("AgentBinding", await control.agentBinding.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      activeAgentVersionId: agentVersion.id,
+      clusterId: cluster.id,
+    },
+  }));
+  const credential = track("Credential", await control.credential.create({
+    data: {
+      environmentId: environment.id,
+      kind: CredentialKind.SERVICE_CREDENTIAL,
+      name: "provider",
+      secretHash: "hash",
+      permissions: ["invoke"],
+    },
+  }));
+  track("AccessKey", await control.accessKey.create({
+    data: {
+      environmentId: environment.id,
+      keyPrefix: "pk_test",
+      keyHash: "access-key-hash",
+      allowedOrigins: ["https://example.test"],
+    },
+  }));
+  track("ProviderKey", await control.providerKey.create({
+    data: {
+      environmentId: environment.id,
+      provider: "anthropic",
+      label: "primary",
+      environmentKeyName: "ANTHROPIC_API_KEY",
+      encryptedReference: "secret://provider",
+      isDefault: true,
+      createdBy: user.id,
+    },
+  }));
+  track("McpToken", await control.mcpToken.create({
+    data: {
+      environmentId: environment.id,
+      mintedByUserId: user.id,
+      name: "runtime",
+      tokenHash: "mcp-token-hash",
+      permissions: ["invoke"],
+      tier: "service",
+    },
+  }));
+  const personalAccessToken = track("PersonalAccessToken", await control.personalAccessToken.create({
+    data: {
+      userId: user.id,
+      scopeKind: AuthorizationScopeKind.GLOBAL,
+      tokenHash: "pat-hash",
+      name: "all-scope",
+      role: "operator",
+      permissions: ["admin"],
+    },
+  }));
+  track("PostmanTemplate", await control.postmanTemplate.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      name: "Default",
+      simulateUserId: "subject",
+      sessionContext: {},
+      createdBy: user.id,
+    },
+  }));
+  const thread = track("Thread", await control.thread.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      endUserId: endUser.id,
+      clusterId: cluster.id,
+      sessionContext: {},
+    },
+  }));
+  const turn = track("Turn", await control.turn.create({
+    data: { threadId: thread.id, sequence: 1, inputText: "hello", output: { text: "hi" } },
+  }));
+  const step = track("Step", await control.step.create({
+    data: { turnId: turn.id, sequence: 1, model: "test:model", status: WorkStatus.SUCCEEDED },
+  }));
+  const tool = track("Tool", await control.tool.create({
+    data: {
+      name: "remember",
+      description: "Remember a fact",
+      kind: ToolKind.RUNTIME,
+      paramSchema: { type: "object", properties: {} },
+      schemaHash: "remember-v1",
+    },
+  }));
+  track("ToolCall", await control.toolCall.create({
+    data: {
+      stepId: step.id,
+      toolId: tool.id,
+      sequence: 1,
+      toolName: tool.name,
+      arguments: {},
+      result: { remembered: true },
+      status: WorkStatus.SUCCEEDED,
+    },
+  }));
+  track("Artifact", await control.artifact.create({
+    data: {
+      environmentId: environment.id,
+      threadId: thread.id,
+      producedByTurnId: turn.id,
+      artifactKey: "answer",
+      kind: "text",
+      content: "hi",
+      metadata: {},
+      createdBy: user.id,
+    },
+  }));
+  track("MessageAttachment", await control.messageAttachment.create({
+    data: {
+      environmentId: environment.id,
+      endUserId: endUser.id,
+      turnId: turn.id,
+      kind: "file",
+      mimeType: "text/plain",
+      bytes: 2,
+      storageKey: "attachment",
+    },
+  }));
+  const entity = track("Entity", await control.entity.create({
+    data: {
+      projectId: project.id,
+      externalId: "entity",
+      displayName: "Entity",
+      connectionStatus: "connected",
+      connectionKind: "mcp",
+    },
+  }));
+  const channelConnection = track("ChannelConnection", await control.channelConnection.create({
+    data: {
+      environmentId: environment.id,
+      entityId: entity.id,
+      provider: "slack",
+      agentRouting: [],
+      defaultAgentId: agent.id,
+      credentialId: credential.id,
+    },
+  }));
+  track("ChannelThread", await control.channelThread.create({
+    data: { connectionId: channelConnection.id, threadId: thread.id, channelThreadKey: "channel-thread" },
+  }));
+  const channelApp = track("ChannelApp", await control.channelApp.create({
+    data: {
+      environmentId: environment.id,
+      provider: "slack",
+      clientId: "client",
+      credentialId: credential.id,
+      distribution: "private",
+      defaultAgentId: agent.id,
+      agentRouting: [],
+    },
+  }));
+  const installation = track("ChannelInstallation", await control.channelInstallation.create({
+    data: {
+      appId: channelApp.id,
+      externalInstallationId: "installation",
+      credentialId: credential.id,
+      defaultAgentId: agent.id,
+      agentRouting: [],
+      status: "active",
+    },
+  }));
+  track("ChannelAppThread", await control.channelAppThread.create({
+    data: { installationId: installation.id, threadId: thread.id, channelThreadKey: "app-thread" },
+  }));
+  track("EntityMcpConfig", await control.entityMcpConfig.create({
+    data: { entityId: entity.id, identityMode: "anonymous", identityProviders: [], branding: {} },
+  }));
+  track("EntityMcpClient", await control.entityMcpClient.create({
+    data: { entityId: entity.id, transport: "http", credentialId: credential.id, headersTemplate: {} },
+  }));
+  track("EnvironmentEntityTool", await control.environmentEntityTool.create({
+    data: { environmentId: environment.id, entityId: entity.id, toolId: tool.id },
+  }));
+  track("ToolHealth", await control.toolHealth.create({
+    data: { environmentId: environment.id, toolId: tool.id, entityExternalId: entity.externalId },
+  }));
+  track("ToolCallAudit", await control.toolCallAudit.create({
+    data: {
+      environmentId: environment.id,
+      toolId: tool.id,
+      endUserId: endUser.id,
+      agentId: agent.id,
+      threadId: thread.id,
+      toolName: tool.name,
+      arguments: {},
+      result: {},
+      status: WorkStatus.SUCCEEDED,
+      latencyMs: 1,
+    },
+  }));
+  track("AdminAudit", await control.adminAudit.create({
+    data: { environmentId: environment.id, action: "create", subjectType: "Agent", after: {} },
+  }));
+  track("AgentApproval", await control.agentApproval.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      threadId: thread.id,
+      turnId: turn.id,
+      action: "send",
+      status: ApprovalStatus.APPROVED,
+      arguments: {},
+      resolution: {},
+    },
+  }));
+  track("EnvironmentProvider", await control.environmentProvider.create({
+    data: { environmentId: environment.id, providerId: "anthropic" },
+  }));
+  track("Budget", await control.budget.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      scope: "agent",
+      period: "month",
+      limitCents: 1000,
+      alertThresholds: [80],
+    },
+  }));
+  track("SafetyEvent", await control.safetyEvent.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      threadId: thread.id,
+      turnId: turn.id,
+      endUserId: endUser.id,
+      detector: "pii",
+      action: "allow",
+      severity: "low",
+      metadata: {},
+    },
+  }));
+  track("MessageRating", await control.messageRating.create({
+    data: {
+      environmentId: environment.id,
+      turnId: turn.id,
+      agentId: agent.id,
+      agentVersionId: agentVersion.id,
+      endUserId: endUser.id,
+      rating: 5,
+    },
+  }));
+  const criterion = track("EvalCriterion", await control.evalCriterion.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      name: "Helpful",
+      judgePrompt: "Judge helpfulness",
+      createdBy: user.id,
+    },
+  }));
+  track("AgentEval", await control.agentEval.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      agentVersionId: agentVersion.id,
+      threadId: thread.id,
+      turnId: turn.id,
+      criterionId: criterion.id,
+      criterionSnapshot: { name: "Helpful" },
+      judgeModel: "test:judge",
+      judgePromptUsed: "Judge helpfulness",
+      score: 1,
+      passed: true,
+    },
+  }));
+  track("GoldenSet", await control.goldenSet.create({
+    data: {
+      environmentId: environment.id,
+      agentId: agent.id,
+      name: "Golden",
+      threadIds: [thread.id],
+      criterionIds: [criterion.id],
+      createdBy: user.id,
+    },
+  }));
+  track("Job", await control.job.create({
+    data: {
+      environmentId: environment.id,
+      externalId: "job",
+      displayName: "Background work",
+      triggerType: "manual",
+      payloadSchema: { type: "object" },
+      handler: "background",
+      createdBy: user.id,
+    },
+  }));
+  const skill = track("Skill", await control.skill.create({
+    data: {
+      organizationId: organization.id,
+      slug: "research",
+      name: "Research",
+      description: "Research skill",
+      version: "1.0.0",
+      origin: "local",
+      source: "instructions",
+      manifest: {},
+      promptBlock: "Research",
+      providesTools: [],
+    },
+  }));
+  const projectSkill = track("ProjectSkill", await control.projectSkill.create({
+    data: { projectId: project.id, skillId: skill.id },
+  }));
+  const environmentSkill = track("EnvironmentSkill", await control.environmentSkill.create({
+    data: { environmentId: environment.id, projectSkillId: projectSkill.id, config: {} },
+  }));
+  track("AgentSkill", await control.agentSkill.create({
+    data: { agentVersionId: agentVersion.id, environmentSkillId: environmentSkill.id, config: {} },
+  }));
+  track("AgentToolPolicy", await control.agentToolPolicy.create({
+    data: { agentVersionId: agentVersion.id, toolId: tool.id, effect: PolicyEffect.ALLOW },
+  }));
+  track("Memory", await control.memory.create({
+    data: {
+      environmentId: environment.id,
+      endUserId: endUser.id,
+      agentId: agent.id,
+      kind: "fact",
+      content: "Likes tests",
+      metadata: {},
+      visibility: "subject",
+      source: "turn",
+      sourceTurnIds: [turn.id],
+    },
+  }));
+  const memoryEntityA = track("MemoryEntity", await control.memoryEntity.create({
+    data: {
+      environmentId: environment.id,
+      endUserId: endUser.id,
+      entityKey: "person",
+      entityType: "person",
+      label: "Person",
+      metadata: {},
+    },
+  }));
+  const memoryEntityB = await control.memoryEntity.create({
+    data: {
+      environmentId: environment.id,
+      endUserId: endUser.id,
+      entityKey: "place",
+      entityType: "place",
+      label: "Place",
+    },
+  });
+  track("MemoryRelationship", await control.memoryRelationship.create({
+    data: {
+      environmentId: environment.id,
+      endUserId: endUser.id,
+      fromEntityId: memoryEntityA.id,
+      toEntityId: memoryEntityB.id,
+      relationshipType: "visited",
+      metadata: {},
+    },
+  }));
+  track("OrganizationMcpPolicy", await control.organizationMcpPolicy.create({
+    data: { organizationId: organization.id, pattern: "*", effect: PolicyEffect.ALLOW },
+  }));
+  track("Macro", await control.macro.create({
+    data: { environmentId: environment.id, name: "Summarize", steps: [], paramSchema: {}, createdBy: user.id },
+  }));
+  track("Event", await control.event.create({
+    data: { environmentId: environment.id, eventType: "turn.completed", payload: {} },
+  }));
+  track("NotificationRule", await control.notificationRule.create({
+    data: { environmentId: environment.id, name: "Failures", filters: {}, delivery: {}, createdBy: user.id },
+  }));
+  const oauthClient = track("OAuthClient", await control.oAuthClient.create({
+    data: {
+      organizationId: organization.id,
+      clientId: "oauth-client",
+      clientName: "OAuth client",
+      redirectUris: ["https://example.test/callback"],
+      tokenEndpointAuthMethod: "none",
+      grantTypes: ["authorization_code"],
+      scopes: ["invoke"],
+      registeredByUserId: user.id,
+      entityId: entity.id,
+    },
+  }));
+  const oauthAccessToken = track("OAuthAccessToken", await control.oAuthAccessToken.create({
+    data: {
+      tokenHash: "oauth-access-hash",
+      clientId: oauthClient.id,
+      userId: user.id,
+      scopeKind: AuthorizationScopeKind.ENVIRONMENT,
+      environmentId: environment.id,
+      scopes: ["invoke"],
+      expiresAt: future(),
+    },
+  }));
+  const refreshFamily = "10000000-0000-4000-8000-000000000001";
+  const oauthRefreshToken = track("OAuthRefreshToken", await control.oAuthRefreshToken.create({
+    data: {
+      tokenHash: "oauth-refresh-hash",
+      accessTokenId: oauthAccessToken.id,
+      clientId: oauthClient.id,
+      userId: user.id,
+      scopeKind: AuthorizationScopeKind.ENVIRONMENT,
+      environmentId: environment.id,
+      scopes: ["invoke"],
+      rotationFamilyId: refreshFamily,
+      expiresAt: future(),
+    },
+  }));
+  const rotatedRefreshToken = await control.oAuthRefreshToken.create({
+    data: {
+      tokenHash: "oauth-refresh-rotated-hash",
+      accessTokenId: oauthAccessToken.id,
+      clientId: oauthClient.id,
+      userId: user.id,
+      scopeKind: AuthorizationScopeKind.ENVIRONMENT,
+      environmentId: environment.id,
+      scopes: ["invoke"],
+      rotationFamilyId: refreshFamily,
+      parentRefreshTokenId: oauthRefreshToken.id,
       expiresAt: future(),
     },
   });
+  const mcpBearerToken = track("McpBearerToken", await control.mcpBearerToken.create({
+    data: {
+      entityId: entity.id,
+      createdByUserId: user.id,
+      tokenHash: "mcp-bearer-hash",
+      label: "entity bearer",
+      mcpUserId: "entity-user",
+      scopes: ["tools:call"],
+    },
+  }));
+  track("OAuthAuthorizationCode", await control.oAuthAuthorizationCode.create({
+    data: {
+      scopeKind: AuthorizationScopeKind.ENVIRONMENT,
+      environmentId: environment.id,
+      clientId: oauthClient.id,
+      userId: user.id,
+      codeHash: "oauth-code",
+      codeChallenge: "challenge",
+      codeChallengeMethod: "S256",
+      redirectUri: "https://example.test/callback",
+      scopes: ["invoke"],
+      expiresAt: future(),
+    },
+  }));
+  track("McpAnonymousSession", await control.mcpAnonymousSession.create({
+    data: { environmentId: environment.id, entityId: entity.id, mcpUserId: "anonymous" },
+  }));
+  track("McpOidcSession", await control.mcpOidcSession.create({
+    data: {
+      environmentId: environment.id,
+      entityId: entity.id,
+      mcpUserId: "oidc",
+      provider: "example",
+      externalSubject: "subject",
+      credentialId: credential.id,
+    },
+  }));
+  track("EntityToolPolicy", await control.entityToolPolicy.create({
+    data: {
+      entityId: entity.id,
+      toolId: tool.id,
+      effect: PolicyEffect.ALLOW,
+      minIdentityMode: "anonymous",
+      addedBy: user.id,
+    },
+  }));
+  track("ErasureOperation", await control.erasureOperation.create({
+    data: {
+      organizationId: organization.id,
+      idempotencyKey: "erasure",
+      subjectKeyHash: "subject-hash",
+      scopes: [],
+      stores: [],
+      inventory: {},
+      policyVersion: "1",
+    },
+  }));
 
   return {
+    registry,
     user,
-    operatorSession,
     organization,
-    organizationMembership,
-    organizationInvitation,
     project,
-    projectMembership,
     environment,
-    environmentSession,
     endUser,
     endUserIdentity,
-    endUserSession,
+    agent,
+    agentVersion,
+    thread,
+    installation,
+    oauthClient,
+    memoryEntityA,
+    personalAccessToken,
+    oauthAccessToken,
+    oauthRefreshToken,
+    rotatedRefreshToken,
+    mcpBearerToken,
   };
 }

--- a/internal-packages/tenancy-database/src/json.test.ts
+++ b/internal-packages/tenancy-database/src/json.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import {
+  JsonShapeError,
+  normalizeAgentVersionJson,
+  normalizeDynamicBlocks,
+  normalizeJsonField,
+  normalizeModelRoutes,
+  normalizePromptBlocks,
+  normalizeToolsBlockConfig,
+} from "./json";
+
+const promptBlocks = [
+  {
+    id: "system",
+    type: "system",
+    name: "System",
+    content: "Be helpful",
+    enabled: true,
+    editable: true,
+    order: 0,
+  },
+];
+const dynamicBlocks = [
+  { key: "account", name: "Account", defaultContent: "Unknown", order: 0 },
+];
+const modelRoutes = [
+  { label: "default", model: "anthropic:claude", isDefault: true },
+  { label: "fast", model: "openai:gpt", providerCredentialId: "credential", isDefault: false },
+];
+
+describe("Json write boundaries", () => {
+  test("persists native expected roots for a complete agent version", () => {
+    const value = normalizeAgentVersionJson({
+      promptBlocks,
+      dynamicBlocks,
+      modelRoutes,
+      toolsBlockConfig: { mode: "direct", pinnedTools: ["remember"] },
+      memoryConfig: { maxItems: 50 },
+      outputSchema: { type: "object", properties: {} },
+    });
+
+    expect(Array.isArray(value.promptBlocks)).toBe(true);
+    expect(Array.isArray(value.dynamicBlocks)).toBe(true);
+    expect(Array.isArray(value.modelRoutes)).toBe(true);
+    expect(typeof value.toolsBlockConfig).toBe("object");
+    expect(value.modelRoutes.map((route) => route.label)).toEqual(["default", "fast"]);
+  });
+
+  test("parses exactly one explicitly supported legacy encoded layer", () => {
+    expect(normalizePromptBlocks(JSON.stringify(promptBlocks))).toEqual(promptBlocks);
+    expect(normalizeDynamicBlocks(JSON.stringify(dynamicBlocks))).toEqual(dynamicBlocks);
+    expect(normalizeModelRoutes(JSON.stringify(modelRoutes))).toEqual(modelRoutes);
+    expect(normalizeToolsBlockConfig(JSON.stringify({ mode: "sub-agent" }))).toEqual({
+      mode: "sub-agent",
+    });
+  });
+
+  test("rejects double encoding, malformed strings, and wrong roots", () => {
+    for (const [normalizer, value] of [
+      [normalizePromptBlocks, promptBlocks],
+      [normalizeDynamicBlocks, dynamicBlocks],
+      [normalizeModelRoutes, modelRoutes],
+      [normalizeToolsBlockConfig, { mode: "direct" }],
+    ] as const) {
+      expect(() => normalizer(JSON.stringify(JSON.stringify(value)))).toThrow(JsonShapeError);
+      expect(() => normalizer("{broken")).toThrow(JsonShapeError);
+    }
+
+    expect(() => normalizePromptBlocks({ blocks: promptBlocks })).toThrow(/expected array root/);
+    expect(() => normalizeToolsBlockConfig([])).toThrow(/expected object root/);
+    expect(() => normalizeJsonField("Event.payload", "{}"))
+      .toThrow(/expected object root/);
+  });
+
+  test("never lets an encoded array reach map as a string", () => {
+    const routes = normalizeModelRoutes(JSON.stringify(modelRoutes));
+    expect(Array.isArray(routes)).toBe(true);
+    expect(() => routes.map((route) => route.model)).not.toThrow();
+    expect(routes.map((route) => route.model)).toEqual(["anthropic:claude", "openai:gpt"]);
+  });
+
+  test("replaces ambiguous enabledTools with AgentToolPolicy relations", () => {
+    expect(() => normalizeToolsBlockConfig({ enabledTools: ["send_email"] })).toThrow(
+      /AgentToolPolicy/
+    );
+    expect(normalizeToolsBlockConfig({ toolExposure: "meta", enabledCategories: ["email"] }))
+      .toEqual({ toolExposure: "meta", enabledCategories: ["email"] });
+  });
+
+  test("validates typed entries rather than only their root", () => {
+    expect(() => normalizeModelRoutes([{ label: "bad", model: "x", isDefault: false }]))
+      .toThrow(/exactly one/);
+    expect(() => normalizeModelRoutes([
+      { label: "same", model: "x", isDefault: true },
+      { label: "same", model: "y", isDefault: false },
+    ])).toThrow(/duplicate route label/);
+    expect(() => normalizePromptBlocks([{ id: "missing-fields" }])).toThrow(/type/);
+    expect(() => normalizeDynamicBlocks([{ key: "x", name: "X", defaultContent: 1 }]))
+      .toThrow(/defaultContent/);
+  });
+});

--- a/internal-packages/tenancy-database/src/json.ts
+++ b/internal-packages/tenancy-database/src/json.ts
@@ -1,0 +1,311 @@
+import type { Prisma } from "../generated/control";
+
+export type JsonRoot = "object" | "array" | "objectOrArray";
+
+export interface JsonShapeDefinition {
+  readonly root: JsonRoot;
+  readonly legacyEncodedLayer: boolean;
+  readonly description: string;
+}
+
+const object = (description: string, legacyEncodedLayer = false): JsonShapeDefinition => ({
+  root: "object",
+  legacyEncodedLayer,
+  description,
+});
+const array = (description: string, legacyEncodedLayer = false): JsonShapeDefinition => ({
+  root: "array",
+  legacyEncodedLayer,
+  description,
+});
+const objectOrArray = (description: string): JsonShapeDefinition => ({
+  root: "objectOrArray",
+  legacyEncodedLayer: false,
+  description,
+});
+
+/**
+ * Complete write-boundary contract for every Json field in schema.prisma.
+ * Optional columns are omitted with `undefined`; JSON null is not a substitute
+ * for an absent value. Only the four explicitly marked legacy fields may parse
+ * one encoded JSON layer.
+ */
+export const jsonShapeRegistry = {
+  "EndUserIdentity.profile": object("Verified identity profile attributes."),
+  "AgentCluster.metadata": object("Non-secret cluster labels."),
+  "AgentVersion.promptBlocks": array("PromptBlock objects.", true),
+  "AgentVersion.dynamicBlocks": array("DynamicBlock objects.", true),
+  "AgentVersion.toolsBlockConfig": object("Typed tool rendering and invocation settings.", true),
+  "AgentVersion.modelRoutes": array("ModelRoute objects.", true),
+  "AgentVersion.memoryConfig": object("Memory limits and visibility defaults."),
+  "AgentVersion.outputSchema": object("JSON Schema for structured model output."),
+  "PostmanTemplate.sessionContext": object("Request and session variables."),
+  "Thread.sessionContext": object("Verified channel context."),
+  "Turn.input": object("Structured accepted turn input."),
+  "Turn.output": object("Structured final turn output."),
+  "ToolCall.arguments": object("Validated tool arguments."),
+  "ToolCall.result": objectOrArray("Structured tool result."),
+  "Artifact.metadata": object("Non-secret artifact attributes."),
+  "ChannelConnection.agentRouting": array("Typed channel routing rules."),
+  "ChannelApp.agentRouting": array("Typed channel routing rules."),
+  "ChannelInstallation.agentRouting": array("Typed channel routing rules."),
+  "EntityMcpConfig.identityProviders": array("Identity provider descriptors."),
+  "EntityMcpConfig.branding": object("Public branding values."),
+  "EntityMcpClient.headersTemplate": object("Non-secret outbound header templates."),
+  "Tool.paramSchema": object("JSON Schema for tool parameters."),
+  "ToolCallAudit.arguments": object("Redacted tool arguments."),
+  "ToolCallAudit.result": objectOrArray("Redacted structured tool result."),
+  "AdminAudit.before": object("Redacted previous state."),
+  "AdminAudit.after": object("Redacted resulting state."),
+  "AgentApproval.arguments": object("Proposed tool or action arguments."),
+  "AgentApproval.resolution": object("Approval resolution details."),
+  "Budget.alertThresholds": array("Integer percentage thresholds."),
+  "SafetyEvent.metadata": object("Redacted detector attributes."),
+  "AgentEval.criterionSnapshot": object("Immutable criterion snapshot."),
+  "Job.payloadSchema": object("JSON Schema for job input."),
+  "Skill.manifest": object("Typed skill manifest."),
+  "Skill.providesTools": array("Tool descriptors supplied by the skill."),
+  "EnvironmentSkill.config": object("Environment-specific skill configuration."),
+  "AgentSkill.config": object("Agent-version skill configuration."),
+  "Memory.metadata": object("Memory extraction and source attributes."),
+  "MemoryEntity.metadata": object("Extracted entity attributes."),
+  "MemoryRelationship.metadata": object("Extracted relationship attributes."),
+  "Macro.steps": array("Typed macro step objects."),
+  "Macro.paramSchema": object("JSON Schema for macro parameters."),
+  "Event.payload": object("Versioned event body."),
+  "NotificationRule.filters": object("Typed event predicates."),
+  "NotificationRule.delivery": object("Typed non-secret destination configuration."),
+  "ErasureOperation.scopes": array("Normalized subject scope descriptors."),
+  "ErasureOperation.stores": array("Storage-system erasure outcomes."),
+  "ErasureOperation.inventory": object("Non-identifying row inventory."),
+} as const satisfies Record<string, JsonShapeDefinition>;
+
+export type JsonField = keyof typeof jsonShapeRegistry;
+export type JsonObject = { readonly [key: string]: JsonValue };
+export type JsonArray = readonly JsonValue[];
+export type JsonValue = string | number | boolean | null | JsonObject | JsonArray;
+
+export class JsonShapeError extends TypeError {
+  constructor(field: JsonField, message: string) {
+    super(`${field}: ${message}`);
+    this.name = "JsonShapeError";
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function assertJsonValue(
+  field: JsonField,
+  value: unknown,
+  path: string = field
+): asserts value is JsonValue {
+  if (value === null) {
+    if (path === field) throw new JsonShapeError(field, "root cannot be null");
+    return;
+  }
+  if (value === undefined) {
+    throw new JsonShapeError(field, `${path} cannot contain undefined`);
+  }
+  if (["string", "number", "boolean"].includes(typeof value)) return;
+  if (Array.isArray(value)) {
+    value.forEach((entry, index) => assertJsonValue(field, entry, `${path}[${index}]`));
+    return;
+  }
+  if (isObject(value)) {
+    for (const [key, entry] of Object.entries(value)) {
+      assertJsonValue(field, entry, `${path}.${key}`);
+    }
+    return;
+  }
+  throw new JsonShapeError(field, `${path} is not a JSON value`);
+}
+
+/** Normalizes and validates a value before it reaches any Prisma Json write. */
+export function normalizeJsonField(field: JsonField, input: unknown): Prisma.InputJsonValue {
+  const definition = jsonShapeRegistry[field];
+  let value = input;
+
+  if (typeof value === "string" && definition.legacyEncodedLayer) {
+    try {
+      value = JSON.parse(value) as unknown;
+    } catch {
+      throw new JsonShapeError(field, "legacy encoded value is malformed JSON");
+    }
+  }
+
+  const validRoot =
+    definition.root === "array"
+      ? Array.isArray(value)
+      : definition.root === "object"
+        ? isObject(value)
+        : Array.isArray(value) || isObject(value);
+  if (!validRoot) {
+    throw new JsonShapeError(field, `expected ${definition.root} root`);
+  }
+
+  // If one parse produced another string, the root check above rejects it. A
+  // second parse is deliberately never attempted, preventing double encoding.
+  assertJsonValue(field, value);
+  return value as Prisma.InputJsonValue;
+}
+
+export interface PromptBlock {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+  enabled: boolean;
+  editable: boolean;
+  order: number;
+}
+
+export interface DynamicBlock {
+  key: string;
+  name: string;
+  defaultContent: string;
+  description?: string;
+  order?: number;
+}
+
+export interface ModelRoute {
+  label: string;
+  model: string;
+  providerCredentialId?: string;
+  isDefault: boolean;
+}
+
+export interface ToolsBlockConfig {
+  mode?: "direct" | "sub-agent" | "execute-tool";
+  toolExposure?: "direct" | "meta";
+  displayMode?: "full" | "summary" | "meta-tool" | "hybrid";
+  pinnedTools?: string[];
+  enabledCategories?: string[];
+  entityIdsRequired?: boolean;
+}
+
+function requireObjectEntries(field: JsonField, value: Prisma.InputJsonValue): Record<string, unknown>[] {
+  return (value as unknown[]).map((entry, index) => {
+    if (!isObject(entry)) throw new JsonShapeError(field, `entry ${index} must be an object`);
+    return entry;
+  });
+}
+
+function requireString(field: JsonField, entry: Record<string, unknown>, key: string, index: number) {
+  if (typeof entry[key] !== "string" || entry[key] === "") {
+    throw new JsonShapeError(field, `entry ${index}.${key} must be a non-empty string`);
+  }
+}
+
+export function normalizePromptBlocks(input: unknown): PromptBlock[] {
+  const field = "AgentVersion.promptBlocks" as const;
+  return requireObjectEntries(field, normalizeJsonField(field, input)).map((entry, index) => {
+    for (const key of ["id", "type", "name", "content"]) requireString(field, entry, key, index);
+    if (typeof entry.enabled !== "boolean" || typeof entry.editable !== "boolean") {
+      throw new JsonShapeError(field, `entry ${index} enabled/editable must be booleans`);
+    }
+    if (!Number.isInteger(entry.order)) {
+      throw new JsonShapeError(field, `entry ${index}.order must be an integer`);
+    }
+    return entry as unknown as PromptBlock;
+  });
+}
+
+export function normalizeDynamicBlocks(input: unknown): DynamicBlock[] {
+  const field = "AgentVersion.dynamicBlocks" as const;
+  return requireObjectEntries(field, normalizeJsonField(field, input)).map((entry, index) => {
+    for (const key of ["key", "name", "defaultContent"]) requireString(field, entry, key, index);
+    if (entry.description !== undefined && typeof entry.description !== "string") {
+      throw new JsonShapeError(field, `entry ${index}.description must be a string`);
+    }
+    if (entry.order !== undefined && !Number.isInteger(entry.order)) {
+      throw new JsonShapeError(field, `entry ${index}.order must be an integer`);
+    }
+    return entry as unknown as DynamicBlock;
+  });
+}
+
+export function normalizeModelRoutes(input: unknown): ModelRoute[] {
+  const field = "AgentVersion.modelRoutes" as const;
+  const labels = new Set<string>();
+  let defaults = 0;
+  const routes = requireObjectEntries(field, normalizeJsonField(field, input)).map((entry, index) => {
+    requireString(field, entry, "label", index);
+    requireString(field, entry, "model", index);
+    if (entry.providerCredentialId !== undefined && typeof entry.providerCredentialId !== "string") {
+      throw new JsonShapeError(field, `entry ${index}.providerCredentialId must be a string`);
+    }
+    if (typeof entry.isDefault !== "boolean") {
+      throw new JsonShapeError(field, `entry ${index}.isDefault must be a boolean`);
+    }
+    if (labels.has(entry.label as string)) {
+      throw new JsonShapeError(field, `duplicate route label ${entry.label as string}`);
+    }
+    labels.add(entry.label as string);
+    if (entry.isDefault) defaults += 1;
+    return entry as unknown as ModelRoute;
+  });
+  if (routes.length > 0 && defaults !== 1) {
+    throw new JsonShapeError(field, "exactly one non-empty route must be the default");
+  }
+  return routes;
+}
+
+function optionalStringArray(field: JsonField, config: Record<string, unknown>, key: string) {
+  const value = config[key];
+  if (value !== undefined && (!Array.isArray(value) || value.some((entry) => typeof entry !== "string"))) {
+    throw new JsonShapeError(field, `${key} must be an array of strings`);
+  }
+}
+
+export function normalizeToolsBlockConfig(input: unknown): ToolsBlockConfig {
+  const field = "AgentVersion.toolsBlockConfig" as const;
+  const config = normalizeJsonField(field, input) as Record<string, unknown>;
+  if ("enabledTools" in config) {
+    throw new JsonShapeError(
+      field,
+      "enabledTools is retired; write explicit AgentToolPolicy relations instead"
+    );
+  }
+  const enums = {
+    mode: ["direct", "sub-agent", "execute-tool"],
+    toolExposure: ["direct", "meta"],
+    displayMode: ["full", "summary", "meta-tool", "hybrid"],
+  } as const;
+  for (const [key, allowed] of Object.entries(enums)) {
+    const value = config[key];
+    if (value !== undefined && !allowed.includes(value as never)) {
+      throw new JsonShapeError(field, `${key} has an unsupported value`);
+    }
+  }
+  optionalStringArray(field, config, "pinnedTools");
+  optionalStringArray(field, config, "enabledCategories");
+  if (config.entityIdsRequired !== undefined && typeof config.entityIdsRequired !== "boolean") {
+    throw new JsonShapeError(field, "entityIdsRequired must be a boolean");
+  }
+  return config as ToolsBlockConfig;
+}
+
+/** Builds the only accepted Json payload for an AgentVersion create/update. */
+export function normalizeAgentVersionJson(input: {
+  promptBlocks: unknown;
+  dynamicBlocks: unknown;
+  toolsBlockConfig: unknown;
+  modelRoutes: unknown;
+  memoryConfig?: unknown;
+  outputSchema?: unknown;
+}) {
+  return {
+    promptBlocks: normalizePromptBlocks(input.promptBlocks),
+    dynamicBlocks: normalizeDynamicBlocks(input.dynamicBlocks),
+    toolsBlockConfig: normalizeToolsBlockConfig(input.toolsBlockConfig),
+    modelRoutes: normalizeModelRoutes(input.modelRoutes),
+    ...(input.memoryConfig === undefined
+      ? {}
+      : { memoryConfig: normalizeJsonField("AgentVersion.memoryConfig", input.memoryConfig) }),
+    ...(input.outputSchema === undefined
+      ? {}
+      : { outputSchema: normalizeJsonField("AgentVersion.outputSchema", input.outputSchema) }),
+  };
+}

--- a/internal-packages/tenancy-database/src/schema.test.ts
+++ b/internal-packages/tenancy-database/src/schema.test.ts
@@ -1,93 +1,221 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { Prisma as ControlPrisma } from "../generated/control";
 import { Prisma as EndUserPrisma } from "../generated/end-user";
 import { describe, expect, test } from "vitest";
+import { endUserDelegateNames } from "./end-user";
+import { jsonShapeRegistry } from "./json";
+import {
+  domainModelNames,
+  legacyTenancyRelationManifest,
+  legacyTenancyRelationCounts,
+  sourceModelManifest,
+} from "./source-model-manifest";
 
 const packageRoot = resolve(__dirname, "..");
-const schema = readFileSync(resolve(packageRoot, "prisma/schema.prisma"), "utf8");
+const schemaPath = resolve(packageRoot, "prisma/schema.prisma");
+const schema = readFileSync(schemaPath, "utf8");
+const sourceSchema = readFileSync(resolve(packageRoot, "../database/prisma/schema.prisma"), "utf8");
 const migration = readFileSync(
   resolve(packageRoot, "prisma/migrations/00000000000000_initial/migration.sql"),
   "utf8"
 );
+const customMigrationMarker = "-- Prisma-inexpressible value constraints.";
 
-const forbiddenNouns = [
-  "run",
-  "task",
-  "deployment",
-  "waitpoint",
-  "queue",
-  "attempt",
-  "worker",
+const tenancyOnlyModels = [
+  "User",
+  "OperatorSession",
+  "Organization",
+  "OrganizationMembership",
+  "OrganizationInvitation",
+  "Project",
+  "ProjectMembership",
+  "Environment",
+  "EnvironmentSession",
+  "EndUserSession",
+] as const;
+
+const expectedEndUserModels = [
+  "AgentApproval",
+  "Artifact",
+  "EndUser",
+  "EndUserIdentity",
+  "EndUserSession",
+  "Memory",
+  "MemoryEntity",
+  "MemoryRelationship",
+  "MessageAttachment",
+  "MessageRating",
+  "Step",
+  "Thread",
+  "ToolCall",
+  "Turn",
 ];
 
-describe("clean-slate tenancy schema", () => {
-  test("contains none of the external runtime nouns in persisted identifiers", () => {
-    const identifiers = [
-      ...ControlPrisma.dmmf.datamodel.models.flatMap((model) => [
-        model.name,
-        ...model.fields.map((field) => field.name),
-      ]),
-      ...ControlPrisma.dmmf.datamodel.enums.flatMap((entry) => [
-        entry.name,
-        ...entry.values.map((value) => value.name),
-      ]),
-    ];
-
-    for (const identifier of identifiers) {
-      for (const noun of forbiddenNouns) {
-        expect(identifier.toLowerCase()).not.toContain(noun);
-      }
-    }
+describe("clean-slate domain schema", () => {
+  test("uses the approved normalized target and no persisted Platos prefixes", () => {
+    const models = ControlPrisma.dmmf.datamodel.models.map((model) => model.name);
+    expect(models).toHaveLength(71);
+    expect(domainModelNames).toHaveLength(61);
+    expect(new Set(domainModelNames).size).toBe(61);
+    expect(new Set([...domainModelNames, ...tenancyOnlyModels])).toEqual(new Set(models));
+    expect(models.some((name) => name.startsWith("Platos"))).toBe(false);
+    expect(schema).not.toContain("@@map(");
+    expect(schema).not.toContain("@map(");
   });
 
   test("states an onDelete policy for every Prisma-owned foreign key", () => {
     const owningRelations = schema
       .split("\n")
       .filter((line) => line.includes("@relation(") && line.includes("fields:"));
-
-    expect(owningRelations.length).toBeGreaterThan(0);
-    for (const relation of owningRelations) {
-      expect(relation).toContain("onDelete:");
-    }
+    for (const relation of owningRelations) expect(relation).toContain("onDelete:");
 
     const sqlForeignKeys = migration.match(/ FOREIGN KEY /g) ?? [];
     const sqlDeletePolicies = migration.match(/ ON DELETE (CASCADE|SET NULL|RESTRICT|NO ACTION)/g) ?? [];
-    expect(sqlDeletePolicies).toHaveLength(sqlForeignKeys.length);
     expect(sqlForeignKeys).toHaveLength(owningRelations.length);
+    expect(sqlDeletePolicies).toHaveLength(sqlForeignKeys.length);
   });
 
-  test("keeps persisted names canonical and has one initial migration", () => {
-    expect(schema).not.toContain("@@map(");
-    expect(schema).not.toContain("@map(");
+  test("accounts for all 54 source models exactly once", () => {
+    const sourceModels = [...sourceSchema.matchAll(/^model (Platos\w+) \{/gm)].map((match) => match[1]);
+    const manifestSources = sourceModelManifest.map((entry) => entry.source);
+    const controlModels = new Set(ControlPrisma.dmmf.datamodel.models.map((model) => model.name));
 
+    expect(sourceModels).toHaveLength(54);
+    expect(manifestSources).toHaveLength(54);
+    expect(new Set(manifestSources).size).toBe(54);
+    expect([...manifestSources].sort()).toEqual([...sourceModels].sort());
+    for (const entry of sourceModelManifest) {
+      expect(entry.targets.length).toBeGreaterThan(0);
+      for (const target of entry.targets) expect(controlModels.has(target)).toBe(true);
+    }
+    expect(new Set(sourceModelManifest.flatMap((entry) => entry.targets)).size).toBe(59);
+    expect(legacyTenancyRelationCounts).toEqual({
+      RuntimeEnvironment: 30,
+      Organization: 6,
+      Project: 6,
+      total: 42,
+    });
+    expect(legacyTenancyRelationManifest).toHaveLength(42);
+    expect(new Set(legacyTenancyRelationManifest.map((entry) => entry.source)).size).toBe(42);
+    for (const relation of legacyTenancyRelationManifest) {
+      const [sourceModel, sourceField] = relation.source.split(".");
+      const sourceBlock = sourceSchema.match(
+        new RegExp(`model ${sourceModel} \\{([\\s\\S]*?)\\n\\}`)
+      )?.[1];
+      expect(sourceBlock, relation.source).toMatch(new RegExp(`^\\s*${sourceField}\\s`, "m"));
+      expect(controlModels.has(relation.targetPath.split(".")[0]), relation.targetPath).toBe(true);
+    }
+  });
+
+  test("preserves typed credential, principal, scope, rotation, and entity bearer capabilities", () => {
+    const model = (name: string) => {
+      const entry = ControlPrisma.dmmf.datamodel.models.find((candidate) => candidate.name === name);
+      expect(entry, name).toBeDefined();
+      return entry!;
+    };
+    const fields = (name: string) => new Set(model(name).fields.map((field) => field.name));
+
+    for (const [name, expected] of Object.entries({
+      AccessKey: ["environmentId", "keyPrefix", "keyHash", "allowedOrigins"],
+      ProviderKey: ["environmentId", "provider", "environmentKeyName", "isDefault"],
+      McpToken: ["environmentId", "mintedByUserId", "permissions", "tier"],
+      PersonalAccessToken: ["userId", "scopeKind", "organizationId", "projectId", "environmentId"],
+      OAuthAuthorizationCode: ["clientId", "userId", "scopeKind", "organizationId", "projectId", "environmentId"],
+      OAuthAccessToken: ["clientId", "userId", "scopeKind", "scopes"],
+      OAuthRefreshToken: ["accessTokenId", "rotationFamilyId", "parentRefreshTokenId", "consumedAt", "replayDetectedAt"],
+      McpBearerToken: ["entityId", "mcpUserId", "createdByUserId", "scopes"],
+    })) {
+      const actual = fields(name);
+      for (const field of expected) expect(actual.has(field), `${name}.${field}`).toBe(true);
+    }
+
+    expect(sourceModelManifest.find((entry) => entry.source === "PlatosPAT")?.targets)
+      .toEqual(["PersonalAccessToken"]);
+    expect(sourceModelManifest.find((entry) => entry.source === "PlatosOAuthRefreshToken")?.targets)
+      .toEqual(["OAuthRefreshToken"]);
+    expect(sourceModelManifest.find((entry) => entry.source === "PlatosMcpBearerToken")?.targets)
+      .toEqual(["McpBearerToken"]);
+    expect(migration).toContain('CONSTRAINT "PersonalAccessToken_scope_shape_check"');
+    expect(migration).toContain('CONSTRAINT "OAuthRefreshToken_scope_shape_check"');
+  });
+
+  test("documents and registers every retained Json field", () => {
+    const jsonFields = ControlPrisma.dmmf.datamodel.models.flatMap((model) =>
+      model.fields
+        .filter((field) => field.type === "Json")
+        .map((field) => `${model.name}.${field.name}`)
+    );
+    expect(Object.keys(jsonShapeRegistry).sort()).toEqual(jsonFields.sort());
+
+    for (const field of jsonFields) {
+      const [modelName, fieldName] = field.split(".");
+      const model = ControlPrisma.dmmf.datamodel.models.find((entry) => entry.name === modelName);
+      const dmmfField = model?.fields.find((entry) => entry.name === fieldName);
+      expect(dmmfField?.documentation, field).toContain("root");
+      expect(migration, field).toContain(`\"${modelName}_${fieldName}_json_root\"`);
+    }
+  });
+
+  test("generates one migration from empty before custom checks and triggers", () => {
     const migrationDirectories = readdirSync(resolve(packageRoot, "prisma/migrations"), {
       withFileTypes: true,
     }).filter((entry) => entry.isDirectory());
     expect(migrationDirectories.map((entry) => entry.name)).toEqual(["00000000000000_initial"]);
+
+    const generated = execFileSync(resolve(packageRoot, "node_modules/.bin/prisma"), [
+      "migrate",
+      "diff",
+      "--from-empty",
+      "--to-schema-datamodel",
+      schemaPath,
+      "--script",
+    ], {
+      cwd: packageRoot,
+      env: { ...process.env, DATABASE_URL: "postgresql://generate:generate@localhost:5432/generate" },
+      encoding: "utf8",
+    });
+    expect(migration.split(customMigrationMarker)[0].trim()).toBe(generated.trim());
+    expect(migration).toContain('CREATE FUNCTION "public"."enforce_domain_ancestry"()');
+    expect(migration).toContain('CREATE FUNCTION "public"."reject_canonical_owner_change"()');
+    for (const trigger of [
+      "EndUserIdentity_owner_immutable",
+      "Thread_subject_immutable",
+      "MessageAttachment_owner_immutable",
+      "ChannelInstallation_owner_immutable",
+      "OAuthClient_owner_immutable",
+      "MemoryEntity_subject_immutable",
+    ]) {
+      expect(migration).toContain(`CREATE TRIGGER \"${trigger}\"`);
+    }
   });
 
-  test("limits the generated end-user relation graph to data-plane models", () => {
+  test("limits the generated end-user graph to subject-reachable data", () => {
     const models = EndUserPrisma.dmmf.datamodel.models;
-    expect(models.map((model) => model.name).sort()).toEqual([
-      "EndUser",
-      "EndUserIdentity",
-      "EndUserSession",
-    ]);
+    expect(models.map((model) => model.name).sort()).toEqual(expectedEndUserModels);
 
-    const relationTargets = models.flatMap((model) =>
-      model.fields.filter((field) => field.kind === "object").map((field) => field.type)
+    const relationTargets = new Set(
+      models.flatMap((model) =>
+        model.fields.filter((field) => field.kind === "object").map((field) => field.type)
+      )
     );
-    expect(new Set(relationTargets)).toEqual(new Set(["EndUser", "EndUserIdentity", "EndUserSession"]));
-  });
+    expect([...relationTargets].every((target) => expectedEndUserModels.includes(target))).toBe(true);
 
-  test("records database-enforced tier and organization boundaries", () => {
-    expect(migration).toContain('CONSTRAINT "OperatorSession_tier_check"');
-    expect(migration).toContain('CONSTRAINT "EnvironmentSession_tier_check"');
-    expect(migration).toContain('CONSTRAINT "EndUserSession_tier_check"');
-    expect(migration).toContain('CREATE TRIGGER "EndUserSession_organization_check"');
-    expect(migration).toContain('CREATE TRIGGER "Environment_end_user_session_organization_check"');
-    expect(migration).toContain('CREATE TRIGGER "Project_end_user_session_organization_check"');
-    expect(migration).toContain('CREATE TRIGGER "EndUser_session_organization_reparent_check"');
+    const forbidden = [
+      "User",
+      "Organization",
+      "Project",
+      "Environment",
+      "Agent",
+      "AgentVersion",
+      "Credential",
+      "Entity",
+      "Tool",
+      "AdminAudit",
+      "ErasureOperation",
+    ];
+    for (const model of forbidden) expect(relationTargets.has(model)).toBe(false);
+    expect(endUserDelegateNames).toHaveLength(expectedEndUserModels.length);
   });
 });

--- a/internal-packages/tenancy-database/src/source-model-manifest.ts
+++ b/internal-packages/tenancy-database/src/source-model-manifest.ts
@@ -1,0 +1,174 @@
+export type CanonicalOwner =
+  | "organization"
+  | "project"
+  | "environment"
+  | "agent"
+  | "agentVersion"
+  | "thread"
+  | "turn"
+  | "step"
+  | "entity"
+  | "channelConnection"
+  | "channelApp"
+  | "channelInstallation"
+  | "projectSkill"
+  | "environmentSkill"
+  | "memoryEntity"
+  | "user"
+  | "oauthClient"
+  | "global";
+
+export type PrincipalSurface = "operator" | "subject" | "subject-audit";
+
+export interface SourceModelDisposition {
+  readonly source: `Platos${string}`;
+  readonly targets: readonly string[];
+  readonly owner: CanonicalOwner;
+  readonly surface: PrincipalSurface;
+  readonly decision: "rename" | "merge" | "split" | "re-home";
+}
+
+/**
+ * Mechanical accounting ledger for the 54 legacy Platos-prefixed models.
+ * A source occurs exactly once even when several sources merge into Credential
+ * or one source splits into Turn, Step, and ToolCall.
+ */
+export const sourceModelManifest = [
+  { source: "PlatosAgent", targets: ["Agent", "AgentBinding"], owner: "project", surface: "operator", decision: "split" },
+  { source: "PlatosAgentCluster", targets: ["AgentCluster"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosAgentVersion", targets: ["AgentVersion"], owner: "agent", surface: "operator", decision: "rename" },
+  { source: "PlatosEndUser", targets: ["EndUser"], owner: "organization", surface: "subject", decision: "re-home" },
+  { source: "PlatosEndUserIdentity", targets: ["EndUserIdentity"], owner: "organization", surface: "subject", decision: "re-home" },
+  { source: "PlatosAccessKey", targets: ["AccessKey"], owner: "environment", surface: "operator", decision: "re-home" },
+  { source: "PlatosPostmanTemplate", targets: ["PostmanTemplate"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosAgentThread", targets: ["Thread"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosAgentMessage", targets: ["Turn", "Step", "ToolCall"], owner: "thread", surface: "subject", decision: "split" },
+  { source: "PlatosAgentArtifact", targets: ["Artifact"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosMessageAttachment", targets: ["MessageAttachment"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosConnectedEntity", targets: ["Entity"], owner: "project", surface: "operator", decision: "rename" },
+  { source: "PlatosChannelConnection", targets: ["ChannelConnection"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosChannelThread", targets: ["ChannelThread"], owner: "channelConnection", surface: "subject", decision: "rename" },
+  { source: "PlatosChannelApp", targets: ["ChannelApp"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosChannelInstallation", targets: ["ChannelInstallation"], owner: "channelApp", surface: "operator", decision: "rename" },
+  { source: "PlatosChannelAppThread", targets: ["ChannelAppThread"], owner: "channelInstallation", surface: "subject", decision: "rename" },
+  { source: "PlatosEntityMcpConfig", targets: ["EntityMcpConfig"], owner: "entity", surface: "operator", decision: "rename" },
+  { source: "PlatosEntityMcpClient", targets: ["EntityMcpClient"], owner: "entity", surface: "operator", decision: "rename" },
+  { source: "PlatosToolDefinition", targets: ["Tool"], owner: "global", surface: "operator", decision: "rename" },
+  { source: "PlatosEntityToolMapping", targets: ["EnvironmentEntityTool"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosToolHealth", targets: ["ToolHealth"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosToolCallAudit", targets: ["ToolCallAudit"], owner: "environment", surface: "subject-audit", decision: "rename" },
+  { source: "PlatosAdminAudit", targets: ["AdminAudit"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosAgentApproval", targets: ["AgentApproval"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosProviderEnabled", targets: ["EnvironmentProvider"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosProviderKey", targets: ["ProviderKey"], owner: "environment", surface: "operator", decision: "re-home" },
+  { source: "PlatosBudgetCap", targets: ["Budget"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosSafetyEvent", targets: ["SafetyEvent"], owner: "environment", surface: "subject-audit", decision: "rename" },
+  { source: "PlatosMessageRating", targets: ["MessageRating"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosEvalCriterion", targets: ["EvalCriterion"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosAgentEval", targets: ["AgentEval"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosGoldenSet", targets: ["GoldenSet"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosTask", targets: ["Job"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosSkill", targets: ["Skill", "ProjectSkill", "EnvironmentSkill"], owner: "organization", surface: "operator", decision: "split" },
+  { source: "PlatosAgentSkill", targets: ["AgentSkill"], owner: "agentVersion", surface: "operator", decision: "re-home" },
+  { source: "PlatosMemory", targets: ["Memory"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosMemoryEntity", targets: ["MemoryEntity"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosMemoryRelationship", targets: ["MemoryRelationship"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosMCPToken", targets: ["McpToken"], owner: "environment", surface: "operator", decision: "re-home" },
+  { source: "PlatosOrgMcpPolicy", targets: ["OrganizationMcpPolicy"], owner: "organization", surface: "operator", decision: "re-home" },
+  { source: "PlatosMacro", targets: ["Macro"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosEvent", targets: ["Event"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosNotificationRule", targets: ["NotificationRule"], owner: "environment", surface: "operator", decision: "rename" },
+  { source: "PlatosPAT", targets: ["PersonalAccessToken"], owner: "user", surface: "operator", decision: "re-home" },
+  { source: "PlatosOAuthClient", targets: ["OAuthClient"], owner: "organization", surface: "operator", decision: "rename" },
+  { source: "PlatosOAuthAuthCode", targets: ["OAuthAuthorizationCode"], owner: "oauthClient", surface: "operator", decision: "re-home" },
+  { source: "PlatosOAuthAccessToken", targets: ["OAuthAccessToken"], owner: "oauthClient", surface: "operator", decision: "re-home" },
+  { source: "PlatosOAuthRefreshToken", targets: ["OAuthRefreshToken"], owner: "oauthClient", surface: "operator", decision: "re-home" },
+  { source: "PlatosMcpAnonSession", targets: ["McpAnonymousSession"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosMcpOidcSession", targets: ["McpOidcSession"], owner: "environment", surface: "subject", decision: "rename" },
+  { source: "PlatosEntityMcpToolAcl", targets: ["EntityToolPolicy"], owner: "entity", surface: "operator", decision: "re-home" },
+  { source: "PlatosMcpBearerToken", targets: ["McpBearerToken"], owner: "entity", surface: "operator", decision: "re-home" },
+  { source: "PlatosErasureOperation", targets: ["ErasureOperation"], owner: "organization", surface: "operator", decision: "rename" },
+] as const satisfies readonly SourceModelDisposition[];
+
+/** New support models required by the approved normalized design. */
+export const supportDomainModels = [
+  "AgentToolPolicy",
+  "Credential",
+] as const;
+
+/** All source target models plus independently required clean-slate support models. */
+export const domainModelNames = [
+  ...new Set(sourceModelManifest.flatMap((entry) => entry.targets)),
+  ...supportDomainModels.filter(
+    (name) => !sourceModelManifest.some((entry) => (entry.targets as readonly string[]).includes(name))
+  ),
+] as readonly string[];
+
+export interface LegacyTenancyRelationDisposition {
+  readonly source: `${`Platos${string}`}.${string}`;
+  readonly inheritedTarget: "RuntimeEnvironment" | "Organization" | "Project";
+  readonly targetPath: string;
+  readonly disposition: "canonical" | "derived" | "normalized";
+}
+
+/** Exact reconciliation ledger for the corrected 30 + 6 + 6 relations. */
+export const legacyTenancyRelationManifest = [
+  { source: "PlatosAgent.organization", inheritedTarget: "Organization", targetPath: "Agent.project.organization", disposition: "derived" },
+  { source: "PlatosAgentThread.organization", inheritedTarget: "Organization", targetPath: "Thread.environment.project.organization", disposition: "derived" },
+  { source: "PlatosAgentArtifact.organization", inheritedTarget: "Organization", targetPath: "Artifact.environment.project.organization", disposition: "derived" },
+  { source: "PlatosMessageAttachment.organization", inheritedTarget: "Organization", targetPath: "MessageAttachment.environment.project.organization", disposition: "derived" },
+  { source: "PlatosConnectedEntity.organization", inheritedTarget: "Organization", targetPath: "Entity.project.organization", disposition: "derived" },
+  { source: "PlatosSkill.organization", inheritedTarget: "Organization", targetPath: "Skill.organization", disposition: "canonical" },
+
+  { source: "PlatosAgent.project", inheritedTarget: "Project", targetPath: "Agent.project", disposition: "canonical" },
+  { source: "PlatosAgentThread.project", inheritedTarget: "Project", targetPath: "Thread.environment.project", disposition: "derived" },
+  { source: "PlatosAgentArtifact.project", inheritedTarget: "Project", targetPath: "Artifact.environment.project", disposition: "derived" },
+  { source: "PlatosMessageAttachment.project", inheritedTarget: "Project", targetPath: "MessageAttachment.environment.project", disposition: "derived" },
+  { source: "PlatosConnectedEntity.project", inheritedTarget: "Project", targetPath: "Entity.project", disposition: "canonical" },
+  { source: "PlatosSkill.project", inheritedTarget: "Project", targetPath: "ProjectSkill.project", disposition: "normalized" },
+
+  { source: "PlatosAgent.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "AgentBinding.environment", disposition: "normalized" },
+  { source: "PlatosAgentCluster.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "AgentCluster.environment", disposition: "canonical" },
+  { source: "PlatosEndUser.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "EndUser.organization", disposition: "normalized" },
+  { source: "PlatosAccessKey.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Credential.environment", disposition: "normalized" },
+  { source: "PlatosPostmanTemplate.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "PostmanTemplate.environment", disposition: "canonical" },
+  { source: "PlatosAgentThread.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Thread.environment", disposition: "canonical" },
+  { source: "PlatosAgentArtifact.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Artifact.environment", disposition: "canonical" },
+  { source: "PlatosMessageAttachment.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "MessageAttachment.environment", disposition: "canonical" },
+  { source: "PlatosEntityToolMapping.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "EnvironmentEntityTool.environment", disposition: "canonical" },
+  { source: "PlatosToolHealth.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "ToolHealth.environment", disposition: "canonical" },
+  { source: "PlatosToolCallAudit.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "ToolCallAudit.environment", disposition: "canonical" },
+  { source: "PlatosAdminAudit.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "AdminAudit.environment", disposition: "canonical" },
+  { source: "PlatosAgentApproval.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "AgentApproval.environment", disposition: "canonical" },
+  { source: "PlatosProviderEnabled.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "EnvironmentProvider.environment", disposition: "canonical" },
+  { source: "PlatosProviderKey.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Credential.environment", disposition: "normalized" },
+  { source: "PlatosBudgetCap.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Budget.environment", disposition: "canonical" },
+  { source: "PlatosSafetyEvent.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "SafetyEvent.environment", disposition: "canonical" },
+  { source: "PlatosMessageRating.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "MessageRating.environment", disposition: "canonical" },
+  { source: "PlatosEvalCriterion.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "EvalCriterion.environment", disposition: "canonical" },
+  { source: "PlatosAgentEval.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "AgentEval.environment", disposition: "canonical" },
+  { source: "PlatosGoldenSet.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "GoldenSet.environment", disposition: "canonical" },
+  { source: "PlatosTask.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Job.environment", disposition: "canonical" },
+  { source: "PlatosSkill.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "EnvironmentSkill.environment", disposition: "normalized" },
+  { source: "PlatosMemory.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Memory.environment", disposition: "canonical" },
+  { source: "PlatosMemoryEntity.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "MemoryEntity.environment", disposition: "canonical" },
+  { source: "PlatosMemoryRelationship.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "MemoryRelationship.environment", disposition: "canonical" },
+  { source: "PlatosMCPToken.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Credential.environment", disposition: "normalized" },
+  { source: "PlatosOrgMcpPolicy.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "OrganizationMcpPolicy.organization", disposition: "normalized" },
+  { source: "PlatosEvent.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "Event.environment", disposition: "canonical" },
+  { source: "PlatosNotificationRule.environment", inheritedTarget: "RuntimeEnvironment", targetPath: "NotificationRule.environment", disposition: "canonical" },
+] as const satisfies readonly LegacyTenancyRelationDisposition[];
+
+/** Mechanical totals derived from the exact relation ledger above. */
+export const legacyTenancyRelationCounts = Object.freeze({
+  RuntimeEnvironment: legacyTenancyRelationManifest.filter(
+    (entry) => entry.inheritedTarget === "RuntimeEnvironment"
+  ).length,
+  Organization: legacyTenancyRelationManifest.filter(
+    (entry) => entry.inheritedTarget === "Organization"
+  ).length,
+  Project: legacyTenancyRelationManifest.filter(
+    (entry) => entry.inheritedTarget === "Project"
+  ).length,
+  total: legacyTenancyRelationManifest.length,
+});

--- a/internal-packages/tenancy-database/src/tool-policy.test.ts
+++ b/internal-packages/tenancy-database/src/tool-policy.test.ts
@@ -1,0 +1,23 @@
+import { AgentToolDefaultPolicy, PolicyEffect } from "../generated/control";
+import { describe, expect, test } from "vitest";
+import { resolveAgentToolIds } from "./tool-policy";
+
+describe("agent tool policy resolution", () => {
+  test("gives zero-row NONE and ALL distinct unlisted-tool behavior", () => {
+    expect(resolveAgentToolIds(AgentToolDefaultPolicy.NONE, [], ["a", "b"])).toEqual([]);
+    expect(resolveAgentToolIds(AgentToolDefaultPolicy.ALL, [], ["a", "b"])).toEqual(["a", "b"]);
+  });
+
+  test("explicit rows override either default", () => {
+    expect(resolveAgentToolIds(
+      AgentToolDefaultPolicy.NONE,
+      [{ toolId: "a", effect: PolicyEffect.ALLOW }],
+      ["a", "b"]
+    )).toEqual(["a"]);
+    expect(resolveAgentToolIds(
+      AgentToolDefaultPolicy.ALL,
+      [{ toolId: "a", effect: PolicyEffect.DENY }],
+      ["a", "b"]
+    )).toEqual(["b"]);
+  });
+});

--- a/internal-packages/tenancy-database/src/tool-policy.ts
+++ b/internal-packages/tenancy-database/src/tool-policy.ts
@@ -1,0 +1,33 @@
+import { AgentToolDefaultPolicy, PolicyEffect } from "../generated/control";
+
+export interface ToolPolicyInput {
+  readonly toolId: string;
+  readonly effect: PolicyEffect;
+}
+
+/**
+ * Resolves explicit rows over the version's database-persisted default.
+ *
+ * NONE + zero rows means no tools. ALL + zero rows means all candidate tools,
+ * including tools registered after the version was created. Explicit ALLOW and
+ * DENY rows override either default, so unlisted-tool behavior is never inferred
+ * from an ambiguous empty relation.
+ */
+export function resolveAgentToolIds(
+  defaultPolicy: AgentToolDefaultPolicy,
+  policies: readonly ToolPolicyInput[],
+  candidateToolIds: readonly string[]
+): string[] {
+  const effects = new Map(policies.map((policy) => [policy.toolId, policy.effect]));
+  const selected = new Set<string>();
+
+  for (const toolId of candidateToolIds) {
+    const effect = effects.get(toolId);
+    const allowed =
+      effect === PolicyEffect.ALLOW ||
+      (effect === undefined && defaultPolicy === AgentToolDefaultPolicy.ALL);
+    if (allowed) selected.add(toolId);
+  }
+
+  return [...selected].sort();
+}


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Re-homes the complete Platos domain onto the clean-slate tenancy core with prefix-free nouns, canonical ownership, structural subject isolation, and enforced JSON shapes.

## Changes

- Accounts exactly once for all 54 legacy `Platos*` sources, producing 59 normalized source targets plus `Credential` and `AgentToolPolicy`: 61 domain/capability models and 71 control-plane models overall.
- Reconciles all 42 inherited tenancy relations into Organization → Project → Environment ownership and adds database constraints/triggers for cross-owner ancestry and immutable ownership chains.
- Preserves distinct access-key, provider-key, MCP-token, PAT, OAuth access/refresh token, and MCP bearer capabilities with typed scopes and rotation ownership.
- Adds a restricted 14-model end-user graph, subject-owned unattached attachments, and structural erasure boundaries that cannot traverse into operator/configuration records.
- Validates all 47 retained JSON fields at the API and database boundaries, rejects double encoding and ambiguous `enabledTools`, and defines explicit zero-row `NONE`/`ALL` tool policy behavior.

## Testing

- Passed `env -u DATABASE_URL pnpm --dir internal-packages/tenancy-database run generate`.
- Passed Prisma validation for `prisma/schema.prisma` and `prisma/end-user.prisma`.
- Passed `env -u DATABASE_URL pnpm --dir internal-packages/tenancy-database run typecheck`.
- Passed `env -u DATABASE_URL pnpm --dir internal-packages/tenancy-database run build` (strict declaration build).
- Passed `env -u DATABASE_URL pnpm --dir internal-packages/tenancy-database test -- --run`: 4 files, 23 tests, using an isolated `postgres:16-alpine` Testcontainer.
- Passed all-model round trips for 71 generated models, source/tenancy reconciliation, JSON root enforcement, credential scope/rotation behavior, subject erasure, ancestry/reparenting rejection, and tool-default policy behavior.
- Passed fresh migration consistency and migrated catalog checks: 71 tables, 0 persisted `Platos*` tables, 47 JSON-root constraints, and explicit deletion rules for all 159 foreign keys.
- Passed `git diff --check 875cf62`.
- No repository database, production service, ClickHouse, or Docker Compose was used.

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/10fc87d0-3aa2-49e6-ab05-1f3569b0f59e)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
