### PR TITLE
Fix initial migration checksum assertion

### DIFF
--- a/internal-packages/tenancy-database/src/schema.test.ts
+++ b/internal-packages/tenancy-database/src/schema.test.ts
@@ -254,7 +254,7 @@ describe("clean-slate domain schema", () => {
       "20260818010000_memory_entity_ownership_transition",
     ]);
     expect(createHash("sha256").update(migration).digest("hex")).toBe(
-      "ef1675ae7a79e3a426829892201a96c809cc2700a16426c24d69a14036dc383a"
+      "76039eaca78e84890ed9ca499890bf9579f31eff540953deda257ac50a855ad8"
     );
     expect(feedbackMigration).toContain('ADD COLUMN "quarantinedAt" TIMESTAMP(3)');
     expect(feedbackMigration).toContain('ADD COLUMN "revision" INTEGER NOT NULL DEFAULT 1');


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the immutable initial-migration checksum assertion with the migration content already merged by PR #91. PR #87 introduced the assertion from an older base, leaving current `main` red despite the migration itself being valid.

## Changes

- Updates only the expected SHA-256 checksum; the initial migration is not modified.

## Testing

- PASS — schema contract suite, 8 tests:
  `pnpm --filter @platos/tenancy-database exec vitest run src/schema.test.ts`
- PASS — `git diff --check`
- PARTIAL — `pnpm --filter @platos/tenancy-database test` passed all 29 collected non-integration tests, including `schema.test.ts`, but four integration files could not load `@testcontainers/postgresql` from the temporary linked-node_modules worktree. The preceding CI run on the same current-main content passed all integration suites and failed only this checksum assertion (63 passed, 1 failed).

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
