### PR TITLE
fix(tools): make entity invalidation atomic

### DIFF
--- a/apps/agent/src/auth/auth.service.test.ts
+++ b/apps/agent/src/auth/auth.service.test.ts
@@ -354,6 +354,9 @@ describe("AuthService — clean Entity registry", () => {
         updateMany: vi.fn(),
         upsert: vi.fn(),
       },
+      environmentEntityTool: {
+        deleteMany: vi.fn(),
+      },
     };
     prisma.$transaction = vi.fn(async (callback: (tx: any) => unknown) => callback(prisma));
     return prisma;
@@ -396,6 +399,21 @@ describe("AuthService — clean Entity registry", () => {
       rotateInTransaction: vi.fn(async (_tx: any, params: any) => ({
         id: params.credentialId,
       })),
+    };
+  }
+
+  function toolRegistry() {
+    const apply = vi.fn(() => ({ bucketsEvicted: 1 }));
+    return {
+      apply,
+      registry: {
+        prepareEntityEviction: vi.fn(() => ({
+          entityPk: cleanEntity.id,
+          bucketsEvicted: 1,
+          apply,
+        })),
+        rebuildIndex: vi.fn(),
+      },
     };
   }
 
@@ -567,13 +585,21 @@ describe("AuthService — clean Entity registry", () => {
     }
   });
 
-  it("revokes scoped Entity credentials before deleting the clean Entity", async () => {
+  it("atomically revokes credentials, removes mappings, and deletes the Entity before cache eviction", async () => {
     const prisma = entityPrisma();
     prisma.entity.findFirst.mockResolvedValue({ id: cleanEntity.id });
     prisma.entity.deleteMany.mockResolvedValue({ count: 1 });
-    const auth = new AuthService(prisma, {} as any, undefined, secretStore() as any);
+    prisma.environmentEntityTool.deleteMany.mockResolvedValue({ count: 2 });
+    const tools = toolRegistry();
+    const auth = new AuthService(
+      prisma,
+      {} as any,
+      tools.registry as any,
+      secretStore() as any,
+    );
 
     await expect(auth.deleteEntity("org_1", "proj_1", "support-core")).resolves.toBe(true);
+    expect(tools.registry.prepareEntityEviction).toHaveBeenCalledWith(cleanEntity.id);
     expect(prisma.credential.updateMany).toHaveBeenCalledWith({
       where: expect.objectContaining({
         kind: "ENTITY_SECRET",
@@ -582,6 +608,9 @@ describe("AuthService — clean Entity registry", () => {
       }),
       data: { revokedAt: expect.any(Date) },
     });
+    expect(prisma.environmentEntityTool.deleteMany).toHaveBeenCalledWith({
+      where: { entityId: cleanEntity.id },
+    });
     expect(prisma.entity.deleteMany).toHaveBeenCalledWith({
       where: {
         id: cleanEntity.id,
@@ -589,5 +618,86 @@ describe("AuthService — clean Entity registry", () => {
         project: { organizationId: "org_1" },
       },
     });
+    expect(tools.apply).toHaveBeenCalledOnce();
+  });
+
+  it("does not start a database transaction when registry eviction cannot be prepared", async () => {
+    const prisma = entityPrisma();
+    prisma.entity.findFirst.mockResolvedValue({ id: cleanEntity.id });
+    const tools = toolRegistry();
+    tools.registry.prepareEntityEviction.mockImplementation(() => {
+      throw new Error("index build failed");
+    });
+    const auth = new AuthService(prisma, {} as any, tools.registry as any);
+
+    await expect(
+      auth.deleteEntity("org_1", "proj_1", "support-core"),
+    ).rejects.toThrow("index build failed");
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.credential.updateMany).not.toHaveBeenCalled();
+    expect(prisma.environmentEntityTool.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.entity.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("does not evict cache/index when the entity transaction fails", async () => {
+    const prisma = entityPrisma();
+    prisma.entity.findFirst.mockResolvedValue({ id: cleanEntity.id });
+    prisma.$transaction.mockRejectedValue(new Error("transaction failed"));
+    const tools = toolRegistry();
+    const auth = new AuthService(prisma, {} as any, tools.registry as any);
+
+    await expect(
+      auth.deleteEntity("org_1", "proj_1", "support-core"),
+    ).rejects.toThrow("transaction failed");
+    expect(tools.apply).not.toHaveBeenCalled();
+    expect(tools.registry.rebuildIndex).not.toHaveBeenCalled();
+  });
+
+  it("returns success after recovering a post-commit eviction failure from canonical DB", async () => {
+    const prisma = entityPrisma();
+    prisma.entity.findFirst.mockResolvedValue({ id: cleanEntity.id });
+    prisma.environmentEntityTool.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.entity.deleteMany.mockResolvedValue({ count: 1 });
+    const tools = toolRegistry();
+    tools.apply.mockImplementation(() => {
+      throw new Error("cache swap failed");
+    });
+    const auth = new AuthService(prisma, {} as any, tools.registry as any);
+
+    await expect(
+      auth.deleteEntity("org_1", "proj_1", "support-core"),
+    ).resolves.toBe(true);
+    expect(tools.registry.rebuildIndex).toHaveBeenCalledOnce();
+  });
+
+  it("fails loudly only when post-commit eviction and canonical recovery both fail", async () => {
+    const prisma = entityPrisma();
+    prisma.entity.findFirst.mockResolvedValue({ id: cleanEntity.id });
+    prisma.environmentEntityTool.deleteMany.mockResolvedValue({ count: 1 });
+    prisma.entity.deleteMany.mockResolvedValue({ count: 1 });
+    const tools = toolRegistry();
+    tools.apply.mockImplementation(() => {
+      throw new Error("cache swap failed");
+    });
+    tools.registry.rebuildIndex.mockRejectedValue(new Error("rebuild failed"));
+    const auth = new AuthService(prisma, {} as any, tools.registry as any);
+
+    await expect(
+      auth.deleteEntity("org_1", "proj_1", "support-core"),
+    ).rejects.toThrow("entity_deleted_but_registry_recovery_failed");
+    expect(tools.registry.rebuildIndex).toHaveBeenCalledOnce();
+  });
+
+  it("returns false for an unknown Entity without touching registry or persistence", async () => {
+    const prisma = entityPrisma();
+    prisma.entity.findFirst.mockResolvedValue(null);
+    const tools = toolRegistry();
+    const auth = new AuthService(prisma, {} as any, tools.registry as any);
+
+    await expect(
+      auth.deleteEntity("org_1", "proj_1", "missing"),
+    ).resolves.toBe(false);
+    expect(tools.registry.prepareEntityEviction).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
   });
 });

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -664,45 +664,18 @@ export class AuthService {
     return entities.map(AuthService.projectEntity);
   }
 
-  /**
-   * Delete an entity and everything the tool registry still believes about it.
-   *
-   * The DB row was previously all that got deleted. The registry's in-memory
-   * scoped-tool cache is keyed by (org, project, env, entityId) and had no
-   * eviction path on this route, so a deleted entity's tools stayed live: they
-   * were still injected into every turn with full schemas, and dispatching one
-   * resolved `entityPk` against a row that no longer existed, failing with
-   * "Entity <id> not registered". Only a process restart cleared it.
-   *
-   * The purge runs BEFORE the row is deleted so the cache key can be rebuilt
-   * from the entity; `purgeEntity` also matches buckets by entityPk so it stays
-   * correct if that order ever changes.
-   */
+  /** Delete an entity, its credentials, and its tool exposure atomically. */
   async deleteEntity(organizationId: string, projectId: string, entityId: string): Promise<boolean> {
     const entity = await this.prisma.entity.findFirst({
       where: { projectId, externalId: entityId, project: { organizationId } },
       select: { id: true },
     });
-
-    if (entity && this.toolRegistry) {
-      try {
-        const purged = await this.toolRegistry.purgeEntity(entity.id);
-        this.logger.log(
-          `deleteEntity ${entityId}: purged ${purged.mappingsRemoved} tool mappings, ${purged.bucketsEvicted} cache buckets`,
-        );
-      } catch (err: any) {
-        // A failed purge must not block the delete — the operator asked for the
-        // entity to be gone. Loud, because the surviving cache entries are the
-        // exact condition that produces "Entity not registered" at dispatch.
-        this.logger.error(
-          `deleteEntity ${entityId}: registry purge failed, stale tools may persist until restart — ${err?.message ?? err}`,
-        );
-      }
-    }
-
     if (!entity) return false;
+    if (!this.toolRegistry) throw new Error("tool_registry_unavailable");
+
+    const eviction = this.toolRegistry.prepareEntityEviction(entity.id);
     const now = new Date();
-    const result = await this.prisma.$transaction(async (tx) => {
+    const persisted = await this.prisma.$transaction(async (tx) => {
       await tx.credential.updateMany({
         where: {
           kind: CredentialKind.ENTITY_SECRET,
@@ -712,11 +685,43 @@ export class AuthService {
         },
         data: { revokedAt: now },
       });
-      return tx.entity.deleteMany({
+      const mappings = await tx.environmentEntityTool.deleteMany({
+        where: { entityId: entity.id },
+      });
+      const deleted = await tx.entity.deleteMany({
         where: { id: entity.id, projectId, project: { organizationId } },
       });
+      if (deleted.count !== 1) throw new Error("entity_delete_conflict");
+      return { mappingsRemoved: mappings.count };
     });
-    return result.count > 0;
+
+    try {
+      const applied = eviction.apply();
+      this.logger.log(
+        `deleteEntity ${entityId}: removed ${persisted.mappingsRemoved} tool mappings, evicted ${applied.bucketsEvicted} cache buckets`,
+      );
+    } catch (evictionError) {
+      this.logger.error(
+        `deleteEntity ${entityId}: post-commit registry eviction failed; rebuilding from canonical database`,
+        evictionError instanceof Error ? evictionError.stack : String(evictionError),
+      );
+      try {
+        await this.toolRegistry.rebuildIndex();
+      } catch (rebuildError) {
+        this.logger.error(
+          `deleteEntity ${entityId}: canonical registry rebuild failed`,
+          rebuildError instanceof Error ? rebuildError.stack : String(rebuildError),
+        );
+        throw new AggregateError(
+          [evictionError, rebuildError],
+          "entity_deleted_but_registry_recovery_failed",
+        );
+      }
+      this.logger.warn(
+        `deleteEntity ${entityId}: registry recovered from canonical database after eviction failure`,
+      );
+    }
+    return true;
   }
 
   /**

--- a/apps/agent/src/tool-gateway/bm25.test.ts
+++ b/apps/agent/src/tool-gateway/bm25.test.ts
@@ -58,6 +58,25 @@ describe("bm25: BM25Index basic indexing", () => {
     expect(results[0].id).toBe("tool_search");
   });
 
+  it("orders equal-score results deterministically by document id", () => {
+    const forward = new BM25Index();
+    forward.addDocument("alpha", "shared search terms");
+    forward.addDocument("zeta", "shared search terms");
+
+    const reverse = new BM25Index();
+    reverse.addDocument("zeta", "shared search terms");
+    reverse.addDocument("alpha", "shared search terms");
+
+    expect(forward.search("shared search", 10).map(({ id }) => id)).toEqual([
+      "alpha",
+      "zeta",
+    ]);
+    expect(reverse.search("shared search", 10).map(({ id }) => id)).toEqual([
+      "alpha",
+      "zeta",
+    ]);
+  });
+
   it("removeDocument drops the doc from future searches", () => {
     idx.addDocument("tool_search", "search for people find a person by name");
     idx.addDocument("tool_email", "send an email message");

--- a/apps/agent/src/tool-gateway/bm25.ts
+++ b/apps/agent/src/tool-gateway/bm25.ts
@@ -154,7 +154,7 @@ export class BM25Index {
       }
     }
 
-    scores.sort((a, b) => b.score - a.score);
+    scores.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id));
     return scores.slice(0, limit);
   }
 

--- a/apps/agent/src/tool-gateway/registry-invalidation.test.ts
+++ b/apps/agent/src/tool-gateway/registry-invalidation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AuthService } from "../auth/auth.service";
 import { ToolRegistryService, type ToolSchema } from "./tool-registry.service";
 
 const SCOPE = {
@@ -55,6 +56,32 @@ function makeDatabase(options: { callbackUrl?: string | null } = {}) {
     entity,
     environment: { projectId: SCOPE.projectId },
   });
+  const state = {
+    tools,
+    mappings,
+    entity,
+    bindings,
+    entityDeleted: false,
+    credentialsRevoked: false,
+    failEntityDelete: false,
+  };
+  const deleteMappings = (where: any) => {
+    const before = mappings.length;
+    const keepIds = where.id?.notIn ? new Set(where.id.notIn) : null;
+    const ids = where.id?.in ? new Set(where.id.in) : null;
+    for (let i = mappings.length - 1; i >= 0; i -= 1) {
+      const row = mappings[i]!;
+      if (
+        (where.entityId === undefined || row.entityId === where.entityId) &&
+        (where.environmentId === undefined || row.environmentId === where.environmentId) &&
+        (!keepIds || !keepIds.has(row.id)) &&
+        (!ids || ids.has(row.id))
+      ) {
+        mappings.splice(i, 1);
+      }
+    }
+    return { count: before - mappings.length };
+  };
   const tx: any = {
     tool: {
       upsert: async ({ where, create }: any) => {
@@ -85,32 +112,45 @@ function makeDatabase(options: { callbackUrl?: string | null } = {}) {
         }
         return { ...row };
       },
-      deleteMany: async ({ where }: any) => {
-        const before = mappings.length;
-        const keepIds = new Set(where.id?.notIn ?? []);
-        for (let i = mappings.length - 1; i >= 0; i -= 1) {
-          const row = mappings[i]!;
-          if (
-            row.environmentId === where.environmentId &&
-            row.entityId === where.entityId &&
-            (!where.id?.notIn || !keepIds.has(row.id))
-          ) {
-            mappings.splice(i, 1);
-          }
-        }
-        return { count: before - mappings.length };
+      deleteMany: async ({ where }: any) => deleteMappings(where),
+    },
+    credential: {
+      updateMany: async () => {
+        state.credentialsRevoked = true;
+        return { count: 1 };
+      },
+    },
+    entity: {
+      deleteMany: async () => {
+        if (state.failEntityDelete) throw new Error("entity delete failed");
+        if (state.entityDeleted) return { count: 0 };
+        state.entityDeleted = true;
+        return { count: 1 };
       },
     },
   };
 
   const prisma: any = {
-    state: { tools, mappings, entity, bindings },
-    $transaction: async (fn: (client: any) => unknown) => fn(tx),
+    state,
+    $transaction: async (fn: (client: any) => unknown) => {
+      const mappingSnapshot = mappings.map((mapping) => ({ ...mapping }));
+      const entityDeletedSnapshot = state.entityDeleted;
+      const credentialsRevokedSnapshot = state.credentialsRevoked;
+      try {
+        return await fn(tx);
+      } catch (error) {
+        mappings.splice(0, mappings.length, ...mappingSnapshot);
+        state.entityDeleted = entityDeletedSnapshot;
+        state.credentialsRevoked = credentialsRevokedSnapshot;
+        throw error;
+      }
+    },
     entity: {
       findFirst: async ({ where }: any) =>
-        where.id === entity.id &&
-        where.externalId === entity.externalId &&
-        where.projectId === entity.projectId
+        !state.entityDeleted &&
+        (where.id === undefined || where.id === entity.id) &&
+        (where.externalId === undefined || where.externalId === entity.externalId) &&
+        (where.projectId === undefined || where.projectId === entity.projectId)
           ? entity
           : null,
     },
@@ -149,22 +189,7 @@ function makeDatabase(options: { callbackUrl?: string | null } = {}) {
         Object.assign(row, data);
         return { ...row };
       },
-      deleteMany: async ({ where }: any) => {
-        const before = mappings.length;
-        const ids = where.id?.in ? new Set(where.id.in) : null;
-        for (let i = mappings.length - 1; i >= 0; i -= 1) {
-          const row = mappings[i]!;
-          if (
-            (where.entityId === undefined || row.entityId === where.entityId) &&
-            (where.environmentId === undefined ||
-              row.environmentId === where.environmentId) &&
-            (!ids || ids.has(row.id))
-          ) {
-            mappings.splice(i, 1);
-          }
-        }
-        return { count: before - mappings.length };
-      },
+      deleteMany: async ({ where }: any) => deleteMappings(where),
     },
   };
 
@@ -223,17 +248,133 @@ describe("ToolRegistryService clean tenancy cutover", () => {
     expect(service.getIndexStats().totalDocs).toBe(1);
   });
 
-  it("purges mappings, cache buckets, and BM25 documents on entity deletion", async () => {
+  it("prepares cache-only eviction, then removes every bucket and BM25 document", async () => {
     const { prisma, declare } = makeDatabase();
     const service = new ToolRegistryService(prisma);
     await declare(service, [tool("a"), tool("b")]);
 
-    await expect(service.purgeEntity("entity-pk")).resolves.toEqual({
-      mappingsRemoved: 2,
+    const eviction = service.prepareEntityEviction("entity-pk");
+    expect(eviction).toMatchObject({
+      entityPk: "entity-pk",
       bucketsEvicted: 1,
     });
+    expect(prisma.state.mappings).toHaveLength(2);
+    expect(service.getScopedTools(SCOPE)).toHaveLength(2);
+    expect(service.getIndexStats().totalDocs).toBe(2);
+
+    await prisma.environmentEntityTool.deleteMany({ where: { entityId: "entity-pk" } });
+    expect(eviction.apply()).toEqual({ bucketsEvicted: 1 });
     expect(prisma.state.mappings).toEqual([]);
     expect(service.getScopedTools(SCOPE)).toEqual([]);
+    expect(service.findTools("a description", SCOPE)).toEqual([]);
+    expect(service.getIndexStats()).toMatchObject({
+      totalDocs: 0,
+      cachedScopeEntityPairs: 0,
+    });
+  });
+
+  it("does not publish a stale rebuild snapshot after entity deletion", async () => {
+    const { prisma, declare } = makeDatabase();
+    const service = new ToolRegistryService(prisma);
+    await declare(service, [tool("a")]);
+
+    const findMany = prisma.environmentEntityTool.findMany;
+    let snapshotRead!: () => void;
+    const snapshotWasRead = new Promise<void>((resolve) => {
+      snapshotRead = resolve;
+    });
+    let releaseSnapshot!: () => void;
+    const snapshotBarrier = new Promise<void>((resolve) => {
+      releaseSnapshot = resolve;
+    });
+    let blockFirstRead = true;
+    let rebuildReads = 0;
+    prisma.environmentEntityTool.findMany = async (args: any) => {
+      rebuildReads += 1;
+      const snapshot = await findMany(args);
+      if (blockFirstRead) {
+        blockFirstRead = false;
+        snapshotRead();
+        await snapshotBarrier;
+      }
+      return snapshot;
+    };
+
+    const staleRebuild = service.rebuildIndex();
+    await snapshotWasRead;
+    const auth = new AuthService(prisma, {} as any, service);
+    await expect(
+      auth.deleteEntity(SCOPE.organizationId, SCOPE.projectId, "entity-a"),
+    ).resolves.toBe(true);
+    releaseSnapshot();
+    await staleRebuild;
+
+    expect(rebuildReads).toBe(2);
+    expect(prisma.state.mappings).toEqual([]);
+    expect(service.getScopedTools(SCOPE)).toEqual([]);
+    expect(service.findTools("a description", SCOPE)).toEqual([]);
+    expect(service.getIndexStats()).toMatchObject({
+      totalDocs: 0,
+      cachedScopeEntityPairs: 0,
+    });
+  });
+
+  it("allows the same external id to be recreated under a different entity PK", async () => {
+    const { prisma, declare } = makeDatabase();
+    const service = new ToolRegistryService(prisma);
+    await declare(service, [tool("old")]);
+    const auth = new AuthService(prisma, {} as any, service);
+    await auth.deleteEntity(SCOPE.organizationId, SCOPE.projectId, "entity-a");
+
+    prisma.state.entity.id = "entity-pk-recreated";
+    prisma.state.entityDeleted = false;
+    await declare(service, [tool("new")]);
+
+    expect(service.getScopedTools(SCOPE).map((entry) => entry.entityPk)).toEqual([
+      "entity-pk-recreated",
+    ]);
+    expect(service.findTools("new description", SCOPE).map((entry) => entry.toolName)).toEqual([
+      "new",
+    ]);
+  });
+
+  it("rolls back persisted mappings and credentials and leaves cache/index live when deletion fails", async () => {
+    const { prisma, declare } = makeDatabase();
+    const service = new ToolRegistryService(prisma);
+    await declare(service, [tool("a"), tool("b")]);
+    prisma.state.failEntityDelete = true;
+    const auth = new AuthService(prisma, {} as any, service);
+
+    await expect(
+      auth.deleteEntity(SCOPE.organizationId, SCOPE.projectId, "entity-a"),
+    ).rejects.toThrow("entity delete failed");
+    expect(prisma.state.entityDeleted).toBe(false);
+    expect(prisma.state.credentialsRevoked).toBe(false);
+    expect(prisma.state.mappings).toHaveLength(2);
+    expect(service.getScopedTools(SCOPE).map((entry) => entry.toolName)).toEqual([
+      "a",
+      "b",
+    ]);
+    expect(service.findTools("a description", SCOPE).map((entry) => entry.toolName)).toContain(
+      "a",
+    );
+    expect(service.getIndexStats().totalDocs).toBe(2);
+  });
+
+  it("commits entity, credential, and mapping deletion before removing all dispatchable state", async () => {
+    const { prisma, declare } = makeDatabase();
+    const service = new ToolRegistryService(prisma);
+    await declare(service, [tool("a"), tool("b")]);
+    const auth = new AuthService(prisma, {} as any, service);
+
+    await expect(
+      auth.deleteEntity(SCOPE.organizationId, SCOPE.projectId, "entity-a"),
+    ).resolves.toBe(true);
+    expect(prisma.state.entityDeleted).toBe(true);
+    expect(prisma.state.credentialsRevoked).toBe(true);
+    expect(prisma.state.mappings).toEqual([]);
+    expect(service.getScopedTools(SCOPE)).toEqual([]);
+    expect(service.findTools("a description", SCOPE)).toEqual([]);
     expect(service.getIndexStats()).toMatchObject({
       totalDocs: 0,
       cachedScopeEntityPairs: 0,

--- a/apps/agent/src/tool-gateway/tool-registry.service.ts
+++ b/apps/agent/src/tool-gateway/tool-registry.service.ts
@@ -39,6 +39,12 @@ export interface OrgToolEntry {
   entityMcpInjectContext: boolean;
 }
 
+export interface PreparedEntityEviction {
+  readonly entityPk: string;
+  readonly bucketsEvicted: number;
+  apply(): { bucketsEvicted: number };
+}
+
 type ScopeTuple = Pick<
   RequestScope,
   "organizationId" | "projectId" | "environmentId"
@@ -96,11 +102,12 @@ function entryOrder(a: OrgToolEntry, b: OrgToolEntry): number {
  */
 @Injectable()
 export class ToolRegistryService implements OnModuleInit {
-  private readonly bm25 = new BM25Index();
-  private readonly scopedToolCache = new Map<
+  private bm25 = new BM25Index();
+  private scopedToolCache = new Map<
     string,
     Map<string, OrgToolEntry>
   >();
+  private cacheRevision = 0;
 
   constructor(
     @Inject(PRISMA_TOKEN)
@@ -113,91 +120,89 @@ export class ToolRegistryService implements OnModuleInit {
 
   /** Replace the complete in-memory registry from clean tenancy rows. */
   async rebuildIndex(): Promise<void> {
-    const mappings = await this.prisma.environmentEntityTool.findMany({
-      include: {
-        tool: true,
-        entity: {
-          include: {
-            project: { select: { organizationId: true } },
-            mcpConfig: { select: { injectMcpContext: true } },
-            mcpClient: { select: { transport: true, url: true } },
-          },
-        },
-        environment: { select: { projectId: true } },
-      },
-      orderBy: [
-        { environmentId: "asc" },
-        { entityId: "asc" },
-        { tool: { name: "asc" } },
-        { toolId: "asc" },
-      ],
-    });
-
-    const environmentIds = [...new Set(mappings.map((row) => row.environmentId))];
-    const bindingsByEnvironment = new Map<string, AgentPolicyBinding[]>();
-    if (environmentIds.length > 0) {
-      const bindings = await this.prisma.agentBinding.findMany({
-        where: { environmentId: { in: environmentIds } },
-        select: {
-          environmentId: true,
-          agentId: true,
-          activeAgentVersion: {
-            select: {
-              toolDefaultPolicy: true,
-              toolPolicies: { select: { toolId: true, effect: true } },
+    for (;;) {
+      const snapshotRevision = this.cacheRevision;
+      const mappings = await this.prisma.environmentEntityTool.findMany({
+        include: {
+          tool: true,
+          entity: {
+            include: {
+              project: { select: { organizationId: true } },
+              mcpConfig: { select: { injectMcpContext: true } },
+              mcpClient: { select: { transport: true, url: true } },
             },
           },
+          environment: { select: { projectId: true } },
         },
-        orderBy: [{ environmentId: "asc" }, { agentId: "asc" }],
+        orderBy: [
+          { environmentId: "asc" },
+          { entityId: "asc" },
+          { tool: { name: "asc" } },
+          { toolId: "asc" },
+        ],
       });
-      for (const binding of bindings) {
-        const bucket = bindingsByEnvironment.get(binding.environmentId) ?? [];
-        bucket.push(binding as AgentPolicyBinding);
-        bindingsByEnvironment.set(binding.environmentId, bucket);
+
+      const environmentIds = [...new Set(mappings.map((row) => row.environmentId))];
+      const bindingsByEnvironment = new Map<string, AgentPolicyBinding[]>();
+      if (environmentIds.length > 0) {
+        const bindings = await this.prisma.agentBinding.findMany({
+          where: { environmentId: { in: environmentIds } },
+          select: {
+            environmentId: true,
+            agentId: true,
+            activeAgentVersion: {
+              select: {
+                toolDefaultPolicy: true,
+                toolPolicies: { select: { toolId: true, effect: true } },
+              },
+            },
+          },
+          orderBy: [{ environmentId: "asc" }, { agentId: "asc" }],
+        });
+        for (const binding of bindings) {
+          const bucket = bindingsByEnvironment.get(binding.environmentId) ?? [];
+          bucket.push(binding as AgentPolicyBinding);
+          bindingsByEnvironment.set(binding.environmentId, bucket);
+        }
       }
-    }
 
-    const next = new Map<string, Map<string, OrgToolEntry>>();
-    for (const mapping of mappings) {
-      const { entity, environment, tool } = mapping;
-      if (entity.projectId !== environment.projectId) continue;
+      const next = new Map<string, Map<string, OrgToolEntry>>();
+      for (const mapping of mappings) {
+        const { entity, environment, tool } = mapping;
+        if (entity.projectId !== environment.projectId) continue;
 
-      const scope: ScopeTuple = {
-        organizationId: entity.project.organizationId,
-        projectId: entity.projectId,
-        environmentId: mapping.environmentId,
-      };
-      const key = scopeEntityKey(scope, entity.externalId);
-      const bucket = next.get(key) ?? new Map<string, OrgToolEntry>();
-      const dispatchable = this.isPersistedMappingDispatchable({
-        connectionKind: entity.connectionKind,
-        callbackUrl: mapping.callbackUrl,
-        hasMcpClient: entity.mcpClient !== null,
-      });
-      bucket.set(
-        tool.name,
-        this.toEntry(
-          mapping,
-          bindingsByEnvironment.get(mapping.environmentId) ?? [],
-          dispatchable,
-        ),
+        const scope: ScopeTuple = {
+          organizationId: entity.project.organizationId,
+          projectId: entity.projectId,
+          environmentId: mapping.environmentId,
+        };
+        const key = scopeEntityKey(scope, entity.externalId);
+        const bucket = next.get(key) ?? new Map<string, OrgToolEntry>();
+        const dispatchable = this.isPersistedMappingDispatchable({
+          connectionKind: entity.connectionKind,
+          callbackUrl: mapping.callbackUrl,
+          hasMcpClient: entity.mcpClient !== null,
+        });
+        bucket.set(
+          tool.name,
+          this.toEntry(
+            mapping,
+            bindingsByEnvironment.get(mapping.environmentId) ?? [],
+            dispatchable,
+          ),
+        );
+        next.set(key, bucket);
+      }
+
+      if (!this.replaceInMemoryRegistry(next, snapshotRevision)) continue;
+
+      const stats = this.bm25.getStats();
+      console.log(
+        `[Platos ToolRegistry] Index rebuilt: ${stats.totalDocs} dispatchable tools, ` +
+          `${stats.uniqueTerms} terms, ${this.scopedToolCache.size} (scope,entity) buckets`,
       );
-      next.set(key, bucket);
+      return;
     }
-
-    this.scopedToolCache.clear();
-    for (const [key, bucket] of [...next.entries()].sort(([a], [b]) =>
-      a.localeCompare(b),
-    )) {
-      this.scopedToolCache.set(key, bucket);
-    }
-    this.rebuildSearchIndex();
-
-    const stats = this.bm25.getStats();
-    console.log(
-      `[Platos ToolRegistry] Index rebuilt: ${stats.totalDocs} dispatchable tools, ` +
-        `${stats.uniqueTerms} terms, ${this.scopedToolCache.size} (scope,entity) buckets`,
-    );
   }
 
   /**
@@ -221,6 +226,7 @@ export class ToolRegistryService implements OnModuleInit {
     newTools: number;
     removed: number;
   }> {
+    const publicationRevision = this.cacheRevision;
     const entity = await this.prisma.entity.findFirst({
       where: {
         id: params.entityPk,
@@ -330,7 +336,23 @@ export class ToolRegistryService implements OnModuleInit {
       return rows;
     });
 
+    const activeToolIds = new Set(persisted.map(({ tool }) => tool.id));
+    const newTools = [...activeToolIds].filter(
+      (toolId) => !previousToolIds.has(toolId),
+    ).length;
+    const updated = persisted.length - newTools;
+    const activeNames = new Set(declaration.map((tool) => tool.name));
+    const removed = previous.filter((mapping) => !activeNames.has(mapping.tool.name)).length;
+    const result = { registered: persisted.length, updated, newTools, removed };
+
     const bindings = await this.loadAgentPolicyBindings(params.environmentId);
+    // Any cache publication that won while this DB operation was in flight may
+    // include an entity deletion. Reload canonical state instead of publishing
+    // this older transaction's bucket over it.
+    if (this.cacheRevision !== publicationRevision) {
+      await this.rebuildIndex();
+      return result;
+    }
     const cacheKey = scopeEntityKey(params, params.sourceEntityId);
     const bucket = new Map<string, OrgToolEntry>();
     for (const { mapping, tool } of persisted) {
@@ -359,14 +381,7 @@ export class ToolRegistryService implements OnModuleInit {
     else this.scopedToolCache.delete(cacheKey);
     this.rebuildSearchIndex();
 
-    const activeToolIds = new Set(persisted.map(({ tool }) => tool.id));
-    const newTools = [...activeToolIds].filter(
-      (toolId) => !previousToolIds.has(toolId),
-    ).length;
-    const updated = persisted.length - newTools;
-    const activeNames = new Set(declaration.map((tool) => tool.name));
-    const removed = previous.filter((mapping) => !activeNames.has(mapping.tool.name)).length;
-    return { registered: persisted.length, updated, newTools, removed };
+    return result;
   }
 
   findTools(
@@ -448,6 +463,7 @@ export class ToolRegistryService implements OnModuleInit {
         updated += 1;
       }
     }
+    if (updated > 0) this.cacheRevision += 1;
     return updated;
   }
 
@@ -508,21 +524,36 @@ export class ToolRegistryService implements OnModuleInit {
     return { removed: stale.length };
   }
 
-  async purgeEntity(
-    entityPk: string,
-  ): Promise<{ mappingsRemoved: number; bucketsEvicted: number }> {
-    const removed = await this.prisma.environmentEntityTool.deleteMany({
-      where: { entityId: entityPk },
-    });
-    let bucketsEvicted = 0;
-    for (const [key, bucket] of this.scopedToolCache) {
-      if ([...bucket.values()].some((entry) => entry.entityPk === entityPk)) {
-        this.scopedToolCache.delete(key);
-        bucketsEvicted += 1;
-      }
-    }
-    this.rebuildSearchIndex();
-    return { mappingsRemoved: removed.count, bucketsEvicted };
+  /**
+   * Build and validate an entity-free cache/index replacement without mutating
+   * either Prisma or the live registry. Entity deletion can therefore fail
+   * before its database transaction if deterministic eviction cannot be built.
+   */
+  prepareEntityEviction(entityPk: string): PreparedEntityEviction {
+    const preparedAtRevision = this.cacheRevision;
+    const prepared = this.registryWithoutEntity(entityPk);
+    let applied = false;
+
+    return {
+      entityPk,
+      bucketsEvicted: prepared.bucketsEvicted,
+      apply: () => {
+        if (applied) throw new Error("entity_eviction_already_applied");
+        applied = true;
+
+        // Registration or policy/liveness invalidation may have committed while
+        // the entity transaction was in flight. Recompute from the latest cache
+        // rather than restoring the older prepared snapshot over newer state.
+        const replacement =
+          this.cacheRevision === preparedAtRevision
+            ? prepared
+            : this.registryWithoutEntity(entityPk);
+        this.scopedToolCache = replacement.cache;
+        this.bm25 = replacement.index;
+        this.cacheRevision += 1;
+        return { bucketsEvicted: replacement.bucketsEvicted };
+      },
+    };
   }
 
   /** Update transport liveness and immediately invalidate search/exposure. */
@@ -685,20 +716,64 @@ export class ToolRegistryService implements OnModuleInit {
   }
 
   private rebuildSearchIndex(): void {
-    this.bm25.clear();
+    this.bm25 = this.buildSearchIndex(this.scopedToolCache);
+    this.cacheRevision += 1;
+  }
+
+  private replaceInMemoryRegistry(
+    cache: Map<string, Map<string, OrgToolEntry>>,
+    expectedRevision: number,
+  ): boolean {
+    const ordered = new Map<string, Map<string, OrgToolEntry>>(
+      [...cache.entries()].sort(([a], [b]) => a.localeCompare(b)),
+    );
+    const index = this.buildSearchIndex(ordered);
+    if (this.cacheRevision !== expectedRevision) return false;
+    this.scopedToolCache = ordered;
+    this.bm25 = index;
+    this.cacheRevision += 1;
+    return true;
+  }
+
+  private registryWithoutEntity(entityPk: string): {
+    cache: Map<string, Map<string, OrgToolEntry>>;
+    index: BM25Index;
+    bucketsEvicted: number;
+  } {
+    const cache = new Map<string, Map<string, OrgToolEntry>>();
+    let bucketsEvicted = 0;
+    for (const [key, bucket] of this.scopedToolCache) {
+      if ([...bucket.values()].some((entry) => entry.entityPk === entityPk)) {
+        bucketsEvicted += 1;
+        continue;
+      }
+      cache.set(key, new Map(bucket));
+    }
+    return {
+      cache,
+      index: this.buildSearchIndex(cache),
+      bucketsEvicted,
+    };
+  }
+
+  private buildSearchIndex(
+    cache: Map<string, Map<string, OrgToolEntry>>,
+  ): BM25Index {
+    const index = new BM25Index();
     const indexed = new Set<string>();
-    const entries = [...this.scopedToolCache.values()]
+    const entries = [...cache.values()]
       .flatMap((bucket) => [...bucket.values()])
       .filter((entry) => entry.enabled && entry.dispatchable)
       .sort(entryOrder);
     for (const entry of entries) {
       if (indexed.has(entry.toolId)) continue;
       indexed.add(entry.toolId);
-      this.bm25.addDocument(
+      index.addDocument(
         entry.toolId,
         `${entry.toolName} ${entry.description} ${this.extractParamNames(entry.paramSchema)}`,
       );
     }
+    return index;
   }
 
   private isPersistedMappingDispatchable(input: {


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Closes the remaining WIN-127 invalidation gaps on top of the registry behavior already carried into `main` by the runtime cutover.

## Changes

- Makes entity credential revocation, tool-mapping deletion, and entity deletion one atomic Prisma transaction.
- Prepares cache/BM25 eviction without mutating live state, then publishes only after the transaction commits.
- Revision-fences registry rebuild and late registration publication so stale in-flight work cannot resurrect deleted entity tools.
- Rebuilds from canonical database state after a post-commit cache publication failure; returns success after successful recovery and throws only when recovery also fails.
- Keeps entity recreation valid by avoiding permanent tombstones.
- Makes BM25 equal-score ordering deterministic by document ID.

## Acceptance criteria

- Declarative registration replacement shrinks mappings, cache, and index.
- Entity deletion leaves zero persisted mappings, cache buckets, or BM25 documents.
- Failed transactions preserve the live entity's credentials, mappings, cache, and index.
- Rebuild replaces state and cannot republish a stale pre-delete snapshot.
- Search contains only dispatchable tools.
- Immediate-on-open WebSocket registration remains buffered and replayed after authentication.
- Equal-score BM25 results are insertion-order independent.

## Testing

- **PASS — final focused acceptance suite: 55 tests**
- **PASS — broader tool-gateway suite: 43 tests**
- **PASS — scoped auth deletion suite: 31 tests**
- **PASS — agent typecheck**
- **PASS — agent strict production build**
- **PASS — `git diff --check`**
- **PASS — final blocker-only review**

The broader auth suite has one unrelated baseline failure in `session-token.controller.test.ts`: its harness still mocks the pre-WIN-123 `accessKey.findFirst` shape while current `AuthService.verifyAccessKey` requires canonical `findMany` runtime authorization. The failing controller/guard files are unchanged by this six-file PR and the failure reproduces on current `main`.
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
