### PR TITLE
fix(deploy): clickhouse-migrate image no longer resolves

### DIFF
--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -222,7 +222,14 @@ services:
   # service_completed_successfully.
   # ─────────────────────────────────────────────────────────────
   clickhouse-migrate:
-    image: ghcr.io/pressly/goose:3
+    # `ghcr.io/pressly/goose` no longer resolves — it answers `unauthorized`
+    # for every tag, anonymously and authenticated alike. Because the webapp
+    # waits on this service completing, an unpullable image meant `compose up`
+    # aborted before anything started, and the ClickHouse schema silently never
+    # migrated. `gomicro/goose` publishes the same CLI on Docker Hub; it needs
+    # an explicit entrypoint because its default is not the goose binary.
+    image: gomicro/goose:latest
+    entrypoint: ["goose"]
     logging: *default-logging
     depends_on:
       clickhouse:


### PR DESCRIPTION
## The bug

`ghcr.io/pressly/goose` answers `unauthorized` for **every** tag — anonymously and authenticated alike:

```
ghcr.io/pressly/goose:3          DENIED/absent
ghcr.io/pressly/goose:latest     DENIED/absent
gomicro/goose:latest             OK
```

The webapp waits on `clickhouse-migrate` with `service_completed_successfully`, so an unpullable image aborts `docker compose up` **before anything starts**. On an existing box the running containers mask it; on a fresh deploy it is fatal.

## What it was hiding

Swapping the image on test.platos applied **32 pending migrations** in one go, finishing at `032_platos_spans_user_identity`. The ClickHouse schema had never been migrated — observability was writing nowhere. That matches WIN-150.

## The change

`gomicro/goose` publishes the same CLI on Docker Hub. Its default entrypoint is not the goose binary, so `entrypoint: ["goose"]` is set explicitly — without it the container fails with `exec: "-dir": executable file not found in $PATH`.

Verified end to end against the live ClickHouse instance before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)