### PR TITLE
fix(agent-runtime): tool results emitted twice per call

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -747,6 +747,30 @@ export function categorizeMetaTool(name: string): string {
 }
 
 /**
+ * Guard against emitting the same tool result twice in one step.
+ *
+ * The AI SDK surfaces a completed tool call through TWO channels: a
+ * `tool-result` (or `tool-error`) stream chunk, and `onStepEnd`'s
+ * `event.toolResults`, which lists every result for the step regardless of
+ * whether a chunk already carried it. Emitting both duplicated every tool
+ * result into the persisted `toolCalls` array and the replayed history, so
+ * each subsequent turn re-sent the doubled payload to the model.
+ *
+ * Returns true the first time a call ID is seen and records it. Results with
+ * no call ID cannot be correlated, so they always emit — dropping a real
+ * result is worse than a rare duplicate.
+ */
+export function claimToolResultEmission(
+  callId: string | null | undefined,
+  emitted: Set<string>,
+): boolean {
+  if (!callId) return true;
+  if (emitted.has(callId)) return false;
+  emitted.add(callId);
+  return true;
+}
+
+/**
  * W.1 — filter a meta-tool dict down to a caller-supplied allowlist.
  *
  * Phase 1 review follow-up: `allowed_tools` can legitimately name EITHER
@@ -5918,6 +5942,15 @@ export class AgentService {
       // Queue for tool results
       const pendingToolResults: AgentStreamEvent[] = [];
 
+      // Call IDs already yielded from a `tool-result` / `tool-error` stream
+      // chunk. `onStepEnd` reports EVERY tool result for the step — including
+      // the ones those chunks already emitted — so without this the same
+      // result is yielded twice: once from the chunk, once from the drain on
+      // `finish-step`. That duplication reached the persisted `toolCalls`
+      // array and the replayed history, doubling tool-result payload on every
+      // subsequent turn.
+      const emittedToolResultCallIds = new Set<string>();
+
       // ─── Theme F.5 — structured output enforcement branch ───────────────
       // When a schema is in play, we bypass the tool-calling streamText loop
       // and route through `streamObject`. Tools aren't compatible with
@@ -6377,9 +6410,14 @@ export class AgentService {
             }
             // Tool results are handled by Vercel AI SDK internally (fed back
             // to the model for the next step). We emit tool_result events
-            // from the onStepFinish callback via the pendingToolResults queue.
+            // from the onStepFinish callback via the pendingToolResults queue,
+            // skipping any call a `tool-result` / `tool-error` chunk already
+            // emitted earlier in this step.
             while (pendingToolResults.length > 0) {
-              yield pendingToolResults.shift()!;
+              const queued = pendingToolResults.shift()!;
+              if (claimToolResultEmission((queued as any).callId, emittedToolResultCallIds)) {
+                yield queued;
+              }
             }
             // Emit per-step trace for the inspector panel.
             {
@@ -6492,6 +6530,7 @@ export class AgentService {
             // provider-executed tool results stream as their own chunks
             // BEFORE the step finishes. Forward with `providerExecuted: true`
             // so the consumer can distinguish from step-attributed results.
+            claimToolResultEmission((chunk as any).toolCallId, emittedToolResultCallIds);
             yield {
               type: "tool_result",
               name: (chunk as any).toolName,
@@ -6505,6 +6544,7 @@ export class AgentService {
             // Tool returned an error result. Frontend currently renders the
             // wrapper JSON as a normal output; with `isError: true` it can
             // light up a "tool failed" indicator on the same toolCallId.
+            claimToolResultEmission((chunk as any).toolCallId, emittedToolResultCallIds);
             yield {
               type: "tool_result",
               name: (chunk as any).toolName,

--- a/apps/agent/src/agent-runtime/tool-result-dedup.test.ts
+++ b/apps/agent/src/agent-runtime/tool-result-dedup.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression: tool results were emitted twice per call.
+ *
+ * The AI SDK reports a completed tool call through two channels — a
+ * `tool-result` / `tool-error` stream chunk, and `onStepEnd`'s
+ * `event.toolResults`, which lists EVERY result for the step including ones a
+ * chunk already carried. The stream yielded both, so each result landed twice
+ * in `PlatosAgentMessage.toolCalls` and twice in the history replayed to the
+ * model on the next turn.
+ *
+ * Observed on test.platos before the fix: 1218 `call` events against 2376
+ * `result` events, of which only 1202 were distinct — an exact 2x on 176 of
+ * 211 tool-bearing messages, still reproducing on the day it was found.
+ *
+ * CLAUDE.md §9.11: Vitest only, no mocks. `claimToolResultEmission` is pure.
+ */
+import { describe, it, expect } from "vitest";
+import { claimToolResultEmission } from "./agent.service";
+
+describe("claimToolResultEmission", () => {
+  it("admits a call ID once and refuses it thereafter", () => {
+    const emitted = new Set<string>();
+    expect(claimToolResultEmission("call_1", emitted)).toBe(true);
+    expect(claimToolResultEmission("call_1", emitted)).toBe(false);
+    expect(claimToolResultEmission("call_1", emitted)).toBe(false);
+  });
+
+  it("tracks distinct call IDs independently", () => {
+    const emitted = new Set<string>();
+    expect(claimToolResultEmission("call_1", emitted)).toBe(true);
+    expect(claimToolResultEmission("call_2", emitted)).toBe(true);
+    expect(claimToolResultEmission("call_1", emitted)).toBe(false);
+    expect(claimToolResultEmission("call_2", emitted)).toBe(false);
+  });
+
+  it("always admits results with no call ID rather than dropping them", () => {
+    const emitted = new Set<string>();
+    // Uncorrelatable results must not be suppressed — losing a real result is
+    // worse than a duplicate.
+    expect(claimToolResultEmission(null, emitted)).toBe(true);
+    expect(claimToolResultEmission(null, emitted)).toBe(true);
+    expect(claimToolResultEmission(undefined, emitted)).toBe(true);
+    expect(claimToolResultEmission("", emitted)).toBe(true);
+    expect(emitted.size).toBe(0);
+  });
+
+  it("collapses the chunk-then-drain sequence to one emission per call", () => {
+    // Models one step: two tools resolve, each surfacing first as a stream
+    // chunk and again in onStepEnd's toolResults.
+    const emitted = new Set<string>();
+    const chunkResults = ["call_a", "call_b"];
+    const stepEndResults = ["call_a", "call_b"];
+
+    const yielded = [...chunkResults, ...stepEndResults].filter((callId) =>
+      claimToolResultEmission(callId, emitted),
+    );
+
+    expect(yielded).toEqual(["call_a", "call_b"]);
+  });
+
+  it("still emits a step-attributed result that no chunk carried", () => {
+    // Provider-executed calls arrive as chunks; client-executed ones may only
+    // appear at step end. Both must reach the consumer exactly once.
+    const emitted = new Set<string>();
+    const yielded = ["call_provider", "call_provider", "call_client"].filter((callId) =>
+      claimToolResultEmission(callId, emitted),
+    );
+
+    expect(yielded).toEqual(["call_provider", "call_client"]);
+  });
+});


### PR DESCRIPTION
## What

The AI SDK surfaces a completed tool call through two channels: a `tool-result` / `tool-error` stream chunk, and `onStepEnd`'s `event.toolResults`, which lists **every** result for the step regardless of whether a chunk already carried it. The stream yielded both.

The comment at `agent.service.ts:6359` documents the intended split — chunks for provider-executed calls, `onStepEnd` for step-attributed ones — but nothing ever excluded the overlap, so every tool result was emitted twice.

## Why it matters

Each duplicate landed in `PlatosAgentMessage.toolCalls` **and** in the history replayed to the model, so every subsequent turn re-sent the doubled tool-result payload. On a tool-heavy thread that compounds turn over turn — a direct contributor to the high input-token counts on test.platos.

## Evidence

Found while migrating test.platos. In the live database:

- **1218** `call` events against **2376** `result` events
- only **1202** of those results distinct
- exactly 2× on **176 of 211** tool-bearing messages
- still reproducing on the day it was found (14 calls / 28 results)

## The fix

Dedup by call ID through `claimToolResultEmission`. A result with no call ID cannot be correlated and always emits — dropping a real result is worse than a rare duplicate.

## Tests

`tool-result-dedup.test.ts` — 5 cases covering the chunk-then-drain sequence, repeated claims, distinct IDs, absent IDs, and a step-attributed result no chunk carried. Adjacent cache/persistence suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)