### PR TITLE
ci: gate Platos tenancy security suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,12 @@ jobs:
       - name: External Trigger configuration and direct-dispatch tests
         run: pnpm --filter platos-agent exec vitest run src/shared/external-trigger-config.test.ts src/agent-runtime/turn-dispatch.service.spec.ts
 
+      - name: Platos tenancy and operator-auth tests
+        # Runs the complete clean-slate schema/service suite, including its real
+        # Postgres testcontainer boundaries. This protects the operator/end-user
+        # tier separation added in WIN-121 rather than relying on sandbox-only runs.
+        run: pnpm --filter @platos/tenancy-database test
+
       - name: Webapp memory-policy tests
         run: pnpm --filter webapp exec vitest run test/memoryPolicy.test.ts
 

--- a/internal-packages/tenancy-database/src/auth.test.ts
+++ b/internal-packages/tenancy-database/src/auth.test.ts
@@ -20,8 +20,12 @@ describe("Platos auth primitives", () => {
 
     expect(encrypted).not.toContain("JBSWY3DPEHPK3PXP");
     expect(decryptSecret(encrypted, key)).toBe("JBSWY3DPEHPK3PXP");
-    const replacement = encrypted.endsWith("A") ? "B" : "A";
-    expect(() => decryptSecret(`${encrypted.slice(0, -1)}${replacement}`, key)).toThrow();
+    const [iv, encodedTag, ciphertext] = encrypted.split(".");
+    const tag = Buffer.from(encodedTag, "base64url");
+    tag[0] ^= 1;
+    expect(() =>
+      decryptSecret(`${iv}.${tag.toString("base64url")}.${ciphertext}`, key)
+    ).toThrow();
   });
 
   test("implements the RFC 6238 SHA-1 six-digit TOTP semantics", () => {

--- a/internal-packages/tenancy-database/src/integration.test.ts
+++ b/internal-packages/tenancy-database/src/integration.test.ts
@@ -390,7 +390,7 @@ describe("domain schema integration", () => {
       data: {
         identityId: seeded.endUserIdentity.id,
         environmentId: seeded.environment.id,
-        tokenHash: "wrong-end-user-tier",
+        tokenHash: "f".repeat(64),
         tier: PrincipalTier.OPERATOR,
         expiresAt: future(),
       },
@@ -398,7 +398,7 @@ describe("domain schema integration", () => {
     await expect(control.operatorSession.create({
       data: {
         userId: seeded.user.id,
-        tokenHash: "wrong-operator-tier",
+        tokenHash: "0".repeat(64),
         tier: PrincipalTier.END_USER,
         expiresAt: future(),
       },


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Makes the complete Platos tenancy package a required CI workload so operator/end-user tier regressions cannot merge silently. It also repairs two assertions whose inputs allowed false-green or nondeterministic results.

## Changes

- Runs `pnpm --filter @platos/tenancy-database test` in the existing CI typecheck job, using GitHub runner Docker for its real Postgres testcontainer boundaries.
- Makes authenticated-encryption tampering deterministic by flipping an AES-GCM tag byte instead of changing a potentially non-significant base64url character.
- Uses valid 64-hex token hashes in the tier test so it isolates the principal-tier constraint instead of passing because a separate hash-shape constraint rejected the fixture.

## Testing

- `pnpm --filter @platos/tenancy-database test` — passed, 36/36 across six files:
  - `src/integration.test.ts`
  - `src/auth.integration.test.ts`
  - `src/schema.test.ts`
  - `src/json.test.ts`
  - `src/auth.test.ts`
  - `src/tool-policy.test.ts`
- Mutation proof with the same command: temporarily removed `OperatorSession_tier_check`; command exited 1 and `integration.test.ts > enforces principal tiers in the database` failed, leaving 35/36 passing. The migration was then restored and the full suite returned to 36/36.
- `git diff --check` — passed.
- This gate intentionally covers only `@platos/tenancy-database`. Agent, webapp, and other workspace suites remain outside this focused package gate; existing CI jobs continue to run their scoped checks.
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
