### PR TITLE
fix(mcp): bind entity dispatch to environment authority

### DIFF
--- a/apps/agent/src/auth/auth.service.test.ts
+++ b/apps/agent/src/auth/auth.service.test.ts
@@ -12,6 +12,7 @@ const SCOPE = {
 
 type BearerState = {
   id: string;
+  environmentId: string;
   revokedAt: Date | null;
   expiresAt: Date | null;
   entity: {
@@ -28,6 +29,7 @@ function makeSessionHarness() {
   } = {
     bearer: {
       id: "bearer_1",
+      environmentId: SCOPE.environmentId,
       revokedAt: null,
       expiresAt: new Date(Date.now() + 90_000),
       entity: {
@@ -152,6 +154,15 @@ describe("AuthService — clean bearer-backed session tokens", () => {
       60,
     );
     await expect(h.auth.validateSessionToken(token!)).resolves.toBeNull();
+  });
+
+  it("rejects a session whose environment differs from its PAT owner in the same project", async () => {
+    const h = makeSessionHarness();
+    h.state.bearer!.environmentId = "env_2";
+    const token = await h.auth.createEntitySessionToken(entityClaims(), "bearer_1", 60);
+
+    await expect(h.auth.validateSessionToken(token!)).resolves.toBeNull();
+    expect(h.prisma.mcpBearerToken.updateMany).not.toHaveBeenCalled();
   });
 
   it("accepts operator platform tokens without an entity authorization", async () => {

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -228,6 +228,7 @@ export class AuthService {
           where: { id: claims.authorizationId },
           select: {
             id: true,
+            environmentId: true,
             revokedAt: true,
             expiresAt: true,
             entity: {
@@ -242,6 +243,7 @@ export class AuthService {
           !authorization ||
           authorization.revokedAt ||
           (authorization.expiresAt && authorization.expiresAt.getTime() <= now.getTime()) ||
+          authorization.environmentId !== claims.environmentId ||
           authorization.entity.externalId !== claims.entityId ||
           authorization.entity.project.id !== claims.projectId ||
           authorization.entity.project.organizationId !== claims.organizationId
@@ -266,6 +268,7 @@ export class AuthService {
         const active = await this.prisma.mcpBearerToken.updateMany({
           where: {
             id: authorization.id,
+            environmentId: claims.environmentId,
             revokedAt: null,
             OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
           },

--- a/apps/agent/src/auth/scope.guard.test.ts
+++ b/apps/agent/src/auth/scope.guard.test.ts
@@ -48,6 +48,7 @@ function makeAuthHarness() {
   const state = {
     bearer: {
       id: "bearer_A",
+      environmentId: scope.environmentId,
       revokedAt: null as Date | null,
       expiresAt: new Date(Date.now() + 60_000) as Date | null,
       entity: {

--- a/apps/agent/src/auth/session-token.controller.test.ts
+++ b/apps/agent/src/auth/session-token.controller.test.ts
@@ -38,6 +38,7 @@ function makeHarness() {
   const state = {
     bearer: {
       id: "bearer-controller",
+      environmentId: SCOPE.environmentId,
       tokenHash: createHash("sha256").update(RAW_BEARER).digest("hex"),
       revokedAt: null as Date | null,
       expiresAt: new Date(Date.now() + 90_000) as Date | null,
@@ -72,6 +73,7 @@ function makeHarness() {
     },
   };
   const auth = new AuthService(prisma as any, {} as any);
+  vi.spyOn(auth, "verifyAccessKey").mockResolvedValue(null);
   return {
     state,
     prisma,
@@ -149,6 +151,23 @@ describe("SessionTokenController clean bearer mint", () => {
     await expect(
       h.controller.mint(SCOPE.entityId, `Bearer ${RAW_BEARER}`, body(overrides)),
     ).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a same-project environment that is not owned by the PAT", async () => {
+    const h = makeHarness();
+    h.state.environment = {
+      id: "environment-other",
+      project: { id: SCOPE.projectId, organizationId: SCOPE.organizationId },
+    };
+
+    await expect(
+      h.controller.mint(
+        SCOPE.entityId,
+        `Bearer ${RAW_BEARER}`,
+        body({ environmentId: "environment-other" }),
+      ),
+    ).rejects.toMatchObject({ status: 401 });
+    expect(h.prisma.mcpBearerToken.updateMany).not.toHaveBeenCalled();
   });
 
   it.each(["revoked", "expired", "revocation race"])(

--- a/apps/agent/src/auth/session-token.controller.ts
+++ b/apps/agent/src/auth/session-token.controller.ts
@@ -156,6 +156,7 @@ export class SessionTokenController {
       where: { tokenHash },
       select: {
         id: true,
+        environmentId: true,
         expiresAt: true,
         revokedAt: true,
         entity: {
@@ -174,6 +175,7 @@ export class SessionTokenController {
       !bearer ||
       bearer.revokedAt ||
       (bearer.expiresAt && bearer.expiresAt.getTime() <= now.getTime()) ||
+      bearer.environmentId !== body.environmentId ||
       bearer.entity.externalId !== entityId ||
       bearer.entity.project.id !== body.projectId ||
       bearer.entity.project.organizationId !== body.organizationId ||
@@ -186,6 +188,7 @@ export class SessionTokenController {
     const active = await this.prisma.mcpBearerToken.updateMany({
       where: {
         id: bearer.id,
+        environmentId: body.environmentId,
         revokedAt: null,
         OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
       },

--- a/apps/agent/src/mcp-platform/identity-resolver.service.test.ts
+++ b/apps/agent/src/mcp-platform/identity-resolver.service.test.ts
@@ -2,9 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Request } from "express";
 import { McpIdentityResolverService } from "./identity-resolver.service";
 
-function request(headers: Record<string, string> = {}): Request {
+function request(
+  headers: Record<string, string> = {},
+  query: Record<string, string> = {},
+): Request {
   return {
     headers,
+    query,
     socket: { remoteAddress: "127.0.0.1" },
   } as unknown as Request;
 }
@@ -17,7 +21,7 @@ function createPrisma() {
       update: vi.fn().mockResolvedValue({}),
       create: vi.fn(),
     },
-    entity: { findUnique: vi.fn() },
+    environment: { findMany: vi.fn() },
   } as any;
 }
 
@@ -40,6 +44,7 @@ describe("McpIdentityResolverService authentication order", () => {
     bearer.validate.mockResolvedValue({
       id: "token_1",
       entityPk: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:token_1",
       scopes: ["mcp:tools"],
     });
@@ -51,8 +56,13 @@ describe("McpIdentityResolverService authentication order", () => {
       ),
     ).resolves.toEqual({
       mcpUserId: "mcp:pat:token_1",
+      environmentId: "env_1",
       identityMode: "bearer",
-      metadata: { tokenId: "token_1", scopes: ["mcp:tools"] },
+      metadata: {
+        tokenId: "token_1",
+        scopes: ["mcp:tools"],
+        environmentId: "env_1",
+      },
     });
     expect(prisma.mcpAnonymousSession.create).not.toHaveBeenCalled();
   });
@@ -61,6 +71,7 @@ describe("McpIdentityResolverService authentication order", () => {
     const req = request();
     (req as any).mcpIdentity = {
       mcpUserId: "mcp:oidc:user",
+      environmentId: "env_1",
       identityMode: "oidc",
       metadata: { clientId: "client_1" },
     };
@@ -72,19 +83,18 @@ describe("McpIdentityResolverService authentication order", () => {
   });
 
   it("creates an environment-owned anonymous session only when enabled", async () => {
-    prisma.entity.findUnique.mockResolvedValue({
-      project: { environments: [{ id: "env_1" }] },
-    });
+    prisma.environment.findMany.mockResolvedValue([{ id: "env_1" }]);
     prisma.mcpAnonymousSession.create.mockImplementation(async ({ data }: any) => ({
       id: "session_1",
       mcpUserId: data.mcpUserId,
     }));
 
-    const result = await service.resolve(request(), "entity_1");
+    const result = await service.resolve(request({}, { environmentId: "env_1" }), "entity_1");
 
     expect(result).toMatchObject({
       identityMode: "anonymous",
-      metadata: { sessionId: "session_1" },
+      environmentId: "env_1",
+      metadata: { sessionId: "session_1", environmentId: "env_1" },
     });
     expect(prisma.mcpAnonymousSession.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
@@ -94,6 +104,34 @@ describe("McpIdentityResolverService authentication order", () => {
       }),
       select: { id: true, mcpUserId: true },
     });
+  });
+
+  it("requires an explicit environment when anonymous scope is ambiguous", async () => {
+    await expect(service.resolve(request(), "entity_1")).resolves.toEqual({
+      error: "environmentId is required for anonymous MCP authentication",
+      status: 400,
+    });
+    expect(prisma.mcpAnonymousSession.create).not.toHaveBeenCalled();
+  });
+
+  it("accepts a canonical anonymous environment selector and verifies ancestry", async () => {
+    prisma.environment.findMany.mockResolvedValue([{ id: "env_2" }]);
+    prisma.mcpAnonymousSession.create.mockResolvedValue({
+      id: "session_2",
+      mcpUserId: "mcp:anon:user",
+    });
+
+    const req = request();
+    (req as any).query = { environmentId: "env_2" };
+    const result = await service.resolve(req, "entity_1");
+    expect(result).toMatchObject({ environmentId: "env_2" });
+    expect(prisma.environment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          project: { entities: { some: { id: "entity_1" } } },
+        }),
+      }),
+    );
   });
 
   it("rejects anonymous and bearer credentials when their modes are disabled", async () => {

--- a/apps/agent/src/mcp-platform/identity-resolver.service.ts
+++ b/apps/agent/src/mcp-platform/identity-resolver.service.ts
@@ -9,6 +9,7 @@ import { randomUUID } from "crypto";
 
 export interface McpIdentityResult {
   mcpUserId: string;
+  environmentId: string;
   identityMode: "anonymous" | "oidc" | "bearer";
   metadata: Record<string, unknown>;
 }
@@ -66,8 +67,13 @@ export class McpIdentityResolverService {
       }
       return {
         mcpUserId: token.mcpUserId,
+        environmentId: token.environmentId,
         identityMode: "bearer",
-        metadata: { tokenId: token.id, scopes: token.scopes },
+        metadata: {
+          tokenId: token.id,
+          scopes: token.scopes,
+          environmentId: token.environmentId,
+        },
       };
     }
 
@@ -82,12 +88,22 @@ export class McpIdentityResolverService {
       if (!allowedModes.some((m) => m === "anonymous")) {
         return { error: "This entity requires authentication", status: 401 };
       }
-      // Mint or retrieve anonymous session
-      const result = await this.getOrCreateAnonSession(entityPk, req);
+      const environment = await this.resolveAnonymousEnvironment(entityPk, req);
+      if ("error" in environment) return environment;
+      // Mint or retrieve anonymous session in the explicitly resolved environment.
+      const result = await this.getOrCreateAnonSession(
+        entityPk,
+        environment.environmentId,
+        req,
+      );
       return {
         mcpUserId: result.mcpUserId,
+        environmentId: environment.environmentId,
         identityMode: "anonymous",
-        metadata: { sessionId: result.id },
+        metadata: {
+          sessionId: result.id,
+          environmentId: environment.environmentId,
+        },
       };
     }
 
@@ -96,13 +112,19 @@ export class McpIdentityResolverService {
 
   private async getOrCreateAnonSession(
     entityPk: string,
+    environmentId: string,
     req: Request,
   ): Promise<{ id: string; mcpUserId: string }> {
     // Check for existing anon session cookie/header
     const existingId = req.headers["x-mcp-anon-session"] as string | undefined;
     if (existingId) {
       const existing = await this.prisma.mcpAnonymousSession.findFirst({
-        where: { mcpUserId: existingId, entityId: entityPk, revokedAt: null },
+        where: {
+          mcpUserId: existingId,
+          entityId: entityPk,
+          environmentId,
+          revokedAt: null,
+        },
         select: { id: true, mcpUserId: true },
       });
       if (existing) {
@@ -116,25 +138,6 @@ export class McpIdentityResolverService {
 
     // Create new anon session
     const mcpUserId = `mcp:anon:${randomUUID().replace(/-/g, "")}`;
-    const entity = await this.prisma.entity.findUnique({
-      where: { id: entityPk },
-      select: {
-        project: {
-          select: {
-            environments: {
-              where: { archivedAt: null },
-              select: { id: true },
-              orderBy: { createdAt: "asc" },
-              take: 1,
-            },
-          },
-        },
-      },
-    });
-    const environmentId = entity?.project.environments[0]?.id;
-    if (!environmentId) {
-      throw new Error("Entity is not attached to an active environment");
-    }
     const session = await this.prisma.mcpAnonymousSession.create({
       data: {
         entityId: entityPk,
@@ -146,5 +149,34 @@ export class McpIdentityResolverService {
       select: { id: true, mcpUserId: true },
     });
     return session;
+  }
+
+  private async resolveAnonymousEnvironment(
+    entityPk: string,
+    req: Request,
+  ): Promise<{ environmentId: string } | McpIdentityRejectReason> {
+    const queryValue = (req.query as Record<string, unknown> | undefined)?.environmentId;
+    if (Array.isArray(queryValue)) {
+      return { error: "environmentId must be a single canonical id", status: 400 };
+    }
+    const requested = typeof queryValue === "string" && queryValue.trim()
+      ? queryValue.trim()
+      : undefined;
+    if (!requested) {
+      return { error: "environmentId is required for anonymous MCP authentication", status: 400 };
+    }
+    const environments = await this.prisma.environment.findMany({
+      where: {
+        id: requested,
+        archivedAt: null,
+        project: { entities: { some: { id: entityPk } } },
+      },
+      select: { id: true },
+      orderBy: { id: "asc" },
+      take: 1,
+    });
+    return environments[0]
+      ? { environmentId: environments[0].id }
+      : { error: "environmentId is not active for this entity", status: 403 };
   }
 }

--- a/apps/agent/src/mcp-platform/mcp-bearer-token.service.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-bearer-token.service.test.ts
@@ -7,11 +7,10 @@ const tokenHash = (raw: string) => createHash("sha256").update(raw).digest("hex"
 function createPrisma() {
   const prisma: any = {
     entity: {
-      findUnique: vi.fn().mockResolvedValue({
+      findFirst: vi.fn().mockResolvedValue({
         project: {
           id: "proj_1",
           organizationId: "org_1",
-          environments: [{ id: "env_1" }],
         },
       }),
     },
@@ -40,12 +39,13 @@ describe("McpBearerTokenService credential lifecycle", () => {
 
   it("mints only plt_ent_ credentials with a 90-day default and redacted evidence", async () => {
     const before = Date.now();
-    const minted = await service.generate("entity_1", "Claude", "user_1");
+    const minted = await service.generate("entity_1", "env_1", "Claude", "user_1");
 
     expect(minted.raw).toMatch(/^plt_ent_/);
     const create = prisma.mcpBearerToken.create.mock.calls[0][0];
     expect(create.data.id).toBe(minted.id);
     expect(create.data.mcpUserId).toBe(`mcp:pat:${minted.id}`);
+    expect(create.data.environmentId).toBe("env_1");
     expect(create.data.expiresAt.getTime()).toBeGreaterThanOrEqual(
       before + 90 * 24 * 60 * 60 * 1000
     );
@@ -56,7 +56,11 @@ describe("McpBearerTokenService credential lifecycle", () => {
         action: "mcp_bearer.mint",
         subjectType: "McpBearerToken",
         subjectId: minted.id,
-        after: { organizationId: "org_1", projectId: "proj_1" },
+        after: {
+          organizationId: "org_1",
+          projectId: "proj_1",
+          environmentId: "env_1",
+        },
         source: "entity_mcp",
       },
     });
@@ -67,7 +71,7 @@ describe("McpBearerTokenService credential lifecycle", () => {
 
   it("does not mint already-expired entity credentials", async () => {
     await expect(
-      service.generate("entity_1", "Claude", "user_1", {
+      service.generate("entity_1", "env_1", "Claude", "user_1", {
         expiresAt: new Date(Date.now() - 1),
       })
     ).rejects.toThrow(/expiresAt must be in the future/i);
@@ -84,6 +88,7 @@ describe("McpBearerTokenService credential lifecycle", () => {
       id: "token_1",
       tokenHash: tokenHash("plt_ent_valid"),
       entityId: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:token_1",
       scopes: ["mcp:tools"],
     });
@@ -91,6 +96,7 @@ describe("McpBearerTokenService credential lifecycle", () => {
     await expect(service.validate("plt_ent_valid")).resolves.toEqual({
       id: "token_1",
       entityPk: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:token_1",
       scopes: ["mcp:tools"],
     });
@@ -109,6 +115,7 @@ describe("McpBearerTokenService credential lifecycle", () => {
       id: "token_1",
       tokenHash: tokenHash("plt_ent_different"),
       entityId: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:token_1",
       scopes: ["mcp:tools"],
     });
@@ -122,6 +129,7 @@ describe("McpBearerTokenService credential lifecycle", () => {
       id: "token_1",
       tokenHash: tokenHash("plt_ent_valid"),
       entityId: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:token_1",
       scopes: ["mcp:tools"],
     });
@@ -137,8 +145,12 @@ describe("McpBearerTokenService credential lifecycle", () => {
       .mockResolvedValueOnce({ id: "token_1", revokedAt: new Date() });
     prisma.mcpBearerToken.updateMany.mockResolvedValue({ count: 1 });
 
-    await expect(service.revoke("token_1", "entity_1", "user_1")).resolves.toBe(true);
-    await expect(service.revoke("token_1", "entity_1", "user_1")).resolves.toBe(true);
+    await expect(
+      service.revoke("token_1", "entity_1", "env_1", "user_1"),
+    ).resolves.toBe(true);
+    await expect(
+      service.revoke("token_1", "entity_1", "env_1", "user_1"),
+    ).resolves.toBe(true);
 
     expect(prisma.adminAudit.create).toHaveBeenCalledTimes(1);
     expect(prisma.adminAudit.create).toHaveBeenCalledWith(

--- a/apps/agent/src/mcp-platform/mcp-bearer-token.service.ts
+++ b/apps/agent/src/mcp-platform/mcp-bearer-token.service.ts
@@ -33,32 +33,30 @@ export class McpBearerTokenService {
     return createHash("sha256").update(raw).digest("hex");
   }
 
-  private async auditScope(entityId: string): Promise<{
+  private async resolveScope(entityId: string, environmentId: string): Promise<{
     organizationId: string;
     projectId: string;
     environmentId: string;
-  }> {
-    const entity = await this.prisma.entity.findUnique({
-      where: { id: entityId },
+  } | null> {
+    const entity = await this.prisma.entity.findFirst({
+      where: {
+        id: entityId,
+        project: {
+          environments: {
+            some: { id: environmentId, archivedAt: null },
+          },
+        },
+      },
       select: {
         project: {
           select: {
             id: true,
             organizationId: true,
-            environments: {
-              where: { archivedAt: null },
-              select: { id: true },
-              orderBy: { createdAt: "asc" },
-              take: 1,
-            },
           },
         },
       },
     });
-    const environmentId = entity?.project.environments[0]?.id;
-    if (!entity || !environmentId) {
-      throw new Error("Entity is not attached to an active environment");
-    }
+    if (!entity) return null;
     return {
       organizationId: entity.project.organizationId,
       projectId: entity.project.id,
@@ -67,7 +65,7 @@ export class McpBearerTokenService {
   }
 
   private auditData(
-    scope: Awaited<ReturnType<McpBearerTokenService["auditScope"]>>,
+    scope: NonNullable<Awaited<ReturnType<McpBearerTokenService["resolveScope"]>>>,
     tokenId: string,
     action: "mint" | "use" | "revoke",
     actorUserId?: string,
@@ -81,6 +79,7 @@ export class McpBearerTokenService {
       after: {
         organizationId: scope.organizationId,
         projectId: scope.projectId,
+        environmentId: scope.environmentId,
       },
       source: "entity_mcp",
     } as const;
@@ -89,6 +88,7 @@ export class McpBearerTokenService {
   /** Generate a new PAT for an entity. Returns the raw token (shown once). */
   async generate(
     entityPk: string,
+    environmentId: string,
     label: string,
     createdBy: string,
     options: { scopes?: string[]; expiresAt?: Date; mcpUserId?: string } = {}
@@ -97,7 +97,10 @@ export class McpBearerTokenService {
     const tokenHash = McpBearerTokenService.hashToken(raw);
     const id = randomUUID();
     const mcpUserId = options.mcpUserId ?? `mcp:pat:${id}`;
-    const scope = await this.auditScope(entityPk);
+    const scope = await this.resolveScope(entityPk, environmentId);
+    if (!scope) {
+      throw new Error("Entity and environment do not share canonical project ancestry");
+    }
     const expiresAt = options.expiresAt ?? new Date(Date.now() + DEFAULT_TTL_MS);
     if (expiresAt.getTime() <= Date.now()) {
       throw new Error("expiresAt must be in the future");
@@ -107,6 +110,7 @@ export class McpBearerTokenService {
         data: {
           id,
           entityId: entityPk,
+          environmentId,
           tokenHash,
           label,
           mcpUserId,
@@ -126,11 +130,23 @@ export class McpBearerTokenService {
   async validate(raw: string): Promise<{
     id: string;
     entityPk: string;
+    environmentId: string;
     mcpUserId: string;
     scopes: string[];
   } | null> {
     if (!raw.startsWith(TOKEN_PREFIX)) return null;
     const tokenHash = McpBearerTokenService.hashToken(raw);
+    return this.validateHash(tokenHash);
+  }
+
+  /** Revalidate an SSE session without retaining the raw bearer in Redis. */
+  async validateHash(tokenHash: string): Promise<{
+    id: string;
+    entityPk: string;
+    environmentId: string;
+    mcpUserId: string;
+    scopes: string[];
+  } | null> {
     const row = await this.prisma.mcpBearerToken.findFirst({
       where: {
         tokenHash,
@@ -139,7 +155,8 @@ export class McpBearerTokenService {
       },
     });
     if (!row || !constantTimeHexEqual(row.tokenHash, tokenHash)) return null;
-    const scope = await this.auditScope(row.entityId);
+    const scope = await this.resolveScope(row.entityId, row.environmentId);
+    if (!scope) return null;
     const recorded = await this.prisma.$transaction(async (tx) => {
       const updated = await tx.mcpBearerToken.updateMany({
         where: {
@@ -156,13 +173,20 @@ export class McpBearerTokenService {
       return true;
     });
     if (!recorded) return null;
-    return { id: row.id, entityPk: row.entityId, mcpUserId: row.mcpUserId, scopes: row.scopes };
+    return {
+      id: row.id,
+      entityPk: row.entityId,
+      environmentId: row.environmentId,
+      mcpUserId: row.mcpUserId,
+      scopes: row.scopes,
+    };
   }
 
   /** List tokens for an entity (hashes not returned). */
-  async list(entityPk: string): Promise<
+  async list(entityPk: string, environmentId: string): Promise<
     Array<{
       id: string;
+      environmentId: string;
       label: string;
       mcpUserId: string;
       scopes: string[];
@@ -172,10 +196,15 @@ export class McpBearerTokenService {
       revokedAt: Date | null;
     }>
   > {
+    const scope = await this.resolveScope(entityPk, environmentId);
+    if (!scope) {
+      throw new Error("Entity and environment do not share canonical project ancestry");
+    }
     return this.prisma.mcpBearerToken.findMany({
-      where: { entityId: entityPk },
+      where: { entityId: entityPk, environmentId },
       select: {
         id: true,
+        environmentId: true,
         label: true,
         mcpUserId: true,
         scopes: true,
@@ -189,17 +218,23 @@ export class McpBearerTokenService {
   }
 
   /** Revoke a PAT by id, scoped to entityPk. */
-  async revoke(id: string, entityPk: string, revokedBy?: string): Promise<boolean> {
+  async revoke(
+    id: string,
+    entityPk: string,
+    environmentId: string,
+    revokedBy?: string,
+  ): Promise<boolean> {
     const existing = await this.prisma.mcpBearerToken.findFirst({
-      where: { id, entityId: entityPk },
+      where: { id, entityId: entityPk, environmentId },
       select: { id: true, revokedAt: true },
     });
     if (!existing) return false;
     if (existing.revokedAt) return true;
-    const scope = await this.auditScope(entityPk);
+    const scope = await this.resolveScope(entityPk, environmentId);
+    if (!scope) return false;
     await this.prisma.$transaction(async (tx) => {
       const updated = await tx.mcpBearerToken.updateMany({
-        where: { id, entityId: entityPk, revokedAt: null },
+        where: { id, entityId: entityPk, environmentId, revokedAt: null },
         data: { revokedAt: new Date() },
       });
       if (updated.count === 0) return;

--- a/apps/agent/src/mcp-platform/mcp-entity.controller.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-entity.controller.test.ts
@@ -16,21 +16,32 @@ const entityRow = {
 };
 
 function createHarness() {
-  const oauth = { verifyAccessToken: vi.fn() };
+  const oauth = {
+    verifyAccessToken: vi.fn(),
+    verifyAccessTokenHash: vi.fn(),
+  };
   const toolExecutor = { execute: vi.fn() };
   const toolRouter = {
     resolve: vi.fn(),
     visibleEntitiesForAgent: vi.fn().mockReturnValue([]),
   };
   const prisma: any = {
-    entity: { findFirst: vi.fn().mockResolvedValue(entityRow) },
+    entity: {
+      findFirst: vi.fn().mockResolvedValue(entityRow),
+      findUnique: vi.fn().mockResolvedValue(entityRow),
+    },
     environment: {
       findFirst: vi.fn().mockResolvedValue({ id: "env_1" }),
     },
     mcpAnonymousSession: { findFirst: vi.fn() },
   };
-  const redis = { incr: vi.fn().mockResolvedValue(1), expire: vi.fn() };
-  const bearer = { validate: vi.fn() };
+  const redis = {
+    incr: vi.fn().mockResolvedValue(1),
+    expire: vi.fn(),
+    get: vi.fn(),
+    publish: vi.fn(),
+  };
+  const bearer = { validate: vi.fn(), validateHash: vi.fn() };
   const identity = { resolve: vi.fn() };
   const acl = {
     getExposedPoliciesByName: vi.fn(),
@@ -54,6 +65,7 @@ function createHarness() {
     toolExecutor,
     toolRouter,
     prisma,
+    redis,
     bearer,
     identity,
     acl,
@@ -71,6 +83,7 @@ describe("McpEntityController full transport authentication", () => {
     h.bearer.validate.mockResolvedValue({
       id: "pat_1",
       entityPk: "entity_1",
+      environmentId: "env_1",
       mcpUserId: "mcp:pat:pat_1",
       scopes: ["mcp:tools"],
     });
@@ -111,19 +124,53 @@ describe("McpEntityController full transport authentication", () => {
     });
   });
 
+  it("accepts OAuth only in its authorized canonical environment", async () => {
+    h.oauth.verifyAccessToken.mockResolvedValue({
+      tokenHash: "hash",
+      clientId: "client_1",
+      userId: "operator_1",
+      mcpUserId: "mcp:oidc:user",
+      identityMode: "oidc",
+      scope: {
+        organizationId: "org_1",
+        projectId: "project_1",
+        environmentId: "env_1",
+      },
+      scopes: ["mcp:tools"],
+      expiresAt: new Date(Date.now() + 60_000),
+      entityPk: "entity_1",
+    });
+
+    await expect(
+      h.controller.authenticate("acme", "plt_oa_secret"),
+    ).resolves.toMatchObject({
+      token: {
+        entityPk: "entity_1",
+        environmentId: "env_1",
+        identityMode: "oidc",
+      },
+    });
+  });
+
   it("falls back to anonymous only when no bearer was supplied", async () => {
     h.identity.resolve.mockResolvedValue({
       mcpUserId: "mcp:anon:user",
+      environmentId: "env_1",
       identityMode: "anonymous",
-      metadata: { sessionId: "session_1" },
+      metadata: { sessionId: "session_1", environmentId: "env_1" },
     });
     h.prisma.mcpAnonymousSession.findFirst.mockResolvedValue({
       id: "session_1",
       environmentId: "env_1",
     });
 
+    h.prisma.environment.findFirst.mockResolvedValue({
+      id: "env_1",
+      project: { entities: [{ id: "entity_1" }] },
+    });
     const result = await h.controller.authenticate("acme", undefined, {
       headers: {},
+      query: { environmentId: "env_1" },
     });
 
     expect(result.token).toMatchObject({
@@ -131,6 +178,40 @@ describe("McpEntityController full transport authentication", () => {
       mcpUserId: "mcp:anon:user",
       identityMode: "anonymous",
       scopes: ["mcp:tools"],
+    });
+  });
+
+  it("never falls through an unrecognized bearer to anonymous", async () => {
+    h.oauth.verifyAccessToken.mockResolvedValue(null);
+
+    await expect(
+      h.controller.authenticate("acme", "not-a-supported-token", { headers: {} }),
+    ).resolves.toEqual({ error: "invalid or expired token", status: 401 });
+    expect(h.identity.resolve).not.toHaveBeenCalled();
+  });
+
+  it("rejects anonymous identity when the entity disables it", async () => {
+    h.prisma.entity.findUnique.mockResolvedValue({
+      ...entityRow,
+      mcpConfig: { ...entityRow.mcpConfig, identityMode: "bearer+oidc" },
+    });
+    h.prisma.environment.findFirst.mockResolvedValue({
+      id: "env_1",
+      project: { entities: [{ id: "entity_1" }] },
+    });
+    h.identity.resolve.mockResolvedValue({
+      error: "This entity requires authentication",
+      status: 401,
+    });
+
+    await expect(
+      h.controller.authenticate("acme", undefined, {
+        headers: {},
+        query: { environmentId: "env_1" },
+      }),
+    ).resolves.toEqual({
+      error: "This entity requires authentication",
+      status: 401,
     });
   });
 
@@ -176,5 +257,135 @@ describe("McpEntityController full transport authentication", () => {
     });
     expect(h.toolRouter.resolve).not.toHaveBeenCalled();
     expect(h.toolExecutor.execute).not.toHaveBeenCalled();
+  });
+
+  it("carries the entity-pinned route to the executor for same-name isolation", async () => {
+    h.acl.getExposedPoliciesByName.mockResolvedValue([]);
+    h.acl.filterByIdentity.mockImplementation((rows: unknown[]) => rows);
+    h.toolRouter.resolve.mockReturnValue({
+      ok: true,
+      entityPk: "entity_1",
+      entityId: "acme",
+      toolId: "tool_acme",
+      toolName: "calendar.create",
+      callbackUrl: "https://acme.example/tools",
+      paramSchema: { type: "object" },
+      category: "calendar",
+      matched: 1,
+    });
+    h.toolExecutor.execute.mockResolvedValue({
+      tool: "calendar.create",
+      status: "success",
+      result: "ok",
+      latencyMs: 1,
+    });
+
+    await h.controller.handleToolsCall(
+      1,
+      { name: "calendar.create", arguments: {} },
+      {
+        entityPk: "entity_1",
+        entityId: "acme",
+        organizationId: "org_1",
+        projectId: "project_1",
+        displayName: "Acme",
+        config: entityRow.mcpConfig,
+      },
+      {
+        clientId: "pat",
+        mcpUserId: "mcp:pat:pat_1",
+        entityPk: "entity_1",
+        environmentId: "env_1",
+        identityMode: "bearer",
+        scopes: ["mcp:tools"],
+      },
+    );
+
+    expect(h.toolExecutor.execute).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: "calendar.create" }),
+      expect.objectContaining({ environmentId: "env_1" }),
+      expect.objectContaining({ source: "mcp_client" }),
+      {
+        entityPk: "entity_1",
+        entityId: "acme",
+        toolId: "tool_acme",
+      },
+    );
+  });
+
+  it("revalidates the exact PAT environment on SSE messages", async () => {
+    const tokenHash = "a".repeat(64);
+    h.redis.get.mockResolvedValue(JSON.stringify({
+      entityIdSlug: "acme",
+      tokenHash,
+      token: {
+        tokenHash,
+        clientId: "pat",
+        mcpUserId: "mcp:pat:pat_1",
+        entityPk: "entity_1",
+        environmentId: "env_1",
+        identityMode: "bearer",
+        scopes: ["mcp:tools"],
+      },
+    }));
+    h.oauth.verifyAccessTokenHash.mockResolvedValue(null);
+    h.bearer.validateHash.mockResolvedValue({
+      id: "pat_1",
+      entityPk: "entity_1",
+      environmentId: "env_1",
+      mcpUserId: "mcp:pat:pat_1",
+      scopes: ["mcp:tools"],
+    });
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await h.controller.messages(
+      "acme",
+      "session_1",
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      res,
+    );
+
+    expect(h.bearer.validateHash).toHaveBeenCalledWith(tokenHash);
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(h.redis.publish).toHaveBeenCalledWith(
+      "platos:mcp:entity:sse:session_1",
+      JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }),
+    );
+  });
+
+  it("denies an SSE message when its PAT was revoked after connection", async () => {
+    const tokenHash = "b".repeat(64);
+    h.redis.get.mockResolvedValue(JSON.stringify({
+      entityIdSlug: "acme",
+      tokenHash,
+      token: {
+        tokenHash,
+        clientId: "pat",
+        mcpUserId: "mcp:pat:pat_1",
+        entityPk: "entity_1",
+        environmentId: "env_1",
+        identityMode: "bearer",
+        scopes: ["mcp:tools"],
+      },
+    }));
+    h.oauth.verifyAccessTokenHash.mockResolvedValue(null);
+    h.bearer.validateHash.mockResolvedValue(null);
+    const res = {
+      status: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+
+    await h.controller.messages(
+      "acme",
+      "session_1",
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(h.redis.publish).not.toHaveBeenCalled();
   });
 });

--- a/apps/agent/src/mcp-platform/mcp-entity.controller.ts
+++ b/apps/agent/src/mcp-platform/mcp-entity.controller.ts
@@ -145,6 +145,72 @@ export class McpEntityController {
     };
   }
 
+  private async loadEntityByPk(entityPk: string) {
+    if (!entityPk) return null;
+    const ent = await this.prisma.entity.findUnique({
+      where: { id: entityPk },
+      select: {
+        id: true,
+        externalId: true,
+        projectId: true,
+        displayName: true,
+        mcpConfig: true,
+        project: { select: { organizationId: true } },
+      },
+    });
+    if (!ent?.mcpConfig) return null;
+    return {
+      entityPk: ent.id,
+      entityId: ent.externalId,
+      organizationId: ent.project.organizationId,
+      projectId: ent.projectId,
+      displayName: ent.displayName,
+      config: {
+        enabled: ent.mcpConfig.enabled,
+        toolAllowlist: ent.mcpConfig.toolAllowlist ?? [],
+        rateLimitPerMinute: ent.mcpConfig.rateLimitPerMinute ?? 60,
+        identityMode: ent.mcpConfig.identityMode ?? "bearer",
+      },
+    };
+  }
+
+  private async loadAnonymousEntity(
+    entityIdSlug: string,
+    req: Request,
+  ): Promise<
+    | {
+        entity: NonNullable<Awaited<ReturnType<McpEntityController["loadEntityByPk"]>>>;
+        environmentId: string;
+      }
+    | { error: string; status: number }
+  > {
+    const raw = (req.query as Record<string, unknown> | undefined)?.environmentId;
+    if (Array.isArray(raw) || typeof raw !== "string" || !raw.trim()) {
+      return { error: "environmentId is required for anonymous MCP authentication", status: 400 } as const;
+    }
+    const environment = await this.prisma.environment.findFirst({
+      where: { id: raw.trim(), archivedAt: null, project: { archivedAt: null } },
+      select: {
+        id: true,
+        project: {
+          select: {
+            entities: {
+              where: { externalId: entityIdSlug },
+              select: { id: true },
+              take: 2,
+            },
+          },
+        },
+      },
+    });
+    if (!environment || environment.project.entities.length !== 1) {
+      return { error: "entity MCP not found in the requested environment", status: 404 } as const;
+    }
+    const entity = await this.loadEntityByPk(environment.project.entities[0]!.id);
+    if (!entity) return { error: "entity MCP not found", status: 404 } as const;
+    return { entity, environmentId: environment.id };
+  }
+
   /**
    * Authenticate + authorize an incoming MCP request. Returns the
    * resolved entity + bearer metadata or null if rejected.
@@ -168,15 +234,13 @@ export class McpEntityController {
       }
     | { error: string; status: number }
   > {
-    const entity = await this.loadEntity(entityIdSlug);
-    if (!entity) return { error: "entity MCP not found", status: 404 };
-    if (!entity.config.enabled) return { error: "entity MCP not enabled", status: 403 };
+    let entity: Awaited<ReturnType<McpEntityController["loadEntityByPk"]>> = null;
 
     // Two token systems are valid here:
     //   1. Bearer PATs (`plt_ent_*`) — minted via the webapp UI / the
     //      `entities.generate_mcp_token` MCP tool. Stored as
-    //      PlatosMcpBearerToken rows with sha256 hashes; entity-scoped only
-    //      (no environmentId). The intended use case is CI/CD or a single
+    //      PlatosMcpBearerToken rows with sha256 hashes; entity + environment
+    //      scoped. The intended use case is CI/CD or a single
     //      service-to-service integrator (e.g. an operator pasting the
     //      token into Claude Code as an HTTP MCP).
     //   2. OAuth 2.1 access tokens (`plt_oa_*`) — minted via the per-entity
@@ -203,36 +267,9 @@ export class McpEntityController {
     if (bearer?.startsWith("plt_ent_")) {
       const patRow = await this.bearerTokenService.validate(bearer);
       if (patRow) {
-        // PATs have no environmentId — they are entity-scoped only. Resolve
-        // the entity's PRODUCTION RuntimeEnvironment for the matrix lookup.
-        // This matches the typical "PAT for prod CI/CD" use case and lines
-        // up with the tool mappings the operator wired up in the dashboard.
-        // Fall back to ANY env owned by the project if there is no
-        // PRODUCTION row (very unusual — projects ship with PROD by default).
-        let environmentId = "";
-        try {
-          const prod = await this.prisma.environment.findFirst({
-            where: {
-              projectId: entity.projectId,
-              archivedAt: null,
-              slug: { in: ["prod", "production"] },
-            },
-            select: { id: true },
-          });
-          if (prod) environmentId = prod.id;
-          if (!environmentId) {
-            const any = await this.prisma.environment.findFirst({
-              where: { projectId: entity.projectId, archivedAt: null },
-              select: { id: true },
-              orderBy: { createdAt: "asc" },
-            });
-            if (any) environmentId = any.id;
-          }
-        } catch {
-          /* fall-through; emptyEnv reject below */
-        }
-        if (!environmentId) {
-          return { error: "could not resolve environment for PAT — entity has no runtime envs", status: 500 };
+        entity = await this.loadEntityByPk(patRow.entityPk);
+        if (!entity || entity.entityId !== entityIdSlug) {
+          return { error: "token not valid for this entity route", status: 403 };
         }
         // sha256(raw) — same hash McpBearerTokenService stored at mint time.
         const tokenHash = crypto.createHash("sha256").update(bearer).digest("hex");
@@ -241,7 +278,7 @@ export class McpEntityController {
           clientId: "pat",
           mcpUserId: patRow.mcpUserId,
           entityPk: patRow.entityPk,
-          environmentId,
+          environmentId: patRow.environmentId,
           organizationId: entity.organizationId,
           projectId: entity.projectId,
           identityMode: "bearer",
@@ -253,6 +290,13 @@ export class McpEntityController {
     if (!verified) {
       const oauthVerified = await this.oauth.verifyAccessToken(bearer);
       if (oauthVerified) {
+        if (!oauthVerified.entityPk) {
+          return { error: "token not valid for an entity MCP route", status: 403 };
+        }
+        entity = await this.loadEntityByPk(oauthVerified.entityPk);
+        if (!entity || entity.entityId !== entityIdSlug) {
+          return { error: "token not valid for this entity route", status: 403 };
+        }
         verified = {
           tokenHash: oauthVerified.tokenHash,
           clientId: oauthVerified.clientId,
@@ -273,7 +317,13 @@ export class McpEntityController {
       }
     }
 
+    if (!verified && bearer) return { error: "invalid or expired token", status: 401 };
+
     if (!verified && !bearer && req) {
+      const anonymousAuthority = await this.loadAnonymousEntity(entityIdSlug, req);
+      if ("error" in anonymousAuthority) return anonymousAuthority;
+      entity = anonymousAuthority.entity;
+      if (!entity.config.enabled) return { error: "entity MCP not enabled", status: 403 };
       const identity = await this.identityResolver.resolve(req, entity.entityPk);
       if ("error" in identity) return identity;
       if (identity.identityMode !== "anonymous") {
@@ -284,6 +334,7 @@ export class McpEntityController {
         where: {
           id: sessionId,
           entityId: entity.entityPk,
+          environmentId: identity.environmentId,
           revokedAt: null,
           environment: {
             projectId: entity.projectId,
@@ -298,7 +349,7 @@ export class McpEntityController {
         clientId: "anonymous",
         mcpUserId: identity.mcpUserId,
         entityPk: entity.entityPk,
-        environmentId: session.environmentId,
+        environmentId: identity.environmentId,
         organizationId: entity.organizationId,
         projectId: entity.projectId,
         identityMode: "anonymous",
@@ -307,6 +358,8 @@ export class McpEntityController {
     }
 
     if (!verified) return { error: "invalid or expired token", status: 401 };
+    if (!entity) return { error: "entity MCP not found", status: 404 };
+    if (!entity.config.enabled) return { error: "entity MCP not enabled", status: 403 };
 
     const allowedModes = entity.config.identityMode.split("+");
     if (!allowedModes.includes(verified.identityMode)) {
@@ -337,6 +390,18 @@ export class McpEntityController {
     }
     if (verified.projectId !== entity.projectId) {
       return { error: "token project does not match entity", status: 403 };
+    }
+    const environment = await this.prisma.environment.findFirst({
+      where: {
+        id: verified.environmentId,
+        projectId: entity.projectId,
+        archivedAt: null,
+        project: { organizationId: entity.organizationId },
+      },
+      select: { id: true },
+    });
+    if (!environment) {
+      return { error: "token environment does not match entity project", status: 403 };
     }
     return {
       entity,
@@ -620,12 +685,24 @@ export class McpEntityController {
     // hashing); we reconstruct the token metadata via the DB. Try the
     // OAuth access-token table first, then fall back to PlatosMcpBearerToken
     // (PAT path) so SSE clients using `plt_ent_*` tokens also work.
-    const oauthRow = await this.prisma.oAuthAccessToken.findUnique({
-      where: { tokenHash: parsed.tokenHash },
-      include: { client: { select: { clientId: true, entityId: true, deletedAt: true } } },
-    });
-    const entity = await this.loadEntity(entityIdSlug);
-    if (!entity || !entity.config.enabled) {
+    const oauthRow = await this.oauth.verifyAccessTokenHash(parsed.tokenHash);
+    const isAnonymous = parsed.tokenHash.startsWith("anonymous:");
+    const patRow = !isAnonymous && !oauthRow
+      ? await this.bearerTokenService.validateHash(parsed.tokenHash)
+      : null;
+    if (!isAnonymous && !oauthRow && !patRow) {
+      res.status(401).send("session token revoked or expired");
+      return;
+    }
+    const authoritativeEntityPk = oauthRow?.entityPk ?? patRow?.entityPk ?? parsed.token.entityPk;
+    const entity = authoritativeEntityPk
+      ? await this.loadEntityByPk(authoritativeEntityPk)
+      : null;
+    if (!entity || entity.entityId !== entityIdSlug) {
+      res.status(403).send("session token does not match entity route");
+      return;
+    }
+    if (!entity.config.enabled) {
       res.status(403).send("entity MCP not enabled");
       return;
     }
@@ -640,13 +717,17 @@ export class McpEntityController {
       scopes: string[];
     } | null = null;
 
-    if (parsed.tokenHash.startsWith("anonymous:")) {
+    if (isAnonymous) {
       const anonymousSession = await this.prisma.mcpAnonymousSession.findFirst({
         where: {
           id: parsed.tokenHash.slice("anonymous:".length),
           entityId: entity.entityPk,
           environmentId: parsed.token.environmentId,
           revokedAt: null,
+          environment: {
+            projectId: entity.projectId,
+            project: { organizationId: entity.organizationId },
+          },
         },
         select: { id: true },
       });
@@ -655,68 +736,65 @@ export class McpEntityController {
         return;
       }
       token = parsed.token;
-    } else if (oauthRow && !oauthRow.revokedAt && oauthRow.expiresAt.getTime() >= Date.now()) {
+    } else if (oauthRow) {
       if (
-        oauthRow.client.deletedAt ||
-        oauthRow.client.entityId !== entity.entityPk ||
-        oauthRow.environmentId !== parsed.token.environmentId
+        oauthRow.entityPk !== entity.entityPk ||
+        oauthRow.scope.organizationId !== entity.organizationId ||
+        oauthRow.scope.projectId !== entity.projectId ||
+        oauthRow.scope.environmentId !== parsed.token.environmentId
       ) {
         res.status(403).send("token not valid for this entity");
         return;
       }
-      token = { ...parsed.token, clientId: oauthRow.client.clientId };
+      token = {
+        tokenHash: oauthRow.tokenHash,
+        clientId: oauthRow.clientId,
+        mcpUserId: oauthRow.mcpUserId,
+        entityPk: entity.entityPk,
+        environmentId: oauthRow.scope.environmentId,
+        identityMode: oauthRow.identityMode,
+        scopes: oauthRow.scopes,
+      };
     } else {
-      // PAT path — look up by tokenHash in PlatosMcpBearerToken.
-      const patRow = await this.prisma.mcpBearerToken.findFirst({
-        where: {
-          tokenHash: parsed.tokenHash,
-          revokedAt: null,
-          OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }],
-        },
-      });
+      // PAT path — revalidate the exact persisted entity + environment owner.
       if (!patRow) {
         res.status(401).send("session token revoked or expired");
         return;
       }
-      if (patRow.entityId !== entity.entityPk) {
+      if (
+        patRow.entityPk !== entity.entityPk ||
+        patRow.environmentId !== parsed.token.environmentId
+      ) {
         res.status(403).send("token not valid for this entity");
         return;
       }
-      // Resolve PROD env (mirrors the PAT branch in authenticate()).
-      const prod = await this.prisma.environment.findFirst({
-        where: {
-          projectId: entity.projectId,
-          archivedAt: null,
-          slug: { in: ["prod", "production"] },
-        },
-        select: { id: true },
-      });
-      const fallback = prod
-        ? null
-        : await this.prisma.environment.findFirst({
-            where: { projectId: entity.projectId, archivedAt: null },
-            select: { id: true },
-            orderBy: { createdAt: "asc" },
-          });
-      const environmentId = prod?.id ?? fallback?.id ?? "";
-      if (!environmentId) {
-        res.status(500).send("could not resolve environment for PAT");
-        return;
-      }
-      // Stamp lastUsedAt — same fire-and-forget pattern as
-      // McpBearerTokenService.validate.
-      this.prisma.mcpBearerToken
-        .update({ where: { id: patRow.id }, data: { lastUsedAt: new Date() } })
-        .catch(() => undefined);
       token = {
-        tokenHash: patRow.tokenHash,
+        tokenHash: parsed.tokenHash,
         clientId: "pat",
         mcpUserId: patRow.mcpUserId,
         entityPk: entity.entityPk,
-        environmentId,
+        environmentId: patRow.environmentId,
         identityMode: "bearer",
-        scopes: (patRow.scopes as string[] | undefined) ?? [],
+        scopes: patRow.scopes,
       };
+    }
+
+    if (!entity.config.identityMode.split("+").includes(token.identityMode)) {
+      res.status(403).send(`${token.identityMode} identity is not enabled for this entity`);
+      return;
+    }
+    const environment = await this.prisma.environment.findFirst({
+      where: {
+        id: token.environmentId,
+        projectId: entity.projectId,
+        archivedAt: null,
+        project: { organizationId: entity.organizationId },
+      },
+      select: { id: true },
+    });
+    if (!environment) {
+      res.status(403).send("token environment does not match entity project");
+      return;
     }
 
     if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
@@ -1112,6 +1190,11 @@ export class McpEntityController {
         mcpClientId: token.clientId,
         endUserId,
       },
+      {
+        entityPk: route.entityPk,
+        entityId: route.entityId,
+        toolId: route.toolId,
+      },
     );
 
     if (result.status === "success") {
@@ -1154,7 +1237,10 @@ export class McpEntityController {
     if (entity.organizationId !== scope.organizationId) {
       throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
     }
-    const tokens = await this.bearerTokenService.list(entity.entityPk);
+    const tokens = await this.bearerTokenService.list(
+      entity.entityPk,
+      scope.environmentId,
+    );
     return { tokens };
   }
 
@@ -1175,6 +1261,7 @@ export class McpEntityController {
     const expiresAt = body.expiresIn ? new Date(Date.now() + body.expiresIn * 1000) : undefined;
     const result = await this.bearerTokenService.generate(
       entity.entityPk,
+      scope.environmentId,
       body.label ?? "PAT",
       scope.userId,
       { scopes: body.scopes, expiresAt },
@@ -1196,7 +1283,12 @@ export class McpEntityController {
     if (entity.organizationId !== scope.organizationId) {
       throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
     }
-    const ok = await this.bearerTokenService.revoke(tokenId, entity.entityPk, scope.userId);
+    const ok = await this.bearerTokenService.revoke(
+      tokenId,
+      entity.entityPk,
+      scope.environmentId,
+      scope.userId,
+    );
     return { revoked: ok };
   }
 

--- a/apps/agent/src/mcp-platform/tools/entities.ts
+++ b/apps/agent/src/mcp-platform/tools/entities.ts
@@ -1194,6 +1194,7 @@ export function buildEntityToolHandlers(deps: {
         const expiresAt = new Date(Date.now() + (expiresInDays ?? 90) * 86400_000);
         const minted = await bearerTokens.generate(
           entityPk,
+          scope.environmentId,
           label,
           scope.userId ?? "mcp:platform",
           {

--- a/apps/agent/src/mcp-platform/tools/mcp.ts
+++ b/apps/agent/src/mcp-platform/tools/mcp.ts
@@ -74,7 +74,7 @@ export function buildMcpToolHandlers(deps: {
         const now = Date.now();
         const allTokens = await Promise.all(
           (filtered as Array<{ id: string; entityId: string }>).map(async (e) => {
-            const rows = await bearerTokens.list(e.id);
+            const rows = await bearerTokens.list(e.id, scope.environmentId);
             return rows.map((r) => ({
               id: r.id,
               entityId: e.entityId,

--- a/apps/agent/src/oauth/oauth.controller.test.ts
+++ b/apps/agent/src/oauth/oauth.controller.test.ts
@@ -1,0 +1,97 @@
+import { HttpException } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import { OAuthController } from "./oauth.controller";
+
+const entity = {
+  id: "entity_1",
+  projectId: "project_1",
+  displayName: "Acme",
+  mcpConfig: { enabled: true, redirectUriAllowlist: [] },
+  project: {
+    organizationId: "org_1",
+    environments: [{ id: "env_1", slug: "prod" }],
+  },
+};
+
+const environment = {
+  id: "env_1",
+  project: {
+    id: "project_1",
+    organizationId: "org_1",
+    entities: [{
+      id: "entity_1",
+      displayName: "Acme",
+      mcpConfig: { enabled: true, redirectUriAllowlist: [] },
+    }],
+  },
+};
+
+function harness() {
+  const prisma = {
+    entity: { findFirst: vi.fn().mockResolvedValue(entity) },
+    environment: { findFirst: vi.fn().mockResolvedValue(environment) },
+  };
+  const oauth = {
+    findClient: vi.fn().mockResolvedValue({
+      entityPk: "entity_1",
+      redirectUris: ["https://client.example/callback"],
+    }),
+    effectiveScopes: vi.fn().mockResolvedValue(["mcp:tools"]),
+    createConsentTransaction: vi.fn().mockResolvedValue("plt_octx_opaque.signature"),
+  };
+  return {
+    prisma,
+    oauth,
+    controller: new OAuthController(oauth as any, prisma as any, {} as any),
+  };
+}
+
+describe("OAuthController entity environment contract", () => {
+  it("fails closed when discovery omits an ambiguous environment", async () => {
+    const h = harness();
+    const error = await h.controller.entityMetadata("acme", undefined).catch((caught) => caught);
+    expect(error).toBeInstanceOf(HttpException);
+    expect(error.getStatus()).toBe(404);
+  });
+
+  it("publishes one canonical environment on every entity OAuth endpoint", async () => {
+    const h = harness();
+    const metadata = await h.controller.entityMetadata("acme", "env_1");
+
+    expect(metadata).toMatchObject({
+      authorization_endpoint: expect.stringContaining("/authorize?environmentId=env_1"),
+      token_endpoint: expect.stringContaining("/token?environmentId=env_1"),
+      revocation_endpoint: expect.stringContaining("/revoke?environmentId=env_1"),
+      registration_endpoint: expect.stringContaining("/register?environmentId=env_1"),
+    });
+    expect(h.prisma.environment.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: "env_1", archivedAt: null }),
+      }),
+    );
+  });
+
+  it("propagates the canonical environment into consent", async () => {
+    const h = harness();
+    const res = { status: vi.fn().mockReturnThis(), json: vi.fn(), redirect: vi.fn() };
+
+    await h.controller.entityAuthorize(
+      "acme",
+      {} as any,
+      res as any,
+      "code",
+      "client_1",
+      "https://client.example/callback",
+      "mcp:tools",
+      "state_1",
+      "challenge_1",
+      "S256",
+      "env_1",
+    );
+
+    const consent = new URL(res.redirect.mock.calls[0]![1]);
+    expect(res.redirect).toHaveBeenCalledWith(302, expect.any(String));
+    expect(consent.searchParams.get("transaction")).toBe("plt_octx_opaque.signature");
+    expect([...consent.searchParams.keys()]).toEqual(["transaction"]);
+  });
+});

--- a/apps/agent/src/oauth/oauth.controller.ts
+++ b/apps/agent/src/oauth/oauth.controller.ts
@@ -20,7 +20,13 @@ import {
   PlatosSecretStore,
   authorizeEnvironmentService,
 } from "@platos/tenancy-database";
-import { OAuthError, OAuthService, OAUTH_ACCESS_TOKEN_TTL_SEC } from "./oauth.service";
+import {
+  ENTITY_MCP_SCOPES,
+  OAuthError,
+  OAuthService,
+  OAUTH_ACCESS_TOKEN_TTL_SEC,
+  PLATFORM_MCP_SCOPES,
+} from "./oauth.service";
 import { env } from "../shared/env";
 import {
   type ControlDatabaseClient,
@@ -66,6 +72,7 @@ export class OAuthController {
    */
   private async resolveEntityForMcp(
     entityIdSlug: string,
+    environmentId?: string,
   ): Promise<
     | {
         entityPk: string;
@@ -77,39 +84,36 @@ export class OAuthController {
       }
     | null
   > {
-    if (!entityIdSlug || typeof entityIdSlug !== "string") return null;
-    const ent = await this.prisma.entity.findFirst({
-      where: { externalId: entityIdSlug, project: { archivedAt: null } },
+    if (!entityIdSlug || typeof entityIdSlug !== "string" || !environmentId) return null;
+    const environment = await this.prisma.environment.findFirst({
+      where: {
+        id: environmentId,
+        archivedAt: null,
+        project: { archivedAt: null, organization: { archivedAt: null } },
+      },
       select: {
         id: true,
-        projectId: true,
-        displayName: true,
-        mcpConfig: true,
         project: {
           select: {
+            id: true,
             organizationId: true,
-            environments: {
-              where: { archivedAt: null },
-              select: { id: true, slug: true },
-              orderBy: { createdAt: "asc" },
+            entities: {
+              where: { externalId: entityIdSlug },
+              select: { id: true, displayName: true, mcpConfig: true },
+              take: 2,
             },
           },
         },
       },
     });
-    if (!ent) return null;
+    if (!environment || environment.project.entities.length !== 1) return null;
+    const ent = environment.project.entities[0]!;
     if (!ent.mcpConfig) return null;
     if (!ent.mcpConfig.enabled) return null;
-    const environments = ent.project.environments;
-    const environment =
-      environments.find((candidate) =>
-        ["prod", "production"].includes(candidate.slug.toLowerCase()),
-      ) ?? environments[0];
-    if (!environment) return null;
     return {
       entityPk: ent.id,
-      organizationId: ent.project.organizationId,
-      projectId: ent.projectId,
+      organizationId: environment.project.organizationId,
+      projectId: environment.project.id,
       environmentId: environment.id,
       displayName: ent.displayName,
       config: ent.mcpConfig,
@@ -138,7 +142,7 @@ export class OAuthController {
         "client_secret_post",
         "none",
       ],
-      scopes_supported: ["mcp:read", "mcp:write"],
+      scopes_supported: [...PLATFORM_MCP_SCOPES],
     };
   }
 
@@ -168,7 +172,7 @@ export class OAuthController {
           ? { tokenEndpointAuthMethod: body.token_endpoint_auth_method }
           : {}),
         ...(body?.grant_types ? { grantTypes: body.grant_types } : {}),
-        scope: body?.scope ?? "mcp:read mcp:write",
+        scope: body?.scope,
         ...(body?.organization_id ? { organizationId: body.organization_id } : {}),
         ...(body?.registered_by_user_id
           ? { registeredByUserId: body.registered_by_user_id }
@@ -206,6 +210,7 @@ export class OAuthController {
     @Query("state") state: string | undefined,
     @Query("code_challenge") codeChallenge: string | undefined,
     @Query("code_challenge_method") codeChallengeMethod: string | undefined,
+    @Query("environment_id") environmentId: string | undefined,
   ): Promise<void> {
     // Parameter validation — per RFC 6749 §4.1.2.1 errors that apply to
     // redirect_uri itself MUST NOT redirect; other errors redirect back.
@@ -254,6 +259,47 @@ export class OAuthController {
       return;
     }
 
+    if (!environmentId) {
+      sendErrorRedirect("invalid_request", "environment_id is required");
+      return;
+    }
+    const environment = await this.prisma.environment.findFirst({
+      where: {
+        id: environmentId,
+        archivedAt: null,
+        project: { archivedAt: null, organizationId: client.organizationId },
+      },
+      select: { id: true, project: { select: { id: true, organizationId: true } } },
+    });
+    if (!environment) {
+      sendErrorRedirect("invalid_scope", "environment_id is not valid for this client");
+      return;
+    }
+
+    let transaction: string;
+    try {
+      const effectiveScopes = await this.oauth.effectiveScopes(clientId, scope);
+      transaction = await this.oauth.createConsentTransaction({
+        clientId,
+        redirectUri,
+        codeChallenge,
+        codeChallengeMethod: "S256",
+        scopes: effectiveScopes,
+        scopeTuple: {
+          organizationId: environment.project.organizationId,
+          projectId: environment.project.id,
+          environmentId: environment.id,
+        },
+        ...(state ? { state } : {}),
+      });
+    } catch (error) {
+      if (error instanceof OAuthError) {
+        sendErrorRedirect(error.code, error.message);
+        return;
+      }
+      throw error;
+    }
+
     // Bounce to the webapp consent screen. The loader reads these query
     // params + requireUserId, renders the approval card, then POSTs back
     // to `/oauth/authorize/callback` on this controller.
@@ -262,13 +308,38 @@ export class OAuthController {
       env.PLATOS_WEBAPP_ADMIN_URL ??
       "http://localhost:3030";
     const consentUrl = new URL("/oauth/consent", webappBase);
-    consentUrl.searchParams.set("client_id", clientId);
-    consentUrl.searchParams.set("redirect_uri", redirectUri);
-    consentUrl.searchParams.set("code_challenge", codeChallenge);
-    consentUrl.searchParams.set("code_challenge_method", codeChallengeMethod ?? "S256");
-    if (scope) consentUrl.searchParams.set("scope", scope);
-    if (state) consentUrl.searchParams.set("state", state);
+    consentUrl.searchParams.set("transaction", transaction);
     res.redirect(302, consentUrl.toString());
+  }
+
+  @Get("oauth/consent")
+  async inspectConsent(@Query("transaction") transaction: string | undefined) {
+    if (!transaction) throw new HttpException("transaction required", HttpStatus.BAD_REQUEST);
+    const row = await this.oauth.inspectConsentTransaction(transaction);
+    if (!row) throw new HttpException("consent transaction invalid or expired", HttpStatus.GONE);
+    return {
+      transaction,
+      flow: row.entityId
+        ? row.entity?.mcpConfig?.identityMode?.split("+").includes("oidc")
+          ? "entity_oidc"
+          : row.entity?.mcpConfig?.identityMode?.split("+").includes("anonymous")
+            ? "entity_anonymous"
+            : "entity_bearer"
+        : "platform",
+      client: {
+        clientId: row.client.clientId,
+        clientName: row.client.clientName,
+        redirectUri: row.redirectUri,
+      },
+      entity: row.entityId && row.entity ? {
+        entityPk: row.entityId,
+        entityId: row.entity.externalId,
+        displayName: row.entity.displayName,
+        branding: row.entity.mcpConfig?.branding ?? null,
+      } : null,
+      environment: row.environment,
+      effectiveScopes: row.scopes,
+    };
   }
 
   /**
@@ -281,95 +352,52 @@ export class OAuthController {
    */
   @Post("oauth/authorize/callback")
   async authorizeCallback(
-    @Headers("x-platos-consent-signature") signature: string | undefined,
+    @Headers("x-platos-internal-token") internalToken: string | undefined,
     @Body()
     body: {
-      clientId: string;
-      redirectUri: string;
+      transaction: string;
       userId: string;
-      organizationId: string;
-      projectId: string;
-      environmentId: string;
-      codeChallenge: string;
-      codeChallengeMethod?: string;
-      scope?: string;
-      state?: string;
-      /** Unix seconds; used to bound HMAC replay window. */
-      ts: number;
+      action?: "approve" | "deny";
     },
   ): Promise<{ redirectTo: string }> {
-    if (!signature) {
-      throw new HttpException("consent signature required", HttpStatus.UNAUTHORIZED);
-    }
-    const secret = env.SESSION_SECRET;
-    if (!secret) {
+    if (!env.PLATOS_INTERNAL_AUTH_TOKEN) {
       throw new HttpException(
-        "SESSION_SECRET not configured",
+        "internal consent authentication not configured",
         HttpStatus.SERVICE_UNAVAILABLE,
       );
     }
-    if (!body.ts || Math.abs(Date.now() / 1000 - body.ts) > 300) {
-      throw new HttpException("consent timestamp stale", HttpStatus.UNAUTHORIZED);
+    const provided = Buffer.from(internalToken ?? "");
+    const expected = Buffer.from(env.PLATOS_INTERNAL_AUTH_TOKEN);
+    if (provided.length !== expected.length || !crypto.timingSafeEqual(provided, expected)) {
+      throw new HttpException("invalid internal consent authentication", HttpStatus.UNAUTHORIZED);
     }
-    // BUG-19: use static crypto import (already imported at module level).
-    const canonical = [
-      body.clientId,
-      body.redirectUri,
-      body.userId,
-      body.organizationId,
-      body.projectId,
-      body.environmentId,
-      body.codeChallenge,
-      body.scope ?? "",
-      body.state ?? "",
-      String(body.ts),
-    ].join("\n");
-    const expected = crypto
-      .createHmac("sha256", secret)
-      .update(canonical)
-      .digest("base64url");
-    const providedBuf = Buffer.from(signature, "utf8");
-    const expectedBuf = Buffer.from(expected, "utf8");
-    if (
-      providedBuf.length !== expectedBuf.length ||
-      !crypto.timingSafeEqual(providedBuf, expectedBuf)
-    ) {
-      throw new HttpException("invalid consent signature", HttpStatus.UNAUTHORIZED);
-    }
-
-    const client = await this.oauth.findClient(body.clientId);
-    if (!client) {
-      throw new HttpException("unknown client", HttpStatus.BAD_REQUEST);
-    }
-    if (!client.redirectUris.includes(body.redirectUri)) {
-      throw new HttpException("redirect_uri not registered", HttpStatus.BAD_REQUEST);
-    }
-
-    const scopes = (body.scope ?? "mcp:read mcp:write").split(/\s+/).filter(Boolean);
 
     try {
+      const consent = await this.oauth.consumeConsentTransaction(body.transaction);
+      if (body.action === "deny") {
+        const denied = new URL(consent.redirectUri);
+        denied.searchParams.set("error", "access_denied");
+        if (consent.state) denied.searchParams.set("state", consent.state);
+        return { redirectTo: denied.toString() };
+      }
       const { code } = await this.oauth.issueAuthCode({
-        clientId: body.clientId,
+        clientId: consent.client.clientId,
         userId: body.userId,
         scopeTuple: {
-          organizationId: body.organizationId,
-          projectId: body.projectId,
-          environmentId: body.environmentId,
+          organizationId: consent.organizationId,
+          projectId: consent.projectId,
+          environmentId: consent.environmentId,
         },
-        codeChallenge: body.codeChallenge,
+        codeChallenge: consent.codeChallenge,
         codeChallengeMethod: "S256",
-        redirectUri: body.redirectUri,
-        scopes,
-        // PIFSP-21 wave-1-caveat: thread the client's entityPk so the auth
-        // code (and the access token minted from it) carries the entity pin.
-        // Without this, entity-scoped MCP tokens have null entityPk and the
-        // McpEntityController rejects them with 403.
-        ...(client.entityPk ? { entityPk: client.entityPk } : {}),
+        redirectUri: consent.redirectUri,
+        scopes: consent.scopes,
+        ...(consent.entityId ? { entityPk: consent.entityId } : {}),
       });
 
-      const redirect = new URL(body.redirectUri);
+      const redirect = new URL(consent.redirectUri);
       redirect.searchParams.set("code", code);
-      if (body.state) redirect.searchParams.set("state", body.state);
+      if (consent.state) redirect.searchParams.set("state", consent.state);
       return { redirectTo: redirect.toString() };
     } catch (err) {
       if (err instanceof OAuthError) {
@@ -635,8 +663,11 @@ export class OAuthController {
   // ═════════════════════════════════════════════════════════════════════
 
   @Get(".well-known/oauth-authorization-server/entity/:entityId")
-  async entityMetadata(@Param("entityId") entityIdSlug: string) {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+  async entityMetadata(
+    @Param("entityId") entityIdSlug: string,
+    @Query("environmentId") environmentId: string | undefined,
+  ) {
+    const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: `MCP not enabled for entity '${entityIdSlug}'` },
@@ -645,12 +676,13 @@ export class OAuthController {
     }
     const issuer = this.issuerUrl;
     const base = `${issuer}/oauth/entity/${encodeURIComponent(entityIdSlug)}`;
+    const environmentQuery = `?environmentId=${encodeURIComponent(ent.environmentId)}`;
     return {
       issuer,
-      authorization_endpoint: `${base}/authorize`,
-      token_endpoint: `${base}/token`,
-      revocation_endpoint: `${base}/revoke`,
-      registration_endpoint: `${base}/register`,
+      authorization_endpoint: `${base}/authorize${environmentQuery}`,
+      token_endpoint: `${base}/token${environmentQuery}`,
+      revocation_endpoint: `${base}/revoke${environmentQuery}`,
+      registration_endpoint: `${base}/register${environmentQuery}`,
       introspection_endpoint: `${issuer}/oauth/introspect`,
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
@@ -660,7 +692,7 @@ export class OAuthController {
         "client_secret_post",
         "none",
       ],
-      scopes_supported: ["mcp:tools"],
+      scopes_supported: [...ENTITY_MCP_SCOPES],
       // Non-standard hint so MCP clients can render the entity's name.
       "platos:entity_id": entityIdSlug,
       "platos:entity_display_name": ent.displayName,
@@ -671,6 +703,7 @@ export class OAuthController {
   @HttpCode(HttpStatus.CREATED)
   async entityRegister(
     @Param("entityId") entityIdSlug: string,
+    @Query("environmentId") environmentId: string | undefined,
     @Body()
     body: {
       client_name?: string;
@@ -680,7 +713,7 @@ export class OAuthController {
       scope?: string;
     },
   ) {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
@@ -714,7 +747,7 @@ export class OAuthController {
           ? { tokenEndpointAuthMethod: body.token_endpoint_auth_method }
           : {}),
         ...(body?.grant_types ? { grantTypes: body.grant_types } : {}),
-        scope: body?.scope ?? "mcp:tools",
+        scope: body?.scope,
         organizationId: ent.organizationId,
         entityPk: ent.entityPk,
       });
@@ -745,8 +778,9 @@ export class OAuthController {
     @Query("state") state: string | undefined,
     @Query("code_challenge") codeChallenge: string | undefined,
     @Query("code_challenge_method") codeChallengeMethod: string | undefined,
+    @Query("environmentId") environmentId: string | undefined,
   ): Promise<void> {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       res.status(404).json({
         error: "not_found",
@@ -807,21 +841,35 @@ export class OAuthController {
       return;
     }
 
+    let transaction: string;
+    try {
+      const effectiveScopes = await this.oauth.effectiveScopes(clientId, scope);
+      transaction = await this.oauth.createConsentTransaction({
+        clientId,
+        redirectUri,
+        codeChallenge,
+        codeChallengeMethod: "S256",
+        scopes: effectiveScopes,
+        scopeTuple: {
+          organizationId: ent.organizationId,
+          projectId: ent.projectId,
+          environmentId: ent.environmentId,
+        },
+        entityPk: ent.entityPk,
+        ...(state ? { state } : {}),
+      });
+    } catch (error) {
+      if (error instanceof OAuthError) {
+        sendErrorRedirect(error.code, error.message);
+        return;
+      }
+      throw error;
+    }
+
     const webappBase =
       env.APP_ORIGIN ?? env.PLATOS_WEBAPP_ADMIN_URL ?? "http://localhost:3030";
     const consentUrl = new URL("/oauth/consent", webappBase);
-    consentUrl.searchParams.set("client_id", clientId);
-    consentUrl.searchParams.set("redirect_uri", redirectUri);
-    consentUrl.searchParams.set("code_challenge", codeChallenge);
-    consentUrl.searchParams.set("code_challenge_method", codeChallengeMethod ?? "S256");
-    // PIFSP-21 — carry entity context to the consent screen so it can
-    // pre-pin org/project/env + render branding without asking the user.
-    consentUrl.searchParams.set("entity_id", entityIdSlug);
-    consentUrl.searchParams.set("entity_pk", ent.entityPk);
-    consentUrl.searchParams.set("organization_id", ent.organizationId);
-    consentUrl.searchParams.set("project_id", ent.projectId);
-    if (scope) consentUrl.searchParams.set("scope", scope);
-    if (state) consentUrl.searchParams.set("state", state);
+    consentUrl.searchParams.set("transaction", transaction);
     res.redirect(302, consentUrl.toString());
   }
 
@@ -839,15 +887,17 @@ export class OAuthController {
     @Res() res: Response,
     @Body()
     body: {
-      client_id?: string;
-      redirect_uri?: string;
-      code_challenge?: string;
-      code_challenge_method?: string;
-      state?: string;
-      scope?: string;
+      transaction?: string;
     },
   ): Promise<void> {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const consent = body.transaction
+      ? await this.oauth.inspectConsentTransaction(body.transaction)
+      : null;
+    if (!consent || !consent.entityId || consent.entity?.externalId !== entityIdSlug) {
+      res.status(400).json({ error: "invalid consent transaction" });
+      return;
+    }
+    const ent = await this.resolveEntityForMcp(entityIdSlug, consent.environmentId);
     if (!ent) {
       res.status(404).json({ error: "not_found" });
       return;
@@ -868,15 +918,7 @@ export class OAuthController {
       return;
     }
 
-    const { client_id, redirect_uri, code_challenge, state } = body;
-    if (!client_id || !redirect_uri || !code_challenge) {
-      res.status(400).json({ error: "client_id, redirect_uri, code_challenge required" });
-      return;
-    }
-
-    // BUG-5: verify client_id exists and is pinned to this entity; verify redirect_uri
-    // is registered for the client — same checks entityAuthorize performs.
-    const anonClient = await this.oauth.findClient(client_id);
+    const anonClient = await this.oauth.findClient(consent.client.clientId);
     if (!anonClient) {
       res.status(400).json({ error: "invalid_client", error_description: "unknown client_id" });
       return;
@@ -886,12 +928,15 @@ export class OAuthController {
       res.status(400).json({ error: "invalid_client", error_description: "client is not registered for this entity" });
       return;
     }
-    if (!anonClient.redirectUris.includes(redirect_uri)) {
-      res.status(400).json({ error: "invalid_redirect_uri", error_description: "redirect_uri not registered for this client" });
+    let consumed;
+    try {
+      consumed = await this.oauth.consumeConsentTransaction(body.transaction!);
+    } catch {
+      res.status(400).json({ error: "consent transaction expired or already consumed" });
       return;
     }
 
-    // Mint anon session
+    // Mint anon session only after atomically claiming the one-time consent.
     // BUG-19: use the static top-level crypto import instead of dynamic require().
     const mcpUserId = `mcp:anon:${crypto.randomUUID().replace(/-/g, "")}`;
     const anonymousSession = await this.prisma.mcpAnonymousSession.create({
@@ -906,24 +951,24 @@ export class OAuthController {
 
     // Issue authcode for the anon user
     const { code } = await this.oauth.issueAuthCode({
-      clientId: client_id,
+      clientId: consumed.client.clientId,
       userId: anonClient.registeredByUserId,
       scopeTuple: {
         organizationId: ent.organizationId,
         projectId: ent.projectId,
         environmentId: ent.environmentId,
       },
-      codeChallenge: code_challenge,
+      codeChallenge: consumed.codeChallenge,
       codeChallengeMethod: "S256",
-      redirectUri: redirect_uri,
-      scopes: (body.scope ?? "mcp:tools").split(" "),
+      redirectUri: consumed.redirectUri,
+      scopes: consumed.scopes,
       entityPk: ent.entityPk,
       mcpIdentity: { kind: "anonymous", sessionId: anonymousSession.id },
     });
 
-    const redirectUrl = new URL(redirect_uri);
+    const redirectUrl = new URL(consumed.redirectUri);
     redirectUrl.searchParams.set("code", code);
-    if (state) redirectUrl.searchParams.set("state", state);
+    if (consumed.state) redirectUrl.searchParams.set("state", consumed.state);
     res.redirect(302, redirectUrl.toString());
   }
 
@@ -936,6 +981,7 @@ export class OAuthController {
   @Post("oauth/entity/:entityId/token")
   async entityToken(
     @Param("entityId") entityIdSlug: string,
+    @Query("environmentId") environmentId: string | undefined,
     @Headers("authorization") authorization: string | undefined,
     @Body()
     body: {
@@ -948,7 +994,7 @@ export class OAuthController {
       refresh_token?: string;
     },
   ) {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
@@ -1002,6 +1048,11 @@ export class OAuthController {
           code: body.code,
           codeVerifier: body.code_verifier,
           redirectUri: body.redirect_uri,
+          expectedScope: {
+            organizationId: ent.organizationId,
+            projectId: ent.projectId,
+            environmentId: ent.environmentId,
+          },
         });
         return {
           access_token: result.accessToken,
@@ -1018,6 +1069,11 @@ export class OAuthController {
         const result = await this.oauth.exchangeRefreshToken({
           clientId,
           refreshToken: body.refresh_token,
+          expectedScope: {
+            organizationId: ent.organizationId,
+            projectId: ent.projectId,
+            environmentId: ent.environmentId,
+          },
         });
         return {
           access_token: result.accessToken,
@@ -1045,6 +1101,7 @@ export class OAuthController {
   @HttpCode(HttpStatus.OK)
   async entityRevoke(
     @Param("entityId") entityIdSlug: string,
+    @Query("environmentId") environmentId: string | undefined,
     @Headers("authorization") authorization: string | undefined,
     @Body()
     body: {
@@ -1054,7 +1111,7 @@ export class OAuthController {
       client_secret?: string;
     },
   ) {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
@@ -1099,7 +1156,11 @@ export class OAuthController {
       }
     }
     if (body?.token) {
-      await this.oauth.revokeToken(body.token, clientId);
+      await this.oauth.revokeToken(body.token, clientId, {
+        organizationId: ent.organizationId,
+        projectId: ent.projectId,
+        environmentId: ent.environmentId,
+      });
     }
     return { ok: true };
   }
@@ -1137,14 +1198,16 @@ export class OAuthController {
     @Param("entityId") entityIdSlug: string,
     @Req() _req: Request,
     @Res() res: Response,
-    @Query("client_id") clientId: string | undefined,
-    @Query("redirect_uri") redirectUri: string | undefined,
-    @Query("code_challenge") codeChallenge: string | undefined,
-    @Query("code_challenge_method") codeChallengeMethod: string | undefined,
-    @Query("scope") scope: string | undefined,
-    @Query("state") state: string | undefined,
+    @Query("transaction") transaction: string | undefined,
   ): Promise<void> {
-    const ent = await this.resolveEntityForMcp(entityIdSlug);
+    const consent = transaction
+      ? await this.oauth.inspectConsentTransaction(transaction)
+      : null;
+    if (!consent || !consent.entityId || consent.entity?.externalId !== entityIdSlug) {
+      res.status(400).json({ error: "invalid consent transaction" });
+      return;
+    }
+    const ent = await this.resolveEntityForMcp(entityIdSlug, consent.environmentId);
     if (!ent) {
       res.status(404).json({ error: "entity MCP not enabled" });
       return;
@@ -1159,12 +1222,7 @@ export class OAuthController {
       return;
     }
 
-    if (!clientId || !redirectUri || !codeChallenge) {
-      res.status(400).json({ error: "client_id, redirect_uri, code_challenge required" });
-      return;
-    }
-
-    const client = await this.oauth.findClient(clientId);
+    const client = await this.oauth.findClient(consent.client.clientId);
     if (!client || (client as any).entityPk !== ent.entityPk) {
       res.status(400).json({ error: "invalid_client" });
       return;
@@ -1183,13 +1241,7 @@ export class OAuthController {
     // Format: base64url(json) + "." + HMAC-SHA256(base64url(json), secret)
     const callbackUrl = `${this.issuerUrl}/oauth/entity/${encodeURIComponent(entityIdSlug)}/oidc-callback`;
     const statePayload = {
-      entityId: entityIdSlug,
-      clientId,
-      redirectUri,
-      codeChallenge,
-      codeChallengeMethod: codeChallengeMethod ?? "S256",
-      scope: scope ?? "mcp:tools",
-      originalState: state ?? "",
+      transaction,
       entityPkceVerifier,
       callbackUrl,
       ts: Math.floor(Date.now() / 1000),
@@ -1245,11 +1297,15 @@ export class OAuthController {
       if (signedState) {
         const sp = this.verifyAndDecodeState(signedState);
         if (sp) {
-          const errUrl = new URL(sp.redirectUri);
-          errUrl.searchParams.set("error", entityError);
-          if (sp.originalState) errUrl.searchParams.set("state", sp.originalState);
-          res.redirect(302, errUrl.toString());
-          return;
+          const consent = await this.oauth.inspectConsentTransaction(sp.transaction);
+          if (consent) {
+            await this.oauth.consumeConsentTransaction(sp.transaction).catch(() => undefined);
+            const errUrl = new URL(consent.redirectUri);
+            errUrl.searchParams.set("error", entityError);
+            if (consent.state) errUrl.searchParams.set("state", consent.state);
+            res.redirect(302, errUrl.toString());
+            return;
+          }
         }
       }
       res.status(400).json({ error: entityError });
@@ -1267,7 +1323,19 @@ export class OAuthController {
       return;
     }
 
-    const ent = await this.resolveEntityForMcp(sp.entityId);
+    const consent = await this.oauth.inspectConsentTransaction(sp.transaction);
+    if (!consent || !consent.entityId || consent.entity?.externalId !== entityIdSlug) {
+      res.status(400).json({ error: "invalid_state", error_description: "consent transaction expired or consumed" });
+      return;
+    }
+    let consumed;
+    try {
+      consumed = await this.oauth.consumeConsentTransaction(sp.transaction);
+    } catch {
+      res.status(400).json({ error: "invalid_state", error_description: "consent transaction already consumed" });
+      return;
+    }
+    const ent = await this.resolveEntityForMcp(entityIdSlug, consent.environmentId);
     if (!ent) {
       res.status(404).json({ error: "entity MCP not enabled" });
       return;
@@ -1283,10 +1351,10 @@ export class OAuthController {
     // BUG-3: validate tokenUrl to prevent SSRF via operator-supplied config.
     const tokenUrlValidation = await validatePublicUrl(providerCfg.tokenUrl);
     if (!tokenUrlValidation.ok) {
-      const errUrl = new URL(sp.redirectUri);
+      const errUrl = new URL(consent.redirectUri);
       errUrl.searchParams.set("error", "server_error");
       errUrl.searchParams.set("error_description", "entity tokenUrl blocked by SSRF guard");
-      if (sp.originalState) errUrl.searchParams.set("state", sp.originalState);
+      if (consent.state) errUrl.searchParams.set("state", consent.state);
       res.redirect(302, errUrl.toString());
       return;
     }
@@ -1318,10 +1386,10 @@ export class OAuthController {
       }
       entityTokenData = await tokenRes.json() as typeof entityTokenData;
     } catch (err: any) {
-      const errUrl = new URL(sp.redirectUri);
+      const errUrl = new URL(consent.redirectUri);
       errUrl.searchParams.set("error", "server_error");
       errUrl.searchParams.set("error_description", "entity token exchange failed");
-      if (sp.originalState) errUrl.searchParams.set("state", sp.originalState);
+      if (consent.state) errUrl.searchParams.set("state", consent.state);
       res.redirect(302, errUrl.toString());
       return;
     }
@@ -1367,7 +1435,7 @@ export class OAuthController {
       ? new Date(Date.now() + entityTokenData.expires_in * 1000)
       : null;
 
-    const client = await this.oauth.findClient(sp.clientId);
+    const client = await this.oauth.findClient(consent.client.clientId);
     if (!client || client.entityPk !== ent.entityPk) {
       res.status(400).json({ error: "invalid_client" });
       return;
@@ -1443,24 +1511,24 @@ export class OAuthController {
     });
 
     const { code: platosCode } = await this.oauth.issueAuthCode({
-      clientId: sp.clientId,
+      clientId: consumed.client.clientId,
       userId: client.registeredByUserId,
       scopeTuple: {
         organizationId: ent.organizationId,
         projectId: ent.projectId,
         environmentId: ent.environmentId,
       },
-      codeChallenge: sp.codeChallenge,
+      codeChallenge: consumed.codeChallenge,
       codeChallengeMethod: "S256",
-      redirectUri: sp.redirectUri,
-      scopes: sp.scope.split(" ").filter(Boolean),
+      redirectUri: consumed.redirectUri,
+      scopes: consumed.scopes,
       entityPk: ent.entityPk,
       mcpIdentity: { kind: "oidc", sessionId: oidcSession.id },
     });
 
-    const finalRedirect = new URL(sp.redirectUri);
+    const finalRedirect = new URL(consumed.redirectUri);
     finalRedirect.searchParams.set("code", platosCode);
-    if (sp.originalState) finalRedirect.searchParams.set("state", sp.originalState);
+    if (consumed.state) finalRedirect.searchParams.set("state", consumed.state);
     res.redirect(302, finalRedirect.toString());
   }
 
@@ -1490,13 +1558,7 @@ export class OAuthController {
   }
 
   private verifyAndDecodeState(signedState: string): {
-    entityId: string;
-    clientId: string;
-    redirectUri: string;
-    codeChallenge: string;
-    codeChallengeMethod: string;
-    scope: string;
-    originalState: string;
+    transaction: string;
     entityPkceVerifier: string;
     callbackUrl: string;
     ts: number;
@@ -1519,6 +1581,7 @@ export class OAuthController {
       const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>;
       // Reject state older than 15 minutes (user has that long to complete auth).
       if (!parsed.ts || Math.abs(Date.now() / 1000 - Number(parsed.ts)) > 900) return null;
+      if (typeof parsed.transaction !== "string" || !parsed.transaction) return null;
       return parsed as ReturnType<typeof this.verifyAndDecodeState>;
     } catch {
       return null;

--- a/apps/agent/src/oauth/oauth.service.test.ts
+++ b/apps/agent/src/oauth/oauth.service.test.ts
@@ -20,6 +20,11 @@ function createPrisma() {
       findUnique: vi.fn(),
       updateMany: vi.fn(),
     },
+    oAuthConsentTransaction: {
+      create: vi.fn(),
+      findUnique: vi.fn(),
+      updateMany: vi.fn(),
+    },
     oAuthAccessToken: {
       create: vi.fn(),
       findUnique: vi.fn(),
@@ -80,7 +85,7 @@ describe("OAuthService clean entity lifecycle", () => {
       clientName: "Claude",
       redirectUris: ["https://client.example/callback"],
       tokenEndpointAuthMethod: "none",
-      scope: "mcp:tools profile",
+      scope: "mcp:tools",
       organizationId: scope.organizationId,
       entityPk: entityId,
     });
@@ -92,12 +97,85 @@ describe("OAuthService clean entity lifecycle", () => {
         organizationId: scope.organizationId,
         registeredByUserId: userId,
         entityId,
-        scopes: ["mcp:tools", "profile"],
+        scopes: ["mcp:tools"],
       }),
     });
     expect(JSON.stringify(prisma.oAuthClient.create.mock.calls[0][0])).not.toContain(
       "anonymous",
     );
+  });
+
+  it("rejects caller-defined privileged labels during dynamic registration", async () => {
+    prisma.entity.findUnique.mockResolvedValue({
+      project: { organizationId: scope.organizationId },
+    });
+    prisma.organizationMembership.findFirst.mockResolvedValue({ userId });
+
+    await expect(service.register({
+      clientName: "Untrusted client",
+      redirectUris: ["https://client.example/callback"],
+      scope: "mcp:tools admin:all",
+      organizationId: scope.organizationId,
+      entityPk: entityId,
+    })).rejects.toMatchObject({ code: "invalid_client_metadata" });
+    expect(prisma.oAuthClient.create).not.toHaveBeenCalled();
+  });
+
+  it("persists exact effective consent scopes and rejects tamper and replay", async () => {
+    mockCanonicalScope(prisma);
+    prisma.oAuthClient.findUnique.mockResolvedValue({
+      id: clientDbId,
+      clientId: "client_1",
+      entityId,
+      organizationId: scope.organizationId,
+      redirectUris: ["https://client.example/callback"],
+      scopes: ["mcp:tools"],
+      deletedAt: null,
+    });
+    prisma.oAuthConsentTransaction.create.mockResolvedValue({});
+
+    const transaction = await service.createConsentTransaction({
+      clientId: "client_1",
+      redirectUri: "https://client.example/callback",
+      codeChallenge: "challenge",
+      codeChallengeMethod: "S256",
+      scopes: ["mcp:tools"],
+      scopeTuple: scope,
+      entityPk: entityId,
+      state: "state_1",
+    });
+    expect(prisma.oAuthConsentTransaction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        scopes: ["mcp:tools"],
+        entityId,
+        environmentId: scope.environmentId,
+        state: "state_1",
+      }),
+    });
+    await expect(service.inspectConsentTransaction(`${transaction}tampered`)).resolves.toBeNull();
+
+    const persisted = {
+      id: "consent_1",
+      tokenHash: "hash",
+      clientId: clientDbId,
+      redirectUri: "https://client.example/callback",
+      codeChallenge: "challenge",
+      codeChallengeMethod: "S256",
+      scopes: ["mcp:tools"],
+      entityId,
+      ...scope,
+      state: "state_1",
+      expiresAt: new Date(Date.now() + 60_000),
+      consumedAt: null,
+      client: { clientId: "client_1", registeredByUserId: userId, deletedAt: null },
+    };
+    prisma.oAuthConsentTransaction.findUnique.mockResolvedValue(persisted);
+    prisma.oAuthConsentTransaction.updateMany.mockResolvedValueOnce({ count: 1 });
+    await expect(service.consumeConsentTransaction(transaction)).resolves.toMatchObject({ id: "consent_1" });
+    prisma.oAuthConsentTransaction.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(service.consumeConsentTransaction(transaction)).rejects.toMatchObject({
+      code: "invalid_request",
+    });
   });
 
   it("hashes authorization codes and persists normalized scope columns", async () => {
@@ -216,9 +294,69 @@ describe("OAuthService clean entity lifecycle", () => {
     expect(child.tokenHash).toBe(sha256(result.refreshToken));
   });
 
+  it("rejects an entity token exchange through a different environment endpoint", async () => {
+    const verifier = "entity-pkce-verifier";
+    prisma.oAuthAuthorizationCode.findUnique.mockResolvedValue({
+      id: "70000000-0000-4000-8000-000000000002",
+      clientId: clientDbId,
+      userId,
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      environmentId: scope.environmentId,
+      scopes: ["mcp:tools"],
+      codeChallenge: createHash("sha256").update(verifier).digest("base64url"),
+      redirectUri: "https://client.example/callback",
+      usedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      client: { clientId: "plt_oac_client", entityId },
+    });
+
+    await expect(
+      service.exchangeAuthCode({
+        clientId: "plt_oac_client",
+        code: "plt_ocd_environment_pinned",
+        codeVerifier: verifier,
+        redirectUri: "https://client.example/callback",
+        expectedScope: { ...scope, environmentId: "30000000-0000-4000-8000-000000000002" },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+    expect(prisma.oAuthAuthorizationCode.updateMany).not.toHaveBeenCalled();
+    expect(prisma.oAuthAccessToken.create).not.toHaveBeenCalled();
+  });
+
+  it("does not consume a refresh token through a different environment endpoint", async () => {
+    prisma.oAuthRefreshToken.findUnique.mockResolvedValue({
+      id: "70000000-0000-4000-8000-000000000003",
+      clientId: clientDbId,
+      userId,
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      environmentId: scope.environmentId,
+      scopes: ["mcp:tools"],
+      rotationFamilyId: "80000000-0000-4000-8000-000000000003",
+      consumedAt: null,
+      revokedAt: null,
+      expiresAt: new Date(Date.now() + 60_000),
+      client: { clientId: "plt_oac_client", entityId },
+    });
+
+    await expect(
+      service.exchangeRefreshToken({
+        clientId: "plt_oac_client",
+        refreshToken: "plt_or_environment_pinned",
+        expectedScope: { ...scope, environmentId: "30000000-0000-4000-8000-000000000002" },
+      }),
+    ).rejects.toMatchObject({ code: "invalid_grant" });
+    expect(prisma.oAuthRefreshToken.updateMany).not.toHaveBeenCalled();
+    expect(prisma.oAuthAccessToken.create).not.toHaveBeenCalled();
+  });
+
   it("revokes an entire refresh family and linked access tokens on replay", async () => {
     prisma.oAuthRefreshToken.findUnique.mockResolvedValue({
       id: "70000000-0000-4000-8000-000000000001",
+      organizationId: scope.organizationId,
+      projectId: scope.projectId,
+      environmentId: scope.environmentId,
       rotationFamilyId: "80000000-0000-4000-8000-000000000001",
       consumedAt: new Date(),
       revokedAt: null,

--- a/apps/agent/src/oauth/oauth.service.ts
+++ b/apps/agent/src/oauth/oauth.service.ts
@@ -5,6 +5,7 @@ import {
   type ControlDatabaseClient,
   PRISMA_TOKEN,
 } from "../shared/database.provider";
+import { env } from "../shared/env";
 
 /** Theme K.10 — OAuth 2.1 authorization-server primitives. */
 
@@ -85,6 +86,11 @@ const CLIENT_ID_PREFIX = "plt_oac_";
 const CLIENT_SECRET_PREFIX = "plt_ocs_";
 const AUTH_CODE_PREFIX = "plt_ocd_";
 const MCP_IDENTITY_SCOPE_PREFIX = "platos:mcp-identity:";
+const CONSENT_TOKEN_PREFIX = "plt_octx_";
+
+export const PLATFORM_MCP_SCOPES = ["mcp:read", "mcp:write"] as const;
+export const ENTITY_MCP_SCOPES = ["mcp:tools"] as const;
+export const OAUTH_CONSENT_TTL_SEC = 10 * 60;
 
 export const OAUTH_ACCESS_TOKEN_TTL_SEC = 3600;
 export const OAUTH_REFRESH_TOKEN_TTL_SEC = 90 * 24 * 3600;
@@ -132,7 +138,37 @@ export class OAuthService {
   }
 
   private parseRegisteredScopes(scope: string | null | undefined): string[] {
-    return (scope ?? "").split(/\s+/).filter(Boolean);
+    return [...new Set((scope ?? "").split(/\s+/).filter(Boolean))];
+  }
+
+  private serverOwnedScopes(entityPk?: string): string[] {
+    return [...(entityPk ? ENTITY_MCP_SCOPES : PLATFORM_MCP_SCOPES)];
+  }
+
+  private consentSignature(opaque: string): string {
+    const secret = env.SESSION_SECRET;
+    if (!secret) {
+      throw new OAuthError("server_error", "consent signing is not configured", 503);
+    }
+    return crypto.createHmac("sha256", secret).update(opaque).digest("base64url");
+  }
+
+  private consentTokenHash(signedToken: string): string | null {
+    const dot = signedToken.lastIndexOf(".");
+    if (dot <= 0) return null;
+    const opaque = signedToken.slice(0, dot);
+    const signature = signedToken.slice(dot + 1);
+    if (!opaque.startsWith(CONSENT_TOKEN_PREFIX) || !signature) return null;
+    const expected = this.consentSignature(opaque);
+    const providedBuffer = Buffer.from(signature);
+    const expectedBuffer = Buffer.from(expected);
+    if (
+      providedBuffer.length !== expectedBuffer.length ||
+      !crypto.timingSafeEqual(providedBuffer, expectedBuffer)
+    ) {
+      return null;
+    }
+    return this.sha256(opaque);
   }
 
   private publicScopes(scopes: string[]): string[] {
@@ -296,6 +332,15 @@ export class OAuthService {
     const clientId = this.randomId(CLIENT_ID_PREFIX, 16);
     const rawSecret =
       authMethod === "none" ? undefined : this.randomId(CLIENT_SECRET_PREFIX, 32);
+    const advertisedScopes = this.serverOwnedScopes(input.entityPk);
+    const requestedRegistrationScopes = this.parseRegisteredScopes(input.scope);
+    const advertisedScopeSet = new Set<string>(advertisedScopes);
+    if (requestedRegistrationScopes.some((scope) => !advertisedScopeSet.has(scope))) {
+      throw new OAuthError(
+        "invalid_client_metadata",
+        "scope contains a label that is not advertised by this authorization server",
+      );
+    }
     const row = await this.prisma.oAuthClient.create({
       data: {
         organizationId,
@@ -305,7 +350,7 @@ export class OAuthService {
         redirectUris: input.redirectUris,
         tokenEndpointAuthMethod: authMethod,
         grantTypes,
-        scopes: this.parseRegisteredScopes(input.scope),
+        scopes: advertisedScopes,
         registeredByUserId,
         entityId: input.entityPk ?? null,
       },
@@ -357,6 +402,106 @@ export class OAuthService {
     const row = await this.prisma.oAuthClient.findUnique({ where: { clientId } });
     if (!row || row.deletedAt) return null;
     return this.projectClient(row);
+  }
+
+  async effectiveScopes(clientId: string, requested?: string): Promise<string[]> {
+    const client = await this.prisma.oAuthClient.findUnique({
+      where: { clientId },
+      select: { scopes: true, deletedAt: true },
+    });
+    if (!client || client.deletedAt) {
+      throw new OAuthError("invalid_client", "unknown client_id");
+    }
+    const requestedScopes = this.parseRegisteredScopes(requested);
+    const effective = requestedScopes.length > 0 ? requestedScopes : client.scopes;
+    if (effective.some((scope) => !client.scopes.includes(scope))) {
+      throw new OAuthError("invalid_scope", "requested scope is not advertised for this client");
+    }
+    return effective;
+  }
+
+  async createConsentTransaction(input: {
+    clientId: string;
+    redirectUri: string;
+    codeChallenge: string;
+    codeChallengeMethod: "S256";
+    scopes: string[];
+    scopeTuple: ScopeTuple;
+    entityPk?: string;
+    state?: string;
+  }): Promise<string> {
+    const scope = await this.canonicalScope(input.scopeTuple);
+    const client = await this.prisma.oAuthClient.findUnique({
+      where: { clientId: input.clientId },
+      select: { id: true, entityId: true, organizationId: true, redirectUris: true, scopes: true, deletedAt: true },
+    });
+    if (
+      !client ||
+      client.deletedAt ||
+      client.organizationId !== scope.organizationId ||
+      client.entityId !== (input.entityPk ?? null) ||
+      !client.redirectUris.includes(input.redirectUri) ||
+      input.scopes.some((label) => !client.scopes.includes(label))
+    ) {
+      throw new OAuthError("invalid_request", "consent request is not valid for this client and scope");
+    }
+    const opaque = this.randomId(CONSENT_TOKEN_PREFIX, 32);
+    const signed = `${opaque}.${this.consentSignature(opaque)}`;
+    await this.prisma.oAuthConsentTransaction.create({
+      data: {
+        tokenHash: this.sha256(opaque),
+        nonce: crypto.randomUUID(),
+        clientId: client.id,
+        redirectUri: input.redirectUri,
+        codeChallenge: input.codeChallenge,
+        codeChallengeMethod: input.codeChallengeMethod,
+        scopes: input.scopes,
+        entityId: input.entityPk ?? null,
+        ...scope,
+        state: input.state ?? null,
+        expiresAt: new Date(Date.now() + OAUTH_CONSENT_TTL_SEC * 1000),
+      },
+    });
+    return signed;
+  }
+
+  async inspectConsentTransaction(signedToken: string) {
+    const tokenHash = this.consentTokenHash(signedToken);
+    if (!tokenHash) return null;
+    const row = await this.prisma.oAuthConsentTransaction.findUnique({
+      where: { tokenHash },
+      include: {
+        client: { select: { clientId: true, clientName: true, deletedAt: true } },
+        entity: { select: { externalId: true, displayName: true, mcpConfig: true } },
+        environment: { select: { id: true, name: true, slug: true } },
+      },
+    });
+    if (!row || row.client.deletedAt || row.consumedAt || row.expiresAt.getTime() <= Date.now()) {
+      return null;
+    }
+    return row;
+  }
+
+  async consumeConsentTransaction(signedToken: string) {
+    const tokenHash = this.consentTokenHash(signedToken);
+    if (!tokenHash) throw new OAuthError("invalid_request", "consent transaction is invalid");
+    return this.prisma.$transaction(async (tx) => {
+      const row = await tx.oAuthConsentTransaction.findUnique({
+        where: { tokenHash },
+        include: { client: { select: { clientId: true, registeredByUserId: true, deletedAt: true } } },
+      });
+      if (!row || row.client.deletedAt || row.consumedAt || row.expiresAt.getTime() <= Date.now()) {
+        throw new OAuthError("invalid_request", "consent transaction is expired or already consumed");
+      }
+      const claimed = await tx.oAuthConsentTransaction.updateMany({
+        where: { id: row.id, consumedAt: null, expiresAt: { gt: new Date() } },
+        data: { consumedAt: new Date() },
+      });
+      if (claimed.count !== 1) {
+        throw new OAuthError("invalid_request", "consent transaction is expired or already consumed");
+      }
+      return row;
+    });
   }
 
   async verifyClientSecret(clientId: string, clientSecret: string): Promise<boolean> {
@@ -646,6 +791,7 @@ export class OAuthService {
     code: string;
     codeVerifier: string;
     redirectUri: string;
+    expectedScope?: ScopeTuple;
   }): Promise<{
     accessToken: string;
     refreshToken: string;
@@ -680,6 +826,14 @@ export class OAuthService {
     }
     if (!row.organizationId || !row.projectId || !row.environmentId) {
       throw new OAuthError("invalid_grant", "authorization code has no canonical scope");
+    }
+    if (
+      input.expectedScope &&
+      (row.organizationId !== input.expectedScope.organizationId ||
+        row.projectId !== input.expectedScope.projectId ||
+        row.environmentId !== input.expectedScope.environmentId)
+    ) {
+      throw new OAuthError("invalid_grant", "authorization code scope does not match this endpoint");
     }
 
     const result = await this.prisma.$transaction(async (tx) => {
@@ -788,6 +942,7 @@ export class OAuthService {
   async exchangeRefreshToken(input: {
     clientId: string;
     refreshToken: string;
+    expectedScope?: ScopeTuple;
   }): Promise<{
     accessToken: string;
     refreshToken: string;
@@ -809,6 +964,17 @@ export class OAuthService {
         "refresh_token was issued to a different client",
       );
     }
+    if (!row.organizationId || !row.projectId || !row.environmentId) {
+      throw new OAuthError("invalid_grant", "refresh_token has no canonical scope");
+    }
+    if (
+      input.expectedScope &&
+      (row.organizationId !== input.expectedScope.organizationId ||
+        row.projectId !== input.expectedScope.projectId ||
+        row.environmentId !== input.expectedScope.environmentId)
+    ) {
+      throw new OAuthError("invalid_grant", "refresh_token scope does not match this endpoint");
+    }
     if (row.consumedAt || row.revokedAt) {
       const now = new Date();
       await this.prisma.$transaction([
@@ -828,9 +994,6 @@ export class OAuthService {
     }
     if (row.expiresAt.getTime() < Date.now()) {
       throw new OAuthError("invalid_grant", "refresh_token expired");
-    }
-    if (!row.organizationId || !row.projectId || !row.environmentId) {
-      throw new OAuthError("invalid_grant", "refresh_token has no canonical scope");
     }
 
     const result = await this.prisma.$transaction(async (tx) => {
@@ -871,7 +1034,13 @@ export class OAuthService {
     if (!raw || typeof raw !== "string" || !raw.startsWith(ACCESS_TOKEN_PREFIX)) {
       return null;
     }
-    const tokenHash = this.sha256(raw);
+    return this.verifyAccessTokenHash(this.sha256(raw));
+  }
+
+  /** Revalidate an SSE session without retaining the raw OAuth bearer. */
+  async verifyAccessTokenHash(
+    tokenHash: string,
+  ): Promise<VerifiedOAuthAccessToken | null> {
     const row = await this.prisma.oAuthAccessToken.findUnique({
       where: { tokenHash },
       include: { client: { select: { clientId: true, entityId: true, deletedAt: true } } },
@@ -936,7 +1105,11 @@ export class OAuthService {
     };
   }
 
-  async revokeToken(raw: string, clientId?: string): Promise<boolean> {
+  async revokeToken(
+    raw: string,
+    clientId?: string,
+    expectedScope?: ScopeTuple,
+  ): Promise<boolean> {
     if (!raw || typeof raw !== "string") return false;
     const tokenHash = this.sha256(raw);
     const now = new Date();
@@ -946,6 +1119,7 @@ export class OAuthService {
           tokenHash,
           revokedAt: null,
           ...(clientId ? { client: { clientId } } : {}),
+          ...(expectedScope ?? {}),
         },
         data: { revokedAt: now },
       });
@@ -957,6 +1131,7 @@ export class OAuthService {
           tokenHash,
           revokedAt: null,
           ...(clientId ? { client: { clientId } } : {}),
+          ...(expectedScope ?? {}),
         },
         data: { revokedAt: now },
       });

--- a/apps/agent/src/tool-gateway/mcp-transport/mcp-connected-entity.acceptance.test.ts
+++ b/apps/agent/src/tool-gateway/mcp-transport/mcp-connected-entity.acceptance.test.ts
@@ -33,13 +33,15 @@ function makeExecutor(options: {
   credentialName?: string;
   resolvedSecret?: string;
   url?: string;
+  entries?: OrgToolEntry[];
+  persistedRoute?: boolean;
 } = {}) {
   const healthWrites: any[] = [];
   const prisma: any = {
     entity: {
-      findFirst: async () => ({
-        id: "entity-1",
-        externalId: "github",
+      findFirst: async ({ where }: any) => ({
+        id: where.id,
+        externalId: where.id === "entity-2" ? "other" : "github",
         projectId: "project-1",
         connectionKind: "mcp",
         mcpClient: {
@@ -52,6 +54,20 @@ function makeExecutor(options: {
         },
       }),
     },
+    environmentEntityTool: {
+      findFirst: vi.fn(async () =>
+        options.persistedRoute === false ? null : {
+          id: "mapping-1",
+          callbackUrl: options.url ?? "https://entity.example/tools",
+          tool: {
+            name: "github.create_issue",
+            description: "Create issue",
+            paramSchema: { type: "object" },
+            category: null,
+          },
+        },
+      ),
+    },
     toolHealth: {
       upsert: async (args: any) => {
         healthWrites.push(args);
@@ -60,7 +76,7 @@ function makeExecutor(options: {
     },
   };
   const registry = {
-    getScopedTools: () => [entry],
+    getScopedTools: () => options.entries ?? [entry],
   };
   const resolvedHeaders: Array<Record<string, string>> = [];
   const credentials = {
@@ -95,6 +111,66 @@ function makeExecutor(options: {
     pool as any,
   );
   return { executor, healthWrites, resolvedHeaders, getClient, callTool };
+}
+
+function makeWireExecutor(
+  injectMcpContext: boolean,
+  options: { connected?: boolean; persistedCallbackUrl?: string } = {},
+) {
+  const wireEntry: OrgToolEntry = {
+    ...entry,
+    connectionKind: "wire",
+    entityMcpInjectContext: injectMcpContext,
+  };
+  const prisma: any = {
+    environmentEntityTool: { findFirst: vi.fn().mockResolvedValue({
+      id: "mapping-1",
+      callbackUrl: options.persistedCallbackUrl ?? "https://entity.example/tools",
+      tool: {
+        name: "github.create_issue",
+        description: "Create issue",
+        paramSchema: { type: "object" },
+        category: null,
+      },
+    }) },
+    entity: {
+      findFirst: vi.fn().mockResolvedValue({
+        id: "entity-1",
+        externalId: "github",
+        projectId: "project-1",
+        connectionKind: "wire",
+        mcpConfig: { injectMcpContext },
+        mcpClient: null,
+      }),
+    },
+    credential: { findFirst: vi.fn().mockResolvedValue({ name: "github" }) },
+    toolHealth: { upsert: vi.fn().mockResolvedValue({}) },
+    mcpOidcSession: { findFirst: vi.fn().mockResolvedValue(null) },
+  };
+  const registry = { getScopedTools: () => [wireEntry] };
+  const ws = {
+    isEntityConnected: vi.fn().mockReturnValue(options.connected ?? true),
+    dispatchToolCall: vi.fn().mockResolvedValue({ result: "ok" }),
+  };
+  const credentials = {
+    resolveCredentialReference: vi.fn().mockResolvedValue("service-secret"),
+  };
+  const executor = new ToolExecutorService(
+    prisma,
+    registry as any,
+    ws as any,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    credentials as any,
+    undefined,
+  );
+  return { executor, ws };
 }
 
 describe("clean EntityMcpClient discovery", () => {
@@ -199,6 +275,134 @@ describe("clean MCP entity dispatch", () => {
         entityExternalId: "github",
       },
     });
+  });
+
+  it("strips caller-owned reserved envelopes before outbound MCP transport", async () => {
+    const { executor, callTool } = makeExecutor();
+    const result = await executor.execute(
+      {
+        tool: "github.create_issue",
+        params: {
+          title: "hello",
+          _context: { mcpUserId: "attacker" },
+          __platos: { organizationId: "attacker" },
+          _platos: { environmentId: "attacker" },
+          platosContext: { source: "attacker" },
+        },
+      },
+      SCOPE,
+      { source: "mcp_client", mcpUserId: "mcp:pat:pat-1" },
+      { entityPk: "entity-1", entityId: "github", toolId: "tool-1" },
+    );
+
+    expect(result.status).toBe("success");
+    expect(callTool).toHaveBeenCalledWith(
+      { name: "github.create_issue", arguments: { title: "hello" } },
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it("dispatches the exact preflighted entity when another entity has the same tool name", async () => {
+    const otherEntry: OrgToolEntry = {
+      ...entry,
+      entityPk: "entity-2",
+      sourceEntityId: "other",
+      toolId: "tool-2",
+    };
+    const { executor, getClient } = makeExecutor({ entries: [otherEntry, entry] });
+
+    const result = await executor.execute(
+      { tool: "github.create_issue", params: { title: "hello" } },
+      SCOPE,
+      { source: "mcp_client", endUserId: "user-1" },
+      { entityPk: "entity-1", entityId: "github", toolId: "tool-1" },
+    );
+
+    expect(result.status).toBe("success");
+    expect(getClient).toHaveBeenCalledWith(
+      expect.objectContaining({ server: { id: "entity-1" } }),
+    );
+  });
+
+  it("denies a stale entity-pinned wire route before either wire transport", async () => {
+    const wireEntry: OrgToolEntry = { ...entry, connectionKind: "wire" };
+    const { executor, getClient } = makeExecutor({
+      entries: [wireEntry],
+      persistedRoute: false,
+    });
+
+    const result = await executor.execute(
+      { tool: "github.create_issue", params: {} },
+      SCOPE,
+      { source: "mcp_client" },
+      { entityPk: "entity-1", entityId: "github", toolId: "tool-1" },
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toMatch(/route is no longer valid/i);
+    expect(getClient).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [true, true],
+    [false, false],
+  ])(
+    "injectMcpContext=%s controls the inbound MCP wire envelope",
+    async (injectMcpContext, expectsContext) => {
+      const { executor, ws } = makeWireExecutor(injectMcpContext);
+      const result = await executor.execute(
+        {
+          tool: "github.create_issue",
+          params: {
+            title: "hello",
+            _context: { source: "attacker" },
+            __platos: { organizationId: "attacker" },
+            platos_context: { source: "attacker" },
+          },
+        },
+        SCOPE,
+        {
+          source: "mcp_client",
+          mcpUserId: "mcp:pat:pat-1",
+          mcpClientId: "pat",
+        },
+        { entityPk: "entity-1", entityId: "github", toolId: "tool-1" },
+      );
+
+      expect(result.status).toBe("success");
+      const dispatchedParams = ws.dispatchToolCall.mock.calls[0]![3];
+      expect(dispatchedParams).not.toHaveProperty("platos_context");
+      if (expectsContext) {
+        expect(dispatchedParams._context).toEqual({
+          source: "mcp_client",
+          mcpUserId: "mcp:pat:pat-1",
+          mcpClientId: "pat",
+        });
+      } else {
+        expect(dispatchedParams).not.toHaveProperty("_context");
+      }
+      expect(dispatchedParams.__platos.organizationId).toBe(SCOPE.organizationId);
+    },
+  );
+
+  it("uses the current persisted callback URL when the registry cache is stale", async () => {
+    const currentUrl = "https://8.8.8.8/current-callback";
+    const { executor } = makeWireExecutor(false, {
+      connected: false,
+      persistedCallbackUrl: currentUrl,
+    });
+
+    const result = await executor.execute(
+      { tool: "github.create_issue", params: { title: "hello" } },
+      SCOPE,
+      { source: "mcp_client" },
+      { entityPk: "entity-1", entityId: "github", toolId: "tool-1" },
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("/current-callback");
+    expect(result.error).not.toContain("entity.example/tools");
   });
 
   it("fails closed before transport when an end-user template is unresolved", async () => {

--- a/apps/agent/src/tool-gateway/tool-executor.service.ts
+++ b/apps/agent/src/tool-gateway/tool-executor.service.ts
@@ -121,6 +121,37 @@ export interface ToolCallOrigin {
   endUserId?: string | null;
 }
 
+/** Exact route resolved by a caller that preflights a specific entity. */
+export interface ToolRouteConstraint {
+  entityPk: string;
+  entityId: string;
+  toolId: string;
+}
+
+const RESERVED_EXTERNAL_ARGUMENT_ENVELOPES = new Set([
+  "_context",
+  "__platos",
+  "_platos",
+  "platos_context",
+  "platosContext",
+  "__platosContext",
+]);
+
+function stripReservedExternalArgumentEnvelopes(
+  params: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  const strip = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(strip);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => !RESERVED_EXTERNAL_ARGUMENT_ENVELOPES.has(key))
+        .map(([key, nested]) => [key, strip(nested)]),
+    );
+  };
+  return strip(params ?? {}) as Record<string, unknown>;
+}
+
 /**
  * ToolExecutorService — executes tool calls on entity backends.
  *
@@ -519,6 +550,7 @@ export class ToolExecutorService {
     call: ToolCallRequest,
     scope: RequestScope,
     origin?: ToolCallOrigin,
+    resolvedRoute?: ToolRouteConstraint,
   ): Promise<ToolCallResult> {
     const startTime = Date.now();
     const startNs = startTime * 1_000_000;
@@ -642,7 +674,13 @@ export class ToolExecutorService {
         ? { ...call, params: gated.params }
         : call;
 
-    const inner = await this.executeInner(dispatchedCall, scope, startTime, origin);
+    const inner = await this.executeInner(
+      dispatchedCall,
+      scope,
+      startTime,
+      origin,
+      resolvedRoute,
+    );
     const { result, toolId, entityId, entityPk } = inner;
 
     // Emit a tool.call span if a trace is open. The span carries scope tags
@@ -736,6 +774,7 @@ export class ToolExecutorService {
     scope: RequestScope,
     startTime: number,
     origin?: ToolCallOrigin,
+    resolvedRoute?: ToolRouteConstraint,
   ): Promise<{
     result: ToolCallResult;
     toolId?: string;
@@ -750,6 +789,15 @@ export class ToolExecutorService {
       enabledOnly: true,
       agentId: scope.agentId,
     });
+    if (resolvedRoute) {
+      scopedTools = scopedTools.filter(
+        (tool) =>
+          tool.entityPk === resolvedRoute.entityPk &&
+          tool.sourceEntityId === resolvedRoute.entityId &&
+          tool.toolId === resolvedRoute.toolId &&
+          tool.environmentId === scope.environmentId,
+      );
+    }
     // Theme CTX.2 — Role 3 (tool-matrix routing). Narrow to tools belonging
     // to the entity_ids declared on `thread.sessionContext` before picking a
     // target. Ensures a tool-name collision across entities resolves to the
@@ -761,7 +809,7 @@ export class ToolExecutorService {
       const entIds = resolveCtxPath(ctxBagExec, entKey);
       scopedTools = filterToolsByEntityIds(scopedTools, entIds);
     }
-    const toolEntry = scopedTools.find((t) => t.toolName === call.tool);
+    let toolEntry = scopedTools.find((t) => t.toolName === call.tool);
 
     if (!toolEntry) {
       // Dynamic-executor fallback — an entity can mark ONE of its tools with
@@ -806,6 +854,7 @@ export class ToolExecutorService {
           scope,
           startTime,
           origin,
+          resolvedRoute,
         );
       }
       return {
@@ -822,6 +871,10 @@ export class ToolExecutorService {
       };
     }
 
+    if (origin?.source === "mcp_client") {
+      call.params = stripReservedExternalArgumentEnvelopes(call.params);
+    }
+
     // Get entity's service secret for HMAC signing.
     // PIFSP-3: `customParams` was the legacy per-entity arg-injection
     // mechanism. Column dropped; the agent-config "MCP arguments" editor
@@ -829,6 +882,55 @@ export class ToolExecutorService {
     // arg-resolution layer left.
     let serviceSecret: string;
     try {
+      if (resolvedRoute) {
+        const persistedRoute = await this.prisma.environmentEntityTool.findFirst({
+          where: {
+            environmentId: scope.environmentId,
+            entityId: resolvedRoute.entityPk,
+            toolId: resolvedRoute.toolId,
+            enabled: true,
+            entity: {
+              externalId: resolvedRoute.entityId,
+              projectId: scope.projectId,
+              project: { organizationId: scope.organizationId },
+            },
+            tool: { name: call.tool },
+          },
+          select: {
+            id: true,
+            callbackUrl: true,
+            tool: {
+              select: {
+                name: true,
+                description: true,
+                paramSchema: true,
+                category: true,
+              },
+            },
+          },
+        });
+        if (!persistedRoute) {
+          return {
+            result: {
+              tool: call.tool,
+              status: "failed",
+              error: "Resolved tool route is no longer valid for this entity and environment",
+              latencyMs: Date.now() - startTime,
+            },
+            toolId: resolvedRoute.toolId,
+            entityId: resolvedRoute.entityId,
+            entityPk: resolvedRoute.entityPk,
+          };
+        }
+        toolEntry = {
+          ...toolEntry,
+          callbackUrl: persistedRoute.callbackUrl ?? "",
+          toolName: persistedRoute.tool.name,
+          description: persistedRoute.tool.description,
+          paramSchema: persistedRoute.tool.paramSchema as Record<string, unknown>,
+          category: persistedRoute.tool.category,
+        };
+      }
       // SECURITY (audit L2) — re-verify scope when re-loading the entity's
       // serviceSecret. The cache boundary holds today, so this is defense in
       // depth: a slip that yielded a cross-scope entityPk would otherwise hand
@@ -842,7 +944,7 @@ export class ToolExecutorService {
       // the read tight, per the audit-L2 defense-in-depth note above.
       const entity = await this.prisma.entity.findFirst({
         where: {
-          id: toolEntry.entityPk,
+          id: resolvedRoute?.entityPk ?? toolEntry.entityPk,
           projectId: scope.projectId,
           project: { organizationId: scope.organizationId },
         },
@@ -851,6 +953,7 @@ export class ToolExecutorService {
           externalId: true,
           projectId: true,
           connectionKind: true,
+          mcpConfig: { select: { injectMcpContext: true } },
           mcpClient: {
             include: { credential: { select: { name: true } } },
           },
@@ -869,6 +972,11 @@ export class ToolExecutorService {
           entityPk: toolEntry.entityPk,
         };
       }
+      toolEntry = {
+        ...toolEntry,
+        connectionKind: entity.connectionKind,
+        entityMcpInjectContext: entity.mcpConfig?.injectMcpContext === true,
+      };
 
       // ── connectionKind === "mcp" DISPATCH BRANCH (design §4) ───────────────
       // The single executor change. Fires BEFORE any wire read: no
@@ -1446,8 +1554,11 @@ export class ToolExecutorService {
     calls: ToolCallRequest[],
     scope: RequestScope,
     origin?: ToolCallOrigin,
+    resolvedRoute?: ToolRouteConstraint,
   ): Promise<ToolCallResult[]> {
-    return Promise.all(calls.map((call) => this.execute(call, scope, origin)));
+    return Promise.all(
+      calls.map((call) => this.execute(call, scope, origin, resolvedRoute)),
+    );
   }
 
   /**

--- a/apps/webapp/app/routes/oauth.consent/route.tsx
+++ b/apps/webapp/app/routes/oauth.consent/route.tsx
@@ -1,43 +1,23 @@
 /**
- * Theme K.10 — OAuth 2.1 + DCR consent screen.
- *
- * Three distinct flows depending on context:
- *
- * 1. Platform OAuth (no entity_id) — Platos-user logs in, picks org/project/env scope.
- *    Submits to /oauth/authorize/callback.
- *
- * 2. Entity OIDC (entity_id + identityMode includes "oidc") — "Sign in with [Entity]"
- *    button. Redirects to /oauth/entity/:entityId/oidc-redirect which bounces the user
- *    to the entity's own OAuth server. Entity backend owns all auth (Google, email, etc.).
- *
- * 3. Entity anonymous (entity_id + identityMode includes "anonymous") — "Continue without
- *    signing in" button. Posts to /oauth/entity/:entityId/authorize/anonymous which mints
- *    a PlatosMcpAnonSession and returns an auth code directly.
- *
- * The entity_id, entity_pk, organization_id, project_id query params are injected by
- * /oauth/entity/:entityId/authorize on the agent side.
+ * OAuth consent UI backed by an opaque, signed, one-time agent transaction.
+ * The browser never carries mutable client, redirect, PKCE, scope, entity, or
+ * tenancy authority fields.
  */
 
-import { json, redirect, type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
+import {
+  json,
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+} from "@remix-run/server-runtime";
 import { Form, useLoaderData } from "@remix-run/react";
-import * as crypto from "node:crypto";
-import { prisma } from "~/db.server";
 import { env } from "~/env.server";
 import { requireUser } from "~/services/session.server";
 
-interface ConsentScope {
-  organizationId: string;
-  organizationName: string;
-  projectId: string;
-  projectName: string;
-  environmentId: string;
-  environmentLabel: string;
-  value: string;
-}
-
 type IdentityFlow = "platform" | "entity_oidc" | "entity_anonymous" | "entity_bearer";
 
-interface LoaderData {
+interface ConsentDetails {
+  transaction: string;
   flow: IdentityFlow;
   client: {
     clientId: string;
@@ -45,485 +25,236 @@ interface LoaderData {
     redirectUri: string;
   };
   entity: {
-    entityId: string;
     entityPk: string;
-    organizationId: string;
-    projectId: string;
+    entityId: string;
     displayName: string;
     branding: { primaryColor?: string; tagline?: string } | null;
   } | null;
-  scopes: ConsentScope[];
-  query: {
-    client_id: string;
-    redirect_uri: string;
-    state: string | undefined;
-    scope: string | undefined;
-    code_challenge: string;
-    code_challenge_method: string;
-  };
+  environment: { id: string; name: string; slug: string };
+  effectiveScopes: string[];
 }
 
-function requireQueryParam(url: URL, name: string): string {
-  const v = url.searchParams.get(name);
-  if (!v) throw new Response(`Missing query param: ${name}`, { status: 400 });
-  return v;
+function agentBase(): string {
+  return process.env.PLATOS_AGENT_API_URL || "http://localhost:3100";
+}
+
+async function loadConsent(transaction: string): Promise<ConsentDetails> {
+  const response = await fetch(
+    `${agentBase()}/oauth/consent?transaction=${encodeURIComponent(transaction)}`,
+    { signal: AbortSignal.timeout(4000) }
+  );
+  if (!response.ok) {
+    throw new Response("Consent transaction is invalid, expired, or already used", {
+      status: response.status === 410 ? 410 : 400,
+    });
+  }
+  return response.json() as Promise<ConsentDetails>;
 }
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
+  const transaction = url.searchParams.get("transaction");
+  if (!transaction) throw new Response("Missing consent transaction", { status: 400 });
+  const consent = await loadConsent(transaction);
 
-  const clientIdParam = requireQueryParam(url, "client_id");
-  const redirectUriParam = requireQueryParam(url, "redirect_uri");
-  const codeChallenge = requireQueryParam(url, "code_challenge");
-  const codeChallengeMethod = url.searchParams.get("code_challenge_method") ?? "S256";
-  const scope = url.searchParams.get("scope") ?? undefined;
-  const state = url.searchParams.get("state") ?? undefined;
-
-  // Entity-scoped params — injected by entityAuthorize on the agent.
-  const entityId = url.searchParams.get("entity_id") ?? null;
-  const entityPk = url.searchParams.get("entity_pk") ?? null;
-  const organizationId = url.searchParams.get("organization_id") ?? null;
-  const projectId = url.searchParams.get("project_id") ?? null;
-
-  const client = await prisma.platosOAuthClient.findUnique({
-    where: { clientId: clientIdParam },
-    select: { clientId: true, clientName: true, redirectUris: true, deletedAt: true },
-  });
-  if (!client) throw new Response("Unknown client_id", { status: 400 });
-  // MCPF-W3 — soft-deleted clients can't mint new tokens; reject at consent
-  // before the user wastes time approving.
-  if (client.deletedAt) throw new Response("Client has been deleted", { status: 400 });
-  if (!client.redirectUris.includes(redirectUriParam)) {
-    throw new Response("redirect_uri not registered for this client", { status: 400 });
-  }
-
-  const queryShape = {
-    client_id: clientIdParam,
-    redirect_uri: redirectUriParam,
-    state,
-    scope,
-    code_challenge: codeChallenge,
-    code_challenge_method: codeChallengeMethod,
-  };
-
-  // ── Entity flows (OIDC / anonymous) ──────────────────────────────────
-  if (entityId && entityPk && organizationId && projectId) {
-    // Fetch identity mode + branding from the agent backend.
-    let identityMode = "bearer";
-    let branding: { primaryColor?: string; tagline?: string } | null = null;
-    let displayName = entityId;
+  if (consent.flow === "platform") {
     try {
-      const agentBase = process.env.PLATOS_AGENT_API_URL || "http://localhost:3100";
-      const cfgRes = await fetch(
-        `${agentBase}/mcp/entity/${encodeURIComponent(entityId)}/config`,
-        {
-          headers: {
-            "X-Platos-Organization-Id": organizationId,
-            "X-Platos-Project-Id": projectId,
-            "X-Platos-Environment-Id": "mcp",
-            "X-Platos-User-Id": "consent-loader",
-          },
-          signal: AbortSignal.timeout(4000),
-        }
-      );
-      if (cfgRes.ok) {
-        const data = (await cfgRes.json()) as {
-          config?: { identityMode?: string; branding?: Record<string, unknown> };
-          entityId?: string;
-        };
-        identityMode = (data.config?.identityMode as string) ?? "bearer";
-        branding = (data.config?.branding as { primaryColor?: string; tagline?: string } | null) ?? null;
-        displayName = (data.entityId as string) ?? entityId;
-      }
+      await requireUser(request);
     } catch {
-      // Proceed with defaults if agent unreachable.
-    }
-
-    const modes = identityMode.split("+").map((m) => m.trim());
-    let flow: IdentityFlow = "entity_bearer";
-    if (modes.includes("oidc")) flow = "entity_oidc";
-    else if (modes.includes("anonymous")) flow = "entity_anonymous";
-
-    return json<LoaderData>({
-      flow,
-      client: {
-        clientId: client.clientId,
-        clientName: client.clientName,
-        redirectUri: redirectUriParam,
-      },
-      entity: {
-        entityId,
-        entityPk,
-        organizationId,
-        projectId,
-        displayName,
-        branding,
-      },
-      scopes: [],
-      query: queryShape,
-    });
-  }
-
-  // ── Platform flow — requires logged-in Platos user ────────���──────────
-  let user;
-  try {
-    user = await requireUser(request);
-  } catch {
-    const searchParams = new URLSearchParams([["redirectTo", `${url.pathname}${url.search}`]]);
-    throw redirect(`/login?${searchParams}`);
-  }
-
-  const memberships = await prisma.orgMember.findMany({
-    where: { userId: user.id },
-    select: {
-      organization: {
-        select: {
-          id: true,
-          title: true,
-          projects: {
-            where: { deletedAt: null },
-            select: {
-              id: true,
-              name: true,
-              environments: {
-                select: {
-                  id: true,
-                  slug: true,
-                  type: true,
-                  orgMember: { select: { userId: true } },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  });
-
-  const scopes: ConsentScope[] = [];
-  for (const m of memberships) {
-    for (const project of m.organization.projects) {
-      for (const envRow of project.environments) {
-        if (envRow.orgMember && envRow.orgMember.userId !== user.id) continue;
-        scopes.push({
-          organizationId: m.organization.id,
-          organizationName: m.organization.title,
-          projectId: project.id,
-          projectName: project.name,
-          environmentId: envRow.id,
-          environmentLabel: `${envRow.slug} (${envRow.type.toLowerCase()})`,
-          value: `${m.organization.id}|${project.id}|${envRow.id}`,
-        });
-      }
+      const redirectTo = `${url.pathname}?transaction=${encodeURIComponent(transaction)}`;
+      throw redirect(`/login?${new URLSearchParams({ redirectTo })}`);
     }
   }
 
-  return json<LoaderData>({
-    flow: "platform",
-    client: {
-      clientId: client.clientId,
-      clientName: client.clientName,
-      redirectUri: redirectUriParam,
-    },
-    entity: null,
-    scopes,
-    query: queryShape,
-  });
+  return json(consent);
 }
 
 export async function action({ request }: ActionFunctionArgs) {
-  const user = await requireUser(request);
   const form = await request.formData();
-  const action = form.get("action") as string;
-  const clientId = form.get("client_id") as string;
-  const redirectUri = form.get("redirect_uri") as string;
-  const codeChallenge = form.get("code_challenge") as string;
-  const scope = form.get("scope") as string | null;
-  const state = form.get("state") as string | null;
-  const scopeValue = form.get("scope_tuple") as string | null;
-
-  if (!clientId || !redirectUri || !codeChallenge) {
-    return json({ error: "Missing required fields" }, { status: 400 });
+  const transaction = form.get("transaction");
+  const action = form.get("action") === "deny" ? "deny" : "approve";
+  if (typeof transaction !== "string" || !transaction) {
+    return json({ error: "Missing consent transaction" }, { status: 400 });
   }
 
-  if (action === "deny") {
-    const r = new URL(redirectUri);
-    r.searchParams.set("error", "access_denied");
-    r.searchParams.set("error_description", "User denied the authorization request.");
-    if (state) r.searchParams.set("state", state);
-    return Response.redirect(r.toString(), 302);
+  const consent = await loadConsent(transaction);
+  let userId = "consent-denied";
+  if (action === "approve") {
+    if (consent.flow !== "platform") {
+      return json({ error: "This consent flow is completed by the entity" }, { status: 400 });
+    }
+    userId = (await requireUser(request)).id;
   }
 
-  if (!scopeValue || !scopeValue.includes("|")) {
-    return json({ error: "Select a scope to authorize" }, { status: 400 });
+  const internalToken = env.PLATOS_INTERNAL_AUTH_TOKEN;
+  if (!internalToken) {
+    return json({ error: "Internal consent authentication is not configured" }, { status: 503 });
   }
-  const [organizationId, projectId, environmentId] = scopeValue.split("|");
-  if (!organizationId || !projectId || !environmentId) {
-    return json({ error: "Invalid scope" }, { status: 400 });
-  }
-
-  const secret = env.SESSION_SECRET;
-  if (!secret) {
-    return json({ error: "SESSION_SECRET not configured on webapp" }, { status: 500 });
-  }
-
-  const ts = Math.floor(Date.now() / 1000);
-  const canonical = [
-    clientId,
-    redirectUri,
-    user.id,
-    organizationId,
-    projectId,
-    environmentId,
-    codeChallenge,
-    scope ?? "",
-    state ?? "",
-    String(ts),
-  ].join("\n");
-  const signature = crypto.createHmac("sha256", secret).update(canonical).digest("base64url");
-
-  const agentBase = process.env.PLATOS_AGENT_API_URL || "http://localhost:3100";
-  const resp = await fetch(`${agentBase}/oauth/authorize/callback`, {
+  const response = await fetch(`${agentBase()}/oauth/authorize/callback`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      "X-Platos-Consent-Signature": signature,
+      "X-Platos-Internal-Token": internalToken,
     },
-    body: JSON.stringify({
-      clientId,
-      redirectUri,
-      userId: user.id,
-      organizationId,
-      projectId,
-      environmentId,
-      codeChallenge,
-      codeChallengeMethod: "S256",
-      ...(scope ? { scope } : {}),
-      ...(state ? { state } : {}),
-      ts,
-    }),
+    body: JSON.stringify({ transaction, userId, action }),
   });
-
-  if (!resp.ok) {
-    const text = await resp.text().catch(() => "");
-    return json({ error: `Agent callback failed: ${resp.status} ${text}` }, { status: 502 });
+  if (!response.ok) {
+    const message = await response.text().catch(() => "");
+    return json(
+      { error: `Consent could not be completed: ${response.status} ${message}` },
+      { status: 502 }
+    );
   }
-  const payload = (await resp.json()) as { redirectTo?: string };
+  const payload = (await response.json()) as { redirectTo?: string };
   if (!payload.redirectTo) {
-    return json({ error: "Agent callback returned no redirect" }, { status: 502 });
+    return json({ error: "Consent callback returned no redirect" }, { status: 502 });
   }
   return Response.redirect(payload.redirectTo, 302);
 }
 
-export default function OAuthConsent() {
-  const data = useLoaderData<typeof loader>();
-  const { flow, client, entity, query } = data;
+function ScopeSummary({ scopes }: { scopes: string[] }) {
+  return (
+    <div className="rounded border border-charcoal-700 bg-charcoal-900 p-3 text-xs text-charcoal-400">
+      Effective scopes: <code className="text-charcoal-200">{scopes.join(" ")}</code>
+    </div>
+  );
+}
 
-  const agentBase =
+export default function OAuthConsent() {
+  const consent = useLoaderData<typeof loader>();
+  const { flow, client, entity, environment, effectiveScopes, transaction } = consent;
+  const accentColor = entity?.branding?.primaryColor ?? "#6366f1";
+  const publicAgentBase =
     typeof window !== "undefined"
       ? window.location.origin.replace(":3030", ":3100")
       : "http://localhost:3100";
 
-  const accentColor = entity?.branding?.primaryColor ?? "#6366f1";
-
-  // ── Entity OIDC flow ──────────────────────────────────────────────────
   if (flow === "entity_oidc" && entity) {
-    const oidcRedirectUrl = new URL(
+    const oidcUrl = new URL(
       `/oauth/entity/${encodeURIComponent(entity.entityId)}/oidc-redirect`,
-      agentBase,
+      publicAgentBase
     );
-    oidcRedirectUrl.searchParams.set("client_id", query.client_id);
-    oidcRedirectUrl.searchParams.set("redirect_uri", query.redirect_uri);
-    oidcRedirectUrl.searchParams.set("code_challenge", query.code_challenge);
-    oidcRedirectUrl.searchParams.set("code_challenge_method", query.code_challenge_method);
-    if (query.scope) oidcRedirectUrl.searchParams.set("scope", query.scope);
-    if (query.state) oidcRedirectUrl.searchParams.set("state", query.state);
-
+    oidcUrl.searchParams.set("transaction", transaction);
     return (
-      <div className="mx-auto flex min-h-screen max-w-sm items-center justify-center p-6">
-        <div className="w-full rounded-xl border border-charcoal-700 bg-charcoal-800 p-8 shadow-xl text-center space-y-6">
-          <div>
-            <div
-              className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full text-white text-xl font-bold"
-              style={{ backgroundColor: accentColor }}
-            >
-              {entity.displayName.slice(0, 1).toUpperCase()}
-            </div>
-            <h1 className="text-lg font-semibold text-white">
-              Connect to <span style={{ color: accentColor }}>{entity.displayName}</span>
-            </h1>
-            {entity.branding?.tagline && (
-              <p className="mt-1 text-sm text-charcoal-400">{entity.branding.tagline}</p>
-            )}
-          </div>
-
-          <p className="text-sm text-charcoal-300">
-            <strong className="text-white">{client.clientName}</strong> wants to access{" "}
-            <strong style={{ color: accentColor }}>{entity.displayName}</strong> on your behalf.
-            You will be redirected to sign in with your existing account.
-          </p>
-
-          <div className="text-xs text-charcoal-500 rounded border border-charcoal-700 bg-charcoal-900 p-2">
-            Redirect back to:{" "}
-            <code className="text-charcoal-300">{client.redirectUri}</code>
-          </div>
-
-          <div className="space-y-2">
-            <a
-              href={oidcRedirectUrl.toString()}
-              className="flex w-full items-center justify-center rounded-lg px-4 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
-              style={{ backgroundColor: accentColor }}
-            >
-              Sign in with {entity.displayName}
-            </a>
-            <a
-              href={`${query.redirect_uri}?error=access_denied${query.state ? `&state=${encodeURIComponent(query.state)}` : ""}`}
-              className="flex w-full items-center justify-center rounded-lg border border-charcoal-600 px-4 py-2 text-sm text-charcoal-300 hover:bg-charcoal-700"
-            >
-              Cancel
-            </a>
-          </div>
-        </div>
-      </div>
+      <ConsentCard title={`Connect to ${entity.displayName}`} accentColor={accentColor}>
+        <p className="text-sm text-charcoal-300">
+          <strong className="text-white">{client.clientName}</strong> wants to access{" "}
+          {entity.displayName} in {environment.name}. You will sign in with the entity provider.
+        </p>
+        <ScopeSummary scopes={effectiveScopes} />
+        <a
+          href={oidcUrl.toString()}
+          className="flex w-full justify-center rounded-lg px-4 py-3 text-sm font-medium text-white"
+          style={{ backgroundColor: accentColor }}
+        >
+          Sign in with {entity.displayName}
+        </a>
+        <DenyForm transaction={transaction} />
+      </ConsentCard>
     );
   }
 
-  // ── Entity anonymous flow ─────────────────────────────────────────────
   if (flow === "entity_anonymous" && entity) {
-    const anonUrl = `${agentBase}/oauth/entity/${encodeURIComponent(entity.entityId)}/authorize/anonymous`;
-
+    const anonymousUrl = `${publicAgentBase}/oauth/entity/${encodeURIComponent(
+      entity.entityId
+    )}/authorize/anonymous`;
     return (
-      <div className="mx-auto flex min-h-screen max-w-sm items-center justify-center p-6">
-        <div className="w-full rounded-xl border border-charcoal-700 bg-charcoal-800 p-8 shadow-xl text-center space-y-6">
-          <div>
-            <div
-              className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full text-white text-xl font-bold"
-              style={{ backgroundColor: accentColor }}
-            >
-              {entity.displayName.slice(0, 1).toUpperCase()}
-            </div>
-            <h1 className="text-lg font-semibold text-white">
-              Connect to <span style={{ color: accentColor }}>{entity.displayName}</span>
-            </h1>
-          </div>
-
-          <p className="text-sm text-charcoal-300">
-            <strong className="text-white">{client.clientName}</strong> wants to access{" "}
-            <strong style={{ color: accentColor }}>{entity.displayName}</strong>. No account
-            required — you will be connected as an anonymous session.
-          </p>
-
-          <form method="POST" action={anonUrl} className="space-y-2">
-            <input type="hidden" name="client_id" value={query.client_id} />
-            <input type="hidden" name="redirect_uri" value={query.redirect_uri} />
-            <input type="hidden" name="code_challenge" value={query.code_challenge} />
-            <input type="hidden" name="code_challenge_method" value={query.code_challenge_method} />
-            {query.scope && <input type="hidden" name="scope" value={query.scope} />}
-            {query.state && <input type="hidden" name="state" value={query.state} />}
-            <button
-              type="submit"
-              className="flex w-full items-center justify-center rounded-lg px-4 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
-              style={{ backgroundColor: accentColor }}
-            >
-              Continue without signing in
-            </button>
-          </form>
-          <a
-            href={`${query.redirect_uri}?error=access_denied${query.state ? `&state=${encodeURIComponent(query.state)}` : ""}`}
-            className="flex w-full items-center justify-center rounded-lg border border-charcoal-600 px-4 py-2 text-sm text-charcoal-300 hover:bg-charcoal-700"
+      <ConsentCard title={`Connect to ${entity.displayName}`} accentColor={accentColor}>
+        <p className="text-sm text-charcoal-300">
+          <strong className="text-white">{client.clientName}</strong> will connect anonymously to{" "}
+          {entity.displayName} in {environment.name}.
+        </p>
+        <ScopeSummary scopes={effectiveScopes} />
+        <form method="POST" action={anonymousUrl}>
+          <input type="hidden" name="transaction" value={transaction} />
+          <button
+            type="submit"
+            className="flex w-full justify-center rounded-lg px-4 py-3 text-sm font-medium text-white"
+            style={{ backgroundColor: accentColor }}
           >
-            Cancel
-          </a>
-        </div>
-      </div>
+            Continue without signing in
+          </button>
+        </form>
+        <DenyForm transaction={transaction} />
+      </ConsentCard>
     );
   }
 
-  // ─�� Entity bearer — bearer tokens are operator-managed, not user-facing ──
   if (flow === "entity_bearer" && entity) {
     return (
-      <div className="mx-auto flex min-h-screen max-w-sm items-center justify-center p-6">
-        <div className="w-full rounded-xl border border-charcoal-700 bg-charcoal-800 p-8 shadow-xl text-center space-y-4">
-          <h1 className="text-lg font-semibold text-white">Bearer authentication</h1>
-          <p className="text-sm text-charcoal-300">
-            <strong style={{ color: accentColor }}>{entity.displayName}</strong> uses bearer
-            token authentication. Your administrator will provide a Personal Access Token to
-            configure in{" "}
-            <strong className="text-white">{client.clientName}</strong>. No browser login is
-            required.
-          </p>
-          <a
-            href={`${query.redirect_uri}?error=access_denied${query.state ? `&state=${encodeURIComponent(query.state)}` : ""}`}
-            className="inline-block rounded border border-charcoal-600 px-4 py-2 text-sm text-charcoal-300 hover:bg-charcoal-700"
-          >
-            Close
-          </a>
-        </div>
-      </div>
+      <ConsentCard title="Bearer authentication" accentColor={accentColor}>
+        <p className="text-sm text-charcoal-300">
+          {entity.displayName} uses an operator-managed bearer token; no browser authorization is
+          available.
+        </p>
+        <DenyForm transaction={transaction} label="Close" />
+      </ConsentCard>
     );
   }
 
-  // ── Platform flow (default) ───────────────────────────────────────────
   return (
-    <div className="mx-auto flex min-h-screen max-w-xl items-center p-6">
-      <div className="w-full rounded-lg border border-charcoal-700 bg-charcoal-800 p-8 shadow-xl">
-        <h1 className="text-xl font-semibold text-white">
-          Authorize <span className="text-indigo-400">{client.clientName}</span>
+    <ConsentCard title={`Authorize ${client.clientName}`} accentColor={accentColor} wide>
+      <p className="text-sm text-charcoal-300">
+        This application wants to access your Platos agents in {environment.name}.
+      </p>
+      <ScopeSummary scopes={effectiveScopes} />
+      <Form method="post" className="flex justify-end gap-2">
+        <input type="hidden" name="transaction" value={transaction} />
+        <button
+          type="submit"
+          name="action"
+          value="deny"
+          className="rounded border border-charcoal-600 px-4 py-2 text-sm text-charcoal-200"
+        >
+          Deny
+        </button>
+        <button
+          type="submit"
+          name="action"
+          value="approve"
+          className="rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white"
+        >
+          Authorize
+        </button>
+      </Form>
+    </ConsentCard>
+  );
+}
+
+function DenyForm({ transaction, label = "Cancel" }: { transaction: string; label?: string }) {
+  return (
+    <Form method="post">
+      <input type="hidden" name="transaction" value={transaction} />
+      <button
+        type="submit"
+        name="action"
+        value="deny"
+        className="flex w-full justify-center rounded-lg border border-charcoal-600 px-4 py-2 text-sm text-charcoal-300"
+      >
+        {label}
+      </button>
+    </Form>
+  );
+}
+
+function ConsentCard({
+  title,
+  accentColor,
+  wide = false,
+  children,
+}: {
+  title: string;
+  accentColor: string;
+  wide?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`mx-auto flex min-h-screen ${wide ? "max-w-xl" : "max-w-sm"} items-center p-6`}>
+      <div className="w-full space-y-5 rounded-xl border border-charcoal-700 bg-charcoal-800 p-8 shadow-xl">
+        <h1 className="text-lg font-semibold text-white" style={{ color: accentColor }}>
+          {title}
         </h1>
-        <p className="mt-2 text-sm text-charcoal-300">
-          This application wants to access your Platos agents on your behalf. It will be able to
-          call tools and read conversation history for the scope you select below.
-        </p>
-
-        <Form method="post" className="mt-6 space-y-4">
-          <input type="hidden" name="client_id" value={query.client_id} />
-          <input type="hidden" name="redirect_uri" value={query.redirect_uri} />
-          <input type="hidden" name="code_challenge" value={query.code_challenge} />
-          {query.scope ? <input type="hidden" name="scope" value={query.scope} /> : null}
-          {query.state ? <input type="hidden" name="state" value={query.state} /> : null}
-
-          <label className="block text-sm text-charcoal-200">
-            Select scope (org / project / environment):
-            <select
-              name="scope_tuple"
-              required
-              className="mt-1 block w-full rounded border border-charcoal-600 bg-charcoal-900 px-3 py-2 text-white"
-            >
-              <option value="">— pick one —</option>
-              {data.scopes.map((s) => (
-                <option key={s.value} value={s.value}>
-                  {s.organizationName} / {s.projectName} / {s.environmentLabel}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <div className="rounded border border-charcoal-700 bg-charcoal-900 p-3 text-xs text-charcoal-400">
-            Redirect: <code className="text-charcoal-200">{client.redirectUri}</code>
-            <br />
-            Requested scopes:{" "}
-            <code className="text-charcoal-200">{query.scope ?? "mcp:read mcp:write"}</code>
-          </div>
-
-          <div className="flex justify-end gap-2">
-            <button
-              type="submit"
-              name="action"
-              value="deny"
-              className="rounded border border-charcoal-600 px-4 py-2 text-sm text-charcoal-200 hover:bg-charcoal-700"
-            >
-              Deny
-            </button>
-            <button
-              type="submit"
-              name="action"
-              value="allow"
-              className="rounded bg-indigo-500 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-400"
-            >
-              Authorize
-            </button>
-          </div>
-        </Form>
+        {children}
       </div>
     </div>
   );

--- a/content/docs/mcp-gateway.md
+++ b/content/docs/mcp-gateway.md
@@ -38,7 +38,7 @@ The MCP gateway is the universal Model Context Protocol surface in front of Plat
 
 ## What it is
 
-A single MCP endpoint at `/mcp` plus per-entity endpoints at `/mcp/entities/{slug}`. The gateway:
+A single MCP endpoint at `/mcp` plus per-entity endpoints at `/mcp/entity/{slug}`. The gateway:
 
 - **Federates**: enumerates tools from all four families on each `tools/list` MCP call. The same federation that the agent runtime uses internally is exposed externally with consistent semantics.
 - **Authenticates**: three identity modes (PIFSP-22): anonymous (limited public tools), OIDC federation (delegated user identity), bearer PAT (long-lived programmatic access).
@@ -75,16 +75,16 @@ Authenticate with a PAT (`Authorization: Bearer plt_ent_...`). The client lists 
 ### Per-entity endpoint
 
 ```
-https://platos.example.com/mcp/entities/acme
+https://platos.example.com/mcp/entity/acme
 ```
 
 Tools list scopes to the entity's pushed tools plus any Platos skills the entity has opted in.
 
 ### Identity modes
 
-- **Anonymous**: no auth header. Only tools flagged `public: true` are exposed. Use cases: read-only public data, demo skills.
-- **OIDC**: `Authorization: Bearer <oidc-id-token>`. The gateway federates with your OIDC provider, resolves the user, and applies per-user ACLs.
-- **Bearer PAT**: `Authorization: Bearer plt_ent_...`. The PAT carries a fixed scope and an explicit ACL.
+- **Anonymous**: no auth header. Only tools admitted by the anonymous ACL are exposed. The canonical `environmentId` query parameter is always required; the gateway resolves the entity slug inside that environment and never performs a global slug preselection.
+- **OIDC**: OAuth authorization pins one canonical environment and carries it through the auth code, access token, refresh token, and delegated OIDC session.
+- **Bearer PAT**: `Authorization: Bearer plt_ent_...`. The PAT is minted for the dashboard's current environment and always reuses that exact environment.
 
 ### Per-tool ACL
 
@@ -102,6 +102,8 @@ Per-entity endpoints expose `serverInfo` (name, description, logo, support URL) 
 
 - The gateway is the cross-scope cut. A bug in `permission-gateway.service.ts` can leak tools across orgs. Audit the test bar; the cross-scope IDOR probes cover this path.
 - Anonymous mode is opt-in per tool. A naively published tool with `public: true` is callable by any unauthenticated client. Treat `public: true` as a deliberate decision, not a default.
+- Never depend on project creation order to select an environment. Supply `?environmentId=<canonical-id>` for anonymous and entity OAuth discovery/authorization. Bearer routes validate the token first, load its authoritative entity and environment, then compare the requested slug.
+- External tool arguments cannot set Platos transport authority. The gateway recursively removes reserved `_context`, `__platos`, `_platos`, `platos_context`, `platosContext`, and `__platosContext` envelopes before MCP or wire dispatch, then adds server-derived context only when the entity enables it.
 - OIDC federation requires `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL` env vars. Misconfigured OIDC silently rejects valid tokens.
 - The Settings -> Integrations route exists in two scopes (project and org) with similar names (drift D-006). The org-scoped page is for OAuth-style integrations like Slack; the project-scoped page is for MCP and webhook config. Cross-link from this doc to disambiguate.
 

--- a/content/docs/mcp-tokens-and-pat.md
+++ b/content/docs/mcp-tokens-and-pat.md
@@ -28,7 +28,7 @@ Two long-lived bearer formats: PAT (`plt_ent_*`) for human and machine users, OA
 
 ## What it is
 
-- **PAT** (Personal Access Token): a string starting `plt_ent_`, issued from the dashboard. Each PAT carries `(userId, scope, scopes[])`. `scopes[]` is an array of permission slugs (e.g. `agents:read`, `threads:write`, `metrics:read`).
+- **PAT** (Personal Access Token): a string starting `plt_ent_`, issued from an environment-scoped entity dashboard. Each PAT carries `(entityId, environmentId, mcpUserId, scopes[])`; the environment cannot change after mint.
 - **OAuth 2.1 DCR token**: issued through dynamic client registration. The MCP client registers (no upfront credentials), gets a client id and secret, runs the auth code flow, and ends up with a bearer token tied to a user and scope. Equivalent power to a PAT, different lifecycle.
 
 `TokenService` mints, lists, revokes; `MCPBearerTokenService` is the verifier on the MCP path. The verifier accepts both formats and normalises them into the same `AuthenticatedRequest` shape.
@@ -44,7 +44,7 @@ The two formats split by ergonomics:
 - PAT: paste a string. Fastest path; right for personal use, scripts, CI.
 - OAuth DCR: ergonomic for production MCP clients (Claude Desktop, IDE plugins) that already speak the OAuth handshake. No paste-the-string UX.
 
-Both paths land at the same enforcement point, so the auth surface stays simple.
+Both paths land at the same enforcement point and revalidate entity/project/environment ancestry on every HTTP or SSE message.
 
 ## How to use it
 
@@ -68,6 +68,8 @@ Set `scopes: ["agent:agent_id_xyz:read"]`. The PAT can list and read that agent 
 
 ### OAuth 2.1 DCR
 
+Dynamic registration can request only the authorization server's advertised MCP scopes (`mcp:tools` for entity endpoints and `mcp:read mcp:write` for the platform endpoint). Caller-defined ACL or privileged labels are rejected. Authorization stores the exact effective scopes in a signed, opaque, one-time consent transaction; the consent page carries only that transaction and displays those server-effective scopes.
+
 The MCP client hits `/.well-known/oauth-authorization-server` and discovers the registration endpoint. POST `/oauth/register` with the standard DCR body returns a `client_id` and `client_secret`. Then standard auth-code flow.
 
 ```http
@@ -84,9 +86,10 @@ The resulting bearer is what the client uses on `/mcp`.
 ## Common pitfalls
 
 - PAT bearer tokens MUST start with `plt_ent_`. The recent fix (commit `adfe32e6b`) accepts both PAT and OAuth bearer; older deployments may only accept the OAuth shape.
+- PATs never default to production or the oldest environment. Mint from the intended environment page; switching dashboard environments creates a separately scoped token.
 - A PAT's `scopes[]` is checked on every call. A token without `agents:write` cannot create an agent even if it has `agents:read`. Audit on `/settings/mcp-tokens` if a permission is failing unexpectedly.
-- OAuth DCR registration is unauthenticated by default; rate limits apply (see [Rate limits](/docs/rate-limits)). A misconfigured client retrying registration can hit the cap.
-- Tokens are scoped at issue time; rotating a project's permissions does not retroactively update existing tokens. Reissue when permissions tighten.
+- OAuth DCR registration is unauthenticated by default; rate limits apply (see [Rate limits](/docs/rate-limits)). Registration cannot add arbitrary scopes, and consent transactions expire and reject tamper or replay.
+- Tokens are scoped at issue time; rotating a project's permissions does not retroactively update existing tokens. Reissue when permissions tighten. Revocation is checked again for every SSE `/messages` request.
 
 ## Related
 

--- a/content/guides/consume-platos-mcp.md
+++ b/content/guides/consume-platos-mcp.md
@@ -62,7 +62,7 @@ An MCP client connected to your Platos instance. The client's tool catalogue fed
    If you only want one entity's tools, point at the per-entity endpoint instead:
 
    ```
-   https://platos.example.com/mcp/entities/my-entity
+   https://platos.example.com/mcp/entity/my-entity
    ```
 
    Branding (PIFSP-24) means the connector shows the entity's own name.
@@ -78,6 +78,8 @@ An MCP client connected to your Platos instance. The client's tool catalogue fed
 - Token must start with `plt_ent_`. The recent fix (commit `adfe32e6b`) accepts both PAT and OAuth bearers; older deployments may only accept the OAuth shape.
 - Token must have the right `scopes`. A PAT scoped only `agents:read` cannot execute tools.
 - Token must be in the right scope (org/project/env). MCP gateway picks the scope from the PAT.
+- Anonymous entity endpoints require `?environmentId=<canonical-id>` on every request. OAuth clients must use only the scopes advertised by discovery; the browser consent URL contains an opaque one-time transaction rather than mutable OAuth authority fields.
+- The PAT's environment is fixed at mint. The gateway never substitutes production or the oldest project environment.
 
 ## Next steps
 

--- a/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
+++ b/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
@@ -541,6 +541,7 @@ CREATE TABLE "public"."OAuthRefreshToken" (
 CREATE TABLE "public"."McpBearerToken" (
     "id" UUID NOT NULL,
     "entityId" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
     "createdByUserId" UUID NOT NULL,
     "tokenHash" TEXT NOT NULL,
     "label" TEXT NOT NULL,
@@ -1320,6 +1321,28 @@ CREATE TABLE "public"."OAuthAuthorizationCode" (
 );
 
 -- CreateTable
+CREATE TABLE "public"."OAuthConsentTransaction" (
+    "id" UUID NOT NULL,
+    "tokenHash" TEXT NOT NULL,
+    "nonce" UUID NOT NULL,
+    "clientId" UUID NOT NULL,
+    "redirectUri" TEXT NOT NULL,
+    "codeChallenge" TEXT NOT NULL,
+    "codeChallengeMethod" TEXT NOT NULL,
+    "scopes" TEXT[],
+    "entityId" UUID,
+    "organizationId" UUID NOT NULL,
+    "projectId" UUID NOT NULL,
+    "environmentId" UUID NOT NULL,
+    "state" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "consumedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OAuthConsentTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "public"."McpAnonymousSession" (
     "id" UUID NOT NULL,
     "environmentId" UUID NOT NULL,
@@ -1676,7 +1699,10 @@ CREATE INDEX "OAuthRefreshToken_environmentId_idx" ON "public"."OAuthRefreshToke
 CREATE UNIQUE INDEX "McpBearerToken_tokenHash_key" ON "public"."McpBearerToken"("tokenHash");
 
 -- CreateIndex
-CREATE INDEX "McpBearerToken_entityId_mcpUserId_revokedAt_expiresAt_idx" ON "public"."McpBearerToken"("entityId", "mcpUserId", "revokedAt", "expiresAt");
+CREATE INDEX "McpBearerToken_entityId_environmentId_mcpUserId_revokedAt_e_idx" ON "public"."McpBearerToken"("entityId", "environmentId", "mcpUserId", "revokedAt", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "McpBearerToken_environmentId_idx" ON "public"."McpBearerToken"("environmentId");
 
 -- CreateIndex
 CREATE INDEX "McpBearerToken_createdByUserId_idx" ON "public"."McpBearerToken"("createdByUserId");
@@ -1952,6 +1978,21 @@ CREATE INDEX "OAuthAuthorizationCode_clientId_idx" ON "public"."OAuthAuthorizati
 CREATE INDEX "OAuthAuthorizationCode_userId_idx" ON "public"."OAuthAuthorizationCode"("userId");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "OAuthConsentTransaction_tokenHash_key" ON "public"."OAuthConsentTransaction"("tokenHash");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OAuthConsentTransaction_nonce_key" ON "public"."OAuthConsentTransaction"("nonce");
+
+-- CreateIndex
+CREATE INDEX "OAuthConsentTransaction_clientId_expiresAt_consumedAt_idx" ON "public"."OAuthConsentTransaction"("clientId", "expiresAt", "consumedAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthConsentTransaction_environmentId_expiresAt_idx" ON "public"."OAuthConsentTransaction"("environmentId", "expiresAt");
+
+-- CreateIndex
+CREATE INDEX "OAuthConsentTransaction_entityId_environmentId_idx" ON "public"."OAuthConsentTransaction"("entityId", "environmentId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "McpAnonymousSession_environmentId_entityId_mcpUserId_key" ON "public"."McpAnonymousSession"("environmentId", "entityId", "mcpUserId");
 
 -- CreateIndex
@@ -2148,6 +2189,9 @@ ALTER TABLE "public"."OAuthRefreshToken" ADD CONSTRAINT "OAuthRefreshToken_paren
 
 -- AddForeignKey
 ALTER TABLE "public"."McpBearerToken" ADD CONSTRAINT "McpBearerToken_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."McpBearerToken" ADD CONSTRAINT "McpBearerToken_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."McpBearerToken" ADD CONSTRAINT "McpBearerToken_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "public"."User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -2495,6 +2539,21 @@ ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorization
 ALTER TABLE "public"."OAuthAuthorizationCode" ADD CONSTRAINT "OAuthAuthorizationCode_userId_fkey" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "public"."OAuthConsentTransaction" ADD CONSTRAINT "OAuthConsentTransaction_clientId_fkey" FOREIGN KEY ("clientId") REFERENCES "public"."OAuthClient"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthConsentTransaction" ADD CONSTRAINT "OAuthConsentTransaction_entityId_fkey" FOREIGN KEY ("entityId") REFERENCES "public"."Entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthConsentTransaction" ADD CONSTRAINT "OAuthConsentTransaction_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "public"."Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthConsentTransaction" ADD CONSTRAINT "OAuthConsentTransaction_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "public"."Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."OAuthConsentTransaction" ADD CONSTRAINT "OAuthConsentTransaction_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "public"."McpAnonymousSession" ADD CONSTRAINT "McpAnonymousSession_environmentId_fkey" FOREIGN KEY ("environmentId") REFERENCES "public"."Environment"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -2680,9 +2739,10 @@ CREATE TRIGGER "ProviderKey_owner_immutable" BEFORE UPDATE ON "public"."Provider
 CREATE TRIGGER "McpToken_owner_immutable" BEFORE UPDATE ON "public"."McpToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('environmentId', 'mintedByUserId');
 CREATE TRIGGER "PersonalAccessToken_scope_immutable" BEFORE UPDATE ON "public"."PersonalAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
 CREATE TRIGGER "OAuthAuthorizationCode_scope_immutable" BEFORE UPDATE ON "public"."OAuthAuthorizationCode" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
+CREATE TRIGGER "OAuthConsentTransaction_owner_immutable" BEFORE UPDATE ON "public"."OAuthConsentTransaction" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('tokenHash', 'nonce', 'clientId', 'redirectUri', 'codeChallenge', 'codeChallengeMethod', 'scopes', 'entityId', 'organizationId', 'projectId', 'environmentId', 'state', 'expiresAt', 'createdAt');
 CREATE TRIGGER "OAuthAccessToken_scope_immutable" BEFORE UPDATE ON "public"."OAuthAccessToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId');
 CREATE TRIGGER "OAuthRefreshToken_scope_immutable" BEFORE UPDATE ON "public"."OAuthRefreshToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('clientId', 'userId', 'scopeKind', 'organizationId', 'projectId', 'environmentId', 'rotationFamilyId', 'parentRefreshTokenId');
-CREATE TRIGGER "McpBearerToken_owner_immutable" BEFORE UPDATE ON "public"."McpBearerToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('entityId', 'createdByUserId');
+CREATE TRIGGER "McpBearerToken_owner_immutable" BEFORE UPDATE ON "public"."McpBearerToken" FOR EACH ROW EXECUTE FUNCTION "public"."reject_canonical_owner_change"('entityId', 'environmentId', 'createdByUserId');
 
 -- A Redis thread lock may select any historical version of an Environment-bound
 -- agent. All of those versions are therefore executable, including their
@@ -3078,9 +3138,24 @@ BEGIN
           AND (NEW."accessTokenId" IS NULL OR access.id IS NOT NULL)
           AND (NEW."parentRefreshTokenId" IS NULL OR parent.id IS NOT NULL)
       ) INTO valid;
+    WHEN 'OAuthConsentTransaction' THEN
+      SELECT EXISTS (
+        SELECT 1 FROM "OAuthClient" client
+        JOIN "Project" project ON project.id = NEW."projectId"
+          AND project."organizationId" = NEW."organizationId"
+        JOIN "Environment" environment ON environment.id = NEW."environmentId"
+          AND environment."projectId" = project.id
+        LEFT JOIN "Entity" entity ON entity.id = NEW."entityId"
+          AND entity."projectId" = project.id
+        WHERE client.id = NEW."clientId"
+          AND client."organizationId" = NEW."organizationId"
+          AND (NEW."entityId" IS NULL OR entity.id IS NOT NULL)
+      ) INTO valid;
     WHEN 'McpBearerToken' THEN
       SELECT EXISTS (
         SELECT 1 FROM "Entity" entity JOIN "Project" p ON p.id = entity."projectId"
+        JOIN "Environment" environment ON environment.id = NEW."environmentId"
+          AND environment."projectId" = entity."projectId"
         JOIN "OrganizationMembership" membership ON membership."organizationId" = p."organizationId"
           AND membership."userId" = NEW."createdByUserId" AND membership."deactivatedAt" IS NULL
         WHERE entity.id = NEW."entityId"
@@ -3127,6 +3202,7 @@ CREATE TRIGGER "MemoryEntity_ancestry" BEFORE INSERT OR UPDATE ON "public"."Memo
 CREATE TRIGGER "MemoryRelationship_ancestry" BEFORE INSERT OR UPDATE ON "public"."MemoryRelationship" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
 CREATE TRIGGER "OAuthClient_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthClient" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
 CREATE TRIGGER "OAuthAuthorizationCode_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthAuthorizationCode" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
+CREATE TRIGGER "OAuthConsentTransaction_ancestry" BEFORE INSERT OR UPDATE ON "public"."OAuthConsentTransaction" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
 CREATE TRIGGER "McpAnonymousSession_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpAnonymousSession" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
 CREATE TRIGGER "McpOidcSession_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpOidcSession" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();
 CREATE TRIGGER "McpToken_ancestry" BEFORE INSERT OR UPDATE ON "public"."McpToken" FOR EACH ROW EXECUTE FUNCTION "public"."enforce_domain_ancestry"();

--- a/internal-packages/tenancy-database/prisma/schema.prisma
+++ b/internal-packages/tenancy-database/prisma/schema.prisma
@@ -262,6 +262,7 @@ model Organization {
   oauthAccessTokens       OAuthAccessToken[]
   oauthRefreshTokens      OAuthRefreshToken[]
   oauthAuthorizationCodes OAuthAuthorizationCode[]
+  oauthConsentTransactions OAuthConsentTransaction[]
 
   @@index([archivedAt])
 }
@@ -327,6 +328,7 @@ model Project {
   oauthAccessTokens       OAuthAccessToken[]
   oauthRefreshTokens      OAuthRefreshToken[]
   oauthAuthorizationCodes OAuthAuthorizationCode[]
+  oauthConsentTransactions OAuthConsentTransaction[]
 
   @@unique([organizationId, slug])
   @@unique([id, organizationId])
@@ -394,6 +396,7 @@ model Environment {
   events                  Event[]
   notificationRules       NotificationRule[]
   oauthAuthorizationCodes OAuthAuthorizationCode[]
+  oauthConsentTransactions OAuthConsentTransaction[]
   mcpAnonymousSessions    McpAnonymousSession[]
   mcpOidcSessions         McpOidcSession[]
   accessKeys              AccessKey[]
@@ -402,6 +405,7 @@ model Environment {
   personalAccessTokens    PersonalAccessToken[]
   oauthAccessTokens       OAuthAccessToken[]
   oauthRefreshTokens      OAuthRefreshToken[]
+  mcpBearerTokens         McpBearerToken[]
 
   @@unique([projectId, slug])
   @@index([projectId, archivedAt])
@@ -849,6 +853,7 @@ model OAuthRefreshToken {
 model McpBearerToken {
   id              String    @id @default(uuid()) @db.Uuid
   entityId        String    @db.Uuid
+  environmentId   String    @db.Uuid
   createdByUserId String    @db.Uuid
   tokenHash       String    @unique
   label           String
@@ -859,10 +864,12 @@ model McpBearerToken {
   expiresAt       DateTime?
   revokedAt       DateTime?
 
-  entity    Entity @relation(fields: [entityId], references: [id], onDelete: Cascade)
-  createdBy User   @relation(fields: [createdByUserId], references: [id], onDelete: Restrict)
+  entity      Entity      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  environment Environment @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+  createdBy   User        @relation(fields: [createdByUserId], references: [id], onDelete: Restrict)
 
-  @@index([entityId, mcpUserId, revokedAt, expiresAt])
+  @@index([entityId, environmentId, mcpUserId, revokedAt, expiresAt])
+  @@index([environmentId])
   @@index([createdByUserId])
 }
 
@@ -1095,6 +1102,7 @@ model Entity {
   mcpAnonymousSessions McpAnonymousSession[]
   mcpOidcSessions      McpOidcSession[]
   oauthClients         OAuthClient[]
+  oauthConsentTransactions OAuthConsentTransaction[]
   mcpBearerTokens      McpBearerToken[]
 
   @@unique([projectId, externalId])
@@ -1836,6 +1844,7 @@ model OAuthClient {
   registeredBy       User                     @relation(fields: [registeredByUserId], references: [id], onDelete: Restrict)
   entity             Entity?                  @relation(fields: [entityId], references: [id], onDelete: SetNull)
   authorizationCodes OAuthAuthorizationCode[]
+  consentTransactions OAuthConsentTransaction[]
   accessTokens       OAuthAccessToken[]
   refreshTokens      OAuthRefreshToken[]
 
@@ -1870,6 +1879,35 @@ model OAuthAuthorizationCode {
   @@index([environmentId, expiresAt])
   @@index([clientId])
   @@index([userId])
+}
+
+model OAuthConsentTransaction {
+  id                  String    @id @default(uuid()) @db.Uuid
+  tokenHash           String    @unique
+  nonce               String    @unique @db.Uuid
+  clientId            String    @db.Uuid
+  redirectUri         String
+  codeChallenge       String
+  codeChallengeMethod String
+  scopes              String[]
+  entityId            String?   @db.Uuid
+  organizationId      String    @db.Uuid
+  projectId           String    @db.Uuid
+  environmentId       String    @db.Uuid
+  state               String?
+  expiresAt           DateTime
+  consumedAt          DateTime?
+  createdAt           DateTime  @default(now())
+
+  client       OAuthClient  @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  entity       Entity?      @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  project      Project      @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  environment  Environment  @relation(fields: [environmentId], references: [id], onDelete: Cascade)
+
+  @@index([clientId, expiresAt, consumedAt])
+  @@index([environmentId, expiresAt])
+  @@index([entityId, environmentId])
 }
 
 model McpAnonymousSession {

--- a/internal-packages/tenancy-database/src/integration.test.ts
+++ b/internal-packages/tenancy-database/src/integration.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { resolve } from "node:path";
 import {
   ApprovalStatus,
@@ -62,7 +63,7 @@ describe("domain schema integration", () => {
 
   test("round-trips every generated model and capability", async () => {
     const modelNames = Prisma.dmmf.datamodel.models.map((model) => model.name);
-    expect(modelNames).toHaveLength(79);
+    expect(modelNames).toHaveLength(80);
     expect([...seeded.registry.keys()].sort()).toEqual([...modelNames].sort());
 
     for (const modelName of modelNames) {
@@ -201,6 +202,17 @@ describe("domain schema integration", () => {
         role: OrganizationRole.MEMBER,
       },
     });
+    await expect(control.mcpBearerToken.create({
+      data: {
+        entityId: seeded.mcpBearerToken.entityId,
+        environmentId: otherEnvironment.id,
+        createdByUserId: seeded.user.id,
+        tokenHash: "cross-environment-mcp-bearer",
+        label: "invalid",
+        mcpUserId: "invalid",
+        scopes: ["tools:call"],
+      },
+    })).rejects.toThrow(/ancestry/);
     await expect(control.oAuthClient.update({
       where: { id: seeded.oauthClient.id },
       data: { organizationId: otherOrganization.id, entityId: null },
@@ -759,6 +771,7 @@ describe("domain schema integration", () => {
     });
     expect(seeded.mcpBearerToken).toMatchObject({
       entityId: expect.any(String),
+      environmentId: seeded.environment.id,
       createdByUserId: seeded.user.id,
       mcpUserId: "entity-user",
       scopes: ["tools:call"],
@@ -1541,6 +1554,7 @@ async function seedEveryModel(control: PrismaClient) {
   const mcpBearerToken = track("McpBearerToken", await control.mcpBearerToken.create({
     data: {
       entityId: entity.id,
+      environmentId: environment.id,
       createdByUserId: user.id,
       tokenHash: "mcp-bearer-hash",
       label: "entity bearer",
@@ -1559,6 +1573,23 @@ async function seedEveryModel(control: PrismaClient) {
       codeChallengeMethod: "S256",
       redirectUri: "https://example.test/callback",
       scopes: ["invoke"],
+      expiresAt: future(),
+    },
+  }));
+  track("OAuthConsentTransaction", await control.oAuthConsentTransaction.create({
+    data: {
+      tokenHash: "oauth-consent-token-hash",
+      nonce: randomUUID(),
+      clientId: oauthClient.id,
+      redirectUri: "https://example.test/callback",
+      codeChallenge: "challenge",
+      codeChallengeMethod: "S256",
+      scopes: ["mcp:tools"],
+      entityId: entity.id,
+      organizationId: organization.id,
+      projectId: project.id,
+      environmentId: environment.id,
+      state: "state",
       expiresAt: future(),
     },
   }));

--- a/internal-packages/tenancy-database/src/schema.test.ts
+++ b/internal-packages/tenancy-database/src/schema.test.ts
@@ -62,9 +62,9 @@ const expectedEndUserModels = [
 describe("clean-slate domain schema", () => {
   test("uses the approved normalized target and no persisted Platos prefixes", () => {
     const models = ControlPrisma.dmmf.datamodel.models.map((model) => model.name);
-    expect(models).toHaveLength(79);
-    expect(domainModelNames).toHaveLength(63);
-    expect(new Set(domainModelNames).size).toBe(63);
+    expect(models).toHaveLength(80);
+    expect(domainModelNames).toHaveLength(64);
+    expect(new Set(domainModelNames).size).toBe(64);
     expect(new Set([...domainModelNames, ...tenancyOnlyModels])).toEqual(new Set(models));
     expect(models.some((name) => name.startsWith("Platos"))).toBe(false);
     expect(schema).not.toContain("@@map(");
@@ -132,9 +132,10 @@ describe("clean-slate domain schema", () => {
       McpToken: ["environmentId", "mintedByUserId", "permissions", "tier"],
       PersonalAccessToken: ["userId", "scopeKind", "organizationId", "projectId", "environmentId"],
       OAuthAuthorizationCode: ["clientId", "userId", "scopeKind", "organizationId", "projectId", "environmentId"],
+      OAuthConsentTransaction: ["clientId", "organizationId", "projectId", "environmentId", "scopes", "nonce"],
       OAuthAccessToken: ["clientId", "userId", "scopeKind", "scopes"],
       OAuthRefreshToken: ["accessTokenId", "rotationFamilyId", "parentRefreshTokenId", "consumedAt", "replayDetectedAt"],
-      McpBearerToken: ["entityId", "mcpUserId", "createdByUserId", "scopes"],
+      McpBearerToken: ["entityId", "environmentId", "mcpUserId", "createdByUserId", "scopes"],
       Thread: ["compactedUpToTurnId", "compactionState", "compactedAt"],
       Turn: ["agentVersionId", "versionBucket", "costCents", "latencyMs"],
       Step: [

--- a/internal-packages/tenancy-database/src/source-model-manifest.ts
+++ b/internal-packages/tenancy-database/src/source-model-manifest.ts
@@ -87,7 +87,7 @@ export const sourceModelManifest = [
   { source: "PlatosMcpAnonSession", targets: ["McpAnonymousSession"], owner: "environment", surface: "subject", decision: "rename" },
   { source: "PlatosMcpOidcSession", targets: ["McpOidcSession"], owner: "environment", surface: "subject", decision: "rename" },
   { source: "PlatosEntityMcpToolAcl", targets: ["EntityToolPolicy"], owner: "entity", surface: "operator", decision: "re-home" },
-  { source: "PlatosMcpBearerToken", targets: ["McpBearerToken"], owner: "entity", surface: "operator", decision: "re-home" },
+  { source: "PlatosMcpBearerToken", targets: ["McpBearerToken"], owner: "environment", surface: "operator", decision: "re-home" },
   { source: "PlatosErasureOperation", targets: ["ErasureOperation"], owner: "organization", surface: "operator", decision: "rename" },
 ] as const satisfies readonly SourceModelDisposition[];
 
@@ -97,6 +97,7 @@ export const supportDomainModels = [
   "Credential",
   "CredentialAudit",
   "CredentialSecretVersion",
+  "OAuthConsentTransaction",
 ] as const;
 
 /** All source target models plus independently required clean-slate support models. */


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
WIN-130 entity/inbound-MCP authorization split. Closes reproduced cross-entity and cross-environment authority gaps without including channel durability or entity deletion.

## Changes

- Resolves bearer/OAuth authority before route slug lookup and pins final dispatch to the authoritative entity and Environment.
- Revalidates the current persisted mapping, callback, and transport configuration immediately before wire or MCP dispatch.
- Makes entity bearer tokens Environment-owned across mint/list/revoke/audit, HTTP, SSE, `/messages`, and session-token revalidation.
- Requires explicit canonical Environment selection for anonymous access; removes production/oldest-Environment fallback.
- Propagates and verifies Environment ownership through OAuth discovery, authorization, token exchange/refresh/revoke, delegated OIDC, and anonymous consent.
- Restricts DCR/authorization scopes to the server-owned advertised MCP scope set; callers cannot mint arbitrary ACL labels.
- Recursively strips reserved context envelopes from external arguments and adds only server-derived context when enabled.
- Uses signed, persisted, expiring, one-time consent transactions; the webapp carries only the opaque transaction identifier.
- Updates the canonical clean initial schema directly. No legacy token deletion or data backfill is included.

## Scope boundary

- No channel changes; channel durability is isolated in https://github.com/winsenlabs/platos/pull/88.
- No entity deletion changes; atomic registry deletion remains in https://github.com/winsenlabs/platos/pull/86.
- No legacy schema or migration-engine work.

## Testing

- **PASS — focused MCP/auth/OAuth matrix: 11 files, 127 tests**
  - Duplicate-slug authority-first routing
  - DCR scope escalation denial
  - Recursive reserved-context stripping
  - Persisted callback reload
  - Consent tamper/replay/expiry rejection
  - Bearer/OAuth/anonymous Environment isolation
  - ACL and same-name cross-entity isolation
- **PASS — full tenancy suite: 8 files, 63 tests on real pgvector Testcontainers**
- **PASS — clean initial migration on a fresh database; exactly one migration applied**
- **PASS — Prisma drift gate (`No difference detected`)**
- **PASS — tenancy typecheck/build**
- **PASS — agent typecheck/strict build**
- **PASS — dependency-aware webapp production build (14/14 tasks)**
- **PASS — consent route ESLint, `git diff --check`, final review**

Preview verified at https://mytptwylizeb.preview.us1.vorflux.com with HTTP 200 and no browser console errors.
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
