### PR TITLE
test(tenancy-database): realign the schema pins main outgrew

### DIFF
--- a/apps/agent/src/control-plane/operation-manifest.generated.json
+++ b/apps/agent/src/control-plane/operation-manifest.generated.json
@@ -11629,6 +11629,23 @@
         ]
       },
       {
+        "id": "GET /oauth/consent",
+        "method": "GET",
+        "path": "/oauth/consent",
+        "classification": "PUBLIC_TRANSPORT",
+        "policyRule": "oauth-protocol",
+        "mcpTools": [],
+        "mappingRationale": null,
+        "implementations": [
+          {
+            "controller": "OAuthController",
+            "handler": "inspectConsent",
+            "source": "apps/agent/src/oauth/oauth.controller.ts",
+            "requiresOperator": false
+          }
+        ]
+      },
+      {
         "id": "GET /oauth/entity/:entityId/authorize",
         "method": "GET",
         "path": "/oauth/entity/:entityId/authorize",
@@ -11842,14 +11859,14 @@
       "MAPPED": 83,
       "MCP_ONLY": 123
     },
-    "restOperations": 284,
-    "restRouteBindings": 285,
+    "restOperations": 285,
+    "restRouteBindings": 286,
     "ambiguousRestOperations": 1,
     "restClassifications": {
       "DEPRECATED": 13,
       "INTERNAL": 12,
       "MAPPED": 82,
-      "PUBLIC_TRANSPORT": 44,
+      "PUBLIC_TRANSPORT": 45,
       "REST_ONLY": 133
     }
   }

--- a/apps/agent/src/openapi/openapi.generated.json
+++ b/apps/agent/src/openapi/openapi.generated.json
@@ -8536,6 +8536,25 @@
         "x-platos-mcp-tools": []
       }
     },
+    "/oauth/consent": {
+      "get": {
+        "operationId": "get__oauth_consent",
+        "summary": "OAuthController.inspectConsent",
+        "tags": [
+          "public_transport"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response. REST payload schemas are intentionally omitted until a source schema is available."
+          }
+        },
+        "security": [],
+        "x-platos-classification": "PUBLIC_TRANSPORT",
+        "x-platos-auth-class": "PUBLIC_OAUTH_PROTOCOL",
+        "x-platos-policy-rule": "oauth-protocol",
+        "x-platos-mcp-tools": []
+      }
+    },
     "/oauth/entity/{entityId}/authorize": {
       "get": {
         "operationId": "get__oauth_entity_by_entityId_authorize",
@@ -8836,6 +8855,6 @@
     }
   },
   "x-platos-manifest-version": "M0.1",
-  "x-platos-rest-operation-count": 284,
+  "x-platos-rest-operation-count": 285,
   "x-platos-mcp-tool-count": 206
 }

--- a/docs/control-plane-parity.generated.md
+++ b/docs/control-plane-parity.generated.md
@@ -7,10 +7,10 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 ## Summary
 
 - MCP tools: **206** across **35** namespaces (24 admin-tier).
-- REST operations: **284** unique method/path pairs from **285** route bindings.
+- REST operations: **285** unique method/path pairs from **286** route bindings.
 - Ambiguous duplicate REST method/path pairs: **1**.
 - MCP classifications: MAPPED=83, MCP_ONLY=123.
-- REST classifications: DEPRECATED=13, INTERNAL=12, MAPPED=82, PUBLIC_TRANSPORT=44, REST_ONLY=133.
+- REST classifications: DEPRECATED=13, INTERNAL=12, MAPPED=82, PUBLIC_TRANSPORT=45, REST_ONLY=133.
 
 ## REST inventory
 
@@ -288,6 +288,7 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 | `GET /metrics` | PUBLIC_TRANSPORT | — | `service-observability` | `apps/agent/src/monitoring/metrics.controller.ts#scrape` |
 | `GET /oauth/authorize` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#authorize` |
 | `POST /oauth/authorize/callback` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#authorizeCallback` |
+| `GET /oauth/consent` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#inspectConsent` |
 | `GET /oauth/entity/:entityId/authorize` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#entityAuthorize` |
 | `POST /oauth/entity/:entityId/authorize/anonymous` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#entityAnonAuthorize` |
 | `GET /oauth/entity/:entityId/oidc-callback` | PUBLIC_TRANSPORT | — | `oauth-protocol` | `apps/agent/src/oauth/oauth.controller.ts#entityOidcCallback` |

--- a/internal-packages/tenancy-database/src/integration.test.ts
+++ b/internal-packages/tenancy-database/src/integration.test.ts
@@ -63,7 +63,7 @@ describe("domain schema integration", () => {
 
   test("round-trips every generated model and capability", async () => {
     const modelNames = Prisma.dmmf.datamodel.models.map((model) => model.name);
-    expect(modelNames).toHaveLength(80);
+    expect(modelNames).toHaveLength(81);
     expect([...seeded.registry.keys()].sort()).toEqual([...modelNames].sort());
 
     for (const modelName of modelNames) {

--- a/internal-packages/tenancy-database/src/schema.test.ts
+++ b/internal-packages/tenancy-database/src/schema.test.ts
@@ -80,9 +80,9 @@ const expectedEndUserModels = [
 describe("clean-slate domain schema", () => {
   test("uses the approved normalized target and no persisted Platos prefixes", () => {
     const models = ControlPrisma.dmmf.datamodel.models.map((model) => model.name);
-    expect(models).toHaveLength(80);
-    expect(domainModelNames).toHaveLength(64);
-    expect(new Set(domainModelNames).size).toBe(64);
+    expect(models).toHaveLength(81);
+    expect(domainModelNames).toHaveLength(65);
+    expect(new Set(domainModelNames).size).toBe(65);
     expect(new Set([...domainModelNames, ...tenancyOnlyModels])).toEqual(new Set(models));
     expect(models.some((name) => name.startsWith("Platos"))).toBe(false);
     expect(schema).not.toContain("@@map(");
@@ -266,7 +266,7 @@ describe("clean-slate domain schema", () => {
       "20260818020000_win130_channel_durability",
     ]);
     expect(createHash("sha256").update(migration).digest("hex")).toBe(
-      "76039eaca78e84890ed9ca499890bf9579f31eff540953deda257ac50a855ad8"
+      "d915b1e0626c750750830f80d6cc0b4bd5a80837476271a3384125f1b49a0398"
     );
 
     const generated = execFileSync(resolve(packageRoot, "node_modules/.bin/prisma"), [


### PR DESCRIPTION
## main is red

`schema.test.ts` pins three values that four PRs landing in sequence moved:

| pin | was | is |
|---|---|---|
| `models` | 80 | **81** |
| `domainModelNames` | 64 | **65** |
| initial-migration SHA-256 | `76039eac…` | `d915b1e0…` |

`ChannelEventInbox` (#88) and `OAuthConsentTransaction` (#89) are already declared in `supportDomainModels` — only the counts lagged. The digest moved because #89 edited the initial migration after #93 realigned it.

## Why CI didn't catch it

Every one of those PRs was green on its own branch. These assertions pin **repo-wide totals and a byte digest**, so any two PRs that touch them are green apart and red together. Branch CI cannot see the interaction; it only appears after the merge.

This is the third occurrence in two days — #93 was the same failure mode.

## Worth deciding separately

The test is named for keeping the initial migration *immutable*, but the repo is doing both things at once:

- **#89 and #91** edited `00000000000000_initial/migration.sql` directly
- **#87 and #88** appended new migrations instead

Both are defensible for a pre-launch clean-slate deployment, but not simultaneously. While the convention is unsettled the digest just gets bumped after each break, which is the opposite of what pinning it is for. Either the initial migration is frozen and everything appends, or it is editable and the digest pin should go.

I've only realigned the values here — not made that call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)