### PR TITLE
fix(deploy): make a fresh deploy resolve cleanly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,14 @@ PLATOS_EMBEDDING_MODEL=             # blank → default per provider (voyage-lar
 POSTGRES_PASSWORD=postgres
 CLICKHOUSE_PASSWORD=password
 
+# The agent runtime reads the clean tenancy schema out of POSTGRES_DB. The
+# dashboard has not been migrated yet, so it reads the legacy schema out of a
+# separate database — the two cannot share one, because both define User,
+# Organization and Project with different columns. Retire POSTGRES_LEGACY_DB
+# once the dashboard reads the clean schema.
+# POSTGRES_DB=postgres
+# POSTGRES_LEGACY_DB=platos_legacy
+
 # MinIO — override root creds in prod; agent startup warns loudly if defaults remain.
 # MINIO_ROOT_USER=platos-minio-admin
 # MINIO_ROOT_PASSWORD=platos-minio-password

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -276,6 +276,8 @@ services:
   # webapp `depends_on` uses service_completed_successfully so it
   # waits for this to finish.
   # ─────────────────────────────────────────────────────────────
+  # Deploys the clean tenancy schema the agent runtime reads. This is the
+  # canonical database: Agent, Thread, Turn, Step, ToolCall, Memory.
   migrations-init:
     image: node:22-alpine
     logging: *default-logging
@@ -286,7 +288,7 @@ services:
       DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
       DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
     volumes:
-      - ./internal-packages/database:/work
+      - ./internal-packages/tenancy-database:/work
     working_dir: /work
     entrypoint:
       - /bin/sh
@@ -295,9 +297,52 @@ services:
         set -e
         echo '[migrations-init] installing prisma...'
         npm install --no-audit --no-fund --silent prisma@6.14.0 @prisma/client@6.14.0
-        echo '[migrations-init] running prisma migrate deploy...'
+        echo '[migrations-init] deploying the clean tenancy schema...'
         npx prisma migrate deploy
         echo '[migrations-init] done'
+    restart: "no"
+
+  # Deploys the legacy schema into a SEPARATE database, for the dashboard.
+  #
+  # The webapp has not been migrated yet (M4 rebuilds it), so it still reads
+  # TaskRun, TaskQueue, RuntimeEnvironment and the Platos* models. Those cannot
+  # share a database with the clean schema: both define User, Organization and
+  # Project with different columns. Giving the legacy set its own Postgres
+  # schema does not work either — its migrations hardcode `public.` prefixes
+  # and fail partway with `relation "public.JobRun" does not exist` — so it
+  # gets its own database instead.
+  #
+  # Retire this service, and POSTGRES_LEGACY_DB, once the dashboard reads the
+  # clean schema.
+  migrations-init-legacy:
+    image: node:22-alpine
+    logging: *default-logging
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+    volumes:
+      - ./internal-packages/database:/work
+    working_dir: /work
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        echo '[migrations-init-legacy] ensuring the legacy database exists...'
+        apk add --no-cache postgresql-client >/dev/null
+        psql -h postgres -U "${POSTGRES_USER:-postgres}" -d postgres -tAc \
+          "SELECT 1 FROM pg_database WHERE datname='${POSTGRES_LEGACY_DB:-platos_legacy}'" \
+          | grep -q 1 || psql -h postgres -U "${POSTGRES_USER:-postgres}" -d postgres \
+          -c "CREATE DATABASE \"${POSTGRES_LEGACY_DB:-platos_legacy}\""
+        echo '[migrations-init-legacy] installing prisma...'
+        npm install --no-audit --no-fund --silent prisma@6.14.0 @prisma/client@6.14.0
+        echo '[migrations-init-legacy] deploying the legacy schema...'
+        npx prisma migrate deploy
+        echo '[migrations-init-legacy] done'
     restart: "no"
 
   agent:
@@ -485,7 +530,7 @@ services:
         condition: service_healthy
       clickhouse:
         condition: service_healthy
-      migrations-init:
+      migrations-init-legacy:
         condition: service_completed_successfully
       clickhouse-migrate:
         condition: service_completed_successfully
@@ -498,8 +543,9 @@ services:
       APP_ORIGIN: "${APP_ORIGIN:-http://localhost:3030}"
       LOGIN_ORIGIN: "${LOGIN_ORIGIN:-http://localhost:3030}"
       API_ORIGIN: "${API_ORIGIN:-http://localhost:3030}"
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
-      DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      # The dashboard still reads the legacy schema; see migrations-init-legacy.
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
       DATABASE_HOST: "postgres:5432"
       REDIS_HOST: redis
       REDIS_PORT: "6379"


### PR DESCRIPTION
## The bug

`migrations-init` deployed the **legacy** schema from `internal-packages/database`, while the agent runtime reads the **clean tenancy** schema. A fresh deploy therefore brought up an agent whose database had no `Thread`, `Turn`, `Agent`, or `EnvironmentEntityTool` — the same `P2021` that crash-looped test.platos and forced the rollback to `a83ee84`.

## Both migration sets are fine

Verified against empty databases:

| set | result | tables |
|---|---|---|
| clean (`tenancy-database`) | applies, exit 0 | 82 |
| legacy (`database`) | applies, exit 0 | 130 |

Nothing is wrong with the migrations. The fault was only ever **which one ran**.

## The fix

Deploy each against the database its consumer actually queries:

```
migrations-init         clean  -> POSTGRES_DB          (agent)
migrations-init-legacy  legacy -> POSTGRES_LEGACY_DB   (webapp)
```

They cannot share one database: both define `User`, `Organization` and `Project` with different columns.

I tried giving the legacy set its own Postgres schema rather than a second database. **It does not work** — its migrations hardcode `public.` prefixes, so `?schema=legacy` aborts partway with `relation "public.JobRun" does not exist`, leaving 62 of 130 tables. Hence a separate database, created by the job on first run.

## Verified end to end from empty

Both jobs exit 0, and each service's database holds what that service queries:

- agent's DB: `Thread=1 Turn=1 Agent=1 EnvironmentEntityTool=1` (82 tables)
- webapp's DB: `TaskRun=1 TaskQueue=1 RuntimeEnvironment=1 PlatosAgent=1` (130 tables)

`docker compose config` parses clean with the webapp resolving to `platos_legacy`.

## Known limitation

The dashboard and the runtime now hold **separate copies of agent configuration**, so a change made in the dashboard will not reach the runtime. That is real, and it lasts until M4 rebuilds the dashboard on the clean schema.

It is strictly better than the current state, where the agent cannot start at all. Retire `migrations-init-legacy` and `POSTGRES_LEGACY_DB` when M4 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)