### PR TITLE
WIN-157: move dashboard login to Platos sessions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,8 +99,8 @@ CLICKHOUSE_PASSWORD=password
 # separate database — the two cannot share one, because both define User,
 # Organization and Project with different columns. Retire POSTGRES_LEGACY_DB
 # once the dashboard reads the clean schema.
-# POSTGRES_DB=postgres
-# POSTGRES_LEGACY_DB=platos_legacy
+POSTGRES_DB=platos_control
+POSTGRES_LEGACY_DB=platos_legacy
 
 # MinIO — override root creds in prod; agent startup warns loudly if defaults remain.
 # MINIO_ROOT_USER=platos-minio-admin
@@ -112,10 +112,14 @@ LOGIN_ORIGIN=http://localhost:3030
 # `${VAR}` references. Plain Node `dotenv` does NOT — if you ever load
 # `.env` directly via `dotenv.config()`, wire `dotenv-expand` too, OR
 # paste the resolved password into DATABASE_URL here.
-DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/postgres?schema=public
+DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/platos_legacy?schema=public
 # This sets the URL used for direct connections to the database and should only be needed in limited circumstances
 # See: https://www.prisma.io/docs/reference/api-reference/prisma-schema-reference#fields:~:text=the%20shadow%20database.-,directUrl,-No
 DIRECT_URL=${DATABASE_URL}
+# Dashboard-only clean control-plane client for OperatorSession/auth and
+# canonical credential authorization. DATABASE_URL and DIRECT_URL remain the
+# legacy dashboard resource database until M4; do not globally repoint them.
+PLATOS_CONTROL_DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/platos_control?schema=public
 REMIX_APP_PORT=3030
 APP_ENV=development
 APP_ORIGIN=http://localhost:3030

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -98,6 +98,12 @@ const EnvironmentSchema = z
         isValidDatabaseUrl,
         "DATABASE_URL is invalid, for details please check the additional output above this message."
       ),
+    PLATOS_CONTROL_DATABASE_URL: z
+      .string()
+      .refine(
+        isValidDatabaseUrl,
+        "PLATOS_CONTROL_DATABASE_URL is invalid, for details please check the additional output above this message."
+      ),
     DATABASE_CONNECTION_LIMIT: z.coerce.number().int().default(10),
     DATABASE_POOL_TIMEOUT: z.coerce.number().int().default(60),
     DATABASE_CONNECTION_TIMEOUT: z.coerce.number().int().default(20),

--- a/apps/webapp/app/models/admin.server.ts
+++ b/apps/webapp/app/models/admin.server.ts
@@ -1,15 +1,17 @@
 import { redirect } from "@remix-run/server-runtime";
 import { prisma } from "~/db.server";
 import { logger } from "~/services/logger.server";
-import { SearchParams } from "~/routes/admin._index";
+import type { SearchParams } from "~/routes/admin._index";
 import {
   clearImpersonationId,
   commitImpersonationSession,
   getImpersonationId,
   setImpersonationId,
 } from "~/services/impersonation.server";
-import { authenticator } from "~/services/auth.server";
-import { requireUser } from "~/services/session.server";
+import {
+  getDashboardIdentity,
+  requireDashboardIdentity,
+} from "~/services/platosDashboardAuth.server";
 import { extractClientIp } from "~/utils/extractClientIp.server";
 
 const pageSize = 20;
@@ -211,8 +213,12 @@ export async function adminGetOrganizations(userId: string, { page, search }: Se
 }
 
 export async function redirectWithImpersonation(request: Request, userId: string, path: string) {
-  const user = await requireUser(request);
-  if (!user.admin) {
+  const identity = await requireDashboardIdentity(request);
+  const actor = await prisma.user.findUnique({
+    where: { id: identity.legacyActorUserId },
+    select: { id: true, admin: true },
+  });
+  if (!actor?.admin || identity.authorization.impersonation) {
     throw new Error("Unauthorized");
   }
 
@@ -223,7 +229,7 @@ export async function redirectWithImpersonation(request: Request, userId: string
     await prisma.impersonationAuditLog.create({
       data: {
         action: "START",
-        adminId: user.id,
+        adminId: actor.id,
         targetId: userId,
         ipAddress,
       },
@@ -231,7 +237,7 @@ export async function redirectWithImpersonation(request: Request, userId: string
   } catch (error) {
     logger.error("Failed to create impersonation audit log", {
       error,
-      adminId: user.id,
+      adminId: actor.id,
       targetId: userId,
     });
   }
@@ -244,10 +250,20 @@ export async function redirectWithImpersonation(request: Request, userId: string
 }
 
 export async function clearImpersonation(request: Request, path: string) {
-  const authUser = await authenticator.isAuthenticated(request);
+  const identity = await getDashboardIdentity(request);
   const targetId = await getImpersonationId(request);
+  const actor = identity
+    ? await prisma.user.findUnique({
+        where: { id: identity.legacyActorUserId },
+        select: { id: true, admin: true },
+      })
+    : null;
 
-  if (targetId && authUser?.userId) {
+  if (
+    targetId &&
+    identity?.authorization.impersonation === null &&
+    actor?.admin === true
+  ) {
     const xff = request.headers.get("x-forwarded-for");
     const ipAddress = extractClientIp(xff);
 
@@ -255,7 +271,7 @@ export async function clearImpersonation(request: Request, path: string) {
       await prisma.impersonationAuditLog.create({
         data: {
           action: "STOP",
-          adminId: authUser.userId,
+          adminId: actor.id,
           targetId,
           ipAddress,
         },
@@ -263,7 +279,7 @@ export async function clearImpersonation(request: Request, path: string) {
     } catch (error) {
       logger.error("Failed to create impersonation audit log", {
         error,
-        adminId: authUser.userId,
+        adminId: actor.id,
         targetId,
       });
     }

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agent-providers._index/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agent-providers._index/route.tsx
@@ -11,6 +11,10 @@ import { Form, useFetcher, useNavigation, type MetaFunction } from "@remix-run/r
 import { useEffect, useRef, useState } from "react";
 import { type ActionFunctionArgs, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson, useTypedLoaderData } from "remix-typedjson";
+import {
+  PlatosAuthError,
+  type EnvironmentOperatorAuthorization,
+} from "@platos/tenancy-database";
 import { PageBody, PageContainer } from "~/components/layout/AppLayout";
 import { Button } from "~/components/primitives/Buttons";
 import { Header3 } from "~/components/primitives/Headers";
@@ -20,6 +24,7 @@ import { Paragraph } from "~/components/primitives/Paragraph";
 import { findProjectBySlug } from "~/models/project.server";
 import { findEnvironmentBySlug } from "~/models/runtimeEnvironment.server";
 import { requireUserId } from "~/services/session.server";
+import { requireCanonicalEnvironmentAuthorization } from "~/services/platosDashboardAuth.server";
 import {
   sanitizeProviderKeysPayload,
   type SafeProviderKey,
@@ -30,6 +35,7 @@ import {
   rotateProviderCredential,
 } from "~/services/platosCredentialStore.server";
 import { EnvironmentParamSchema } from "~/utils/pathBuilder";
+import type { CanonicalUserId } from "~/services/dashboardIdentity.server";
 
 export const meta: MetaFunction = () => [{ title: "Providers | Platos" }];
 
@@ -41,7 +47,7 @@ type Scope = {
   organizationId: string;
   projectId: string;
   environmentId: string;
-  userId: string;
+  userId: CanonicalUserId;
 };
 
 type ProviderState = {
@@ -173,7 +179,10 @@ async function agentMutate(
 }
 
 function mutationError(error: unknown) {
-  if (error instanceof AgentApiError && error.status === 403) {
+  if (
+    (error instanceof AgentApiError && error.status === 403) ||
+    (error instanceof PlatosAuthError && error.code === "forbidden")
+  ) {
     return typedjson(
       { error: "Project admin or organization admin access is required." },
       { status: 403 }
@@ -190,6 +199,7 @@ async function scopeFromRequest(
   params: Record<string, string | undefined>
 ): Promise<{
   scope: Scope;
+  credentialAuthorization: EnvironmentOperatorAuthorization;
   organization: { id: string; slug: string };
   project: { id: string; slug: string };
   environment: { id: string; slug: string; parentEnvironmentId: string | null };
@@ -206,13 +216,17 @@ async function scopeFromRequest(
     throw new Response(undefined, { status: 404, statusText: "Environment not found" });
   }
 
+  const canonical = await requireCanonicalEnvironmentAuthorization({
+    request,
+    organizationSlug,
+    projectSlug: projectParam,
+    environmentSlug: envParam,
+    access: "metadata",
+  });
+
   return {
-    scope: {
-      organizationId: project.organizationId,
-      projectId: project.id,
-      environmentId: environment.id,
-      userId,
-    },
+    scope: canonical.scope,
+    credentialAuthorization: canonical.authorization,
     organization: { id: project.organizationId, slug: organizationSlug },
     project: { id: project.id, slug: projectParam },
     environment: {
@@ -233,7 +247,7 @@ async function scopeFromRequest(
  *      environment variables.
  */
 export async function loader({ request, params }: LoaderFunctionArgs) {
-  const { scope } = await scopeFromRequest(request, params);
+  const { scope, credentialAuthorization } = await scopeFromRequest(request, params);
 
   let providers: ProviderState[] = [];
   let agentReachable = false;
@@ -264,8 +278,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   try {
     providerKeys = sanitizeProviderKeysPayload(
       await listProviderCredentialMetadata({
-        userId: scope.userId,
-        environmentId: scope.environmentId,
+        authorization: credentialAuthorization,
       })
     );
   } catch {
@@ -297,7 +310,8 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 }
 
 export async function action({ request, params }: ActionFunctionArgs) {
-  const { scope } = await scopeFromRequest(request, params);
+  const routeScope = await scopeFromRequest(request, params);
+  const { scope } = routeScope;
   const formData = await request.formData();
   const intent = String(formData.get("intent") ?? "");
   const providerId = String(formData.get("provider") ?? "");
@@ -356,8 +370,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         );
       }
       await createProviderCredential({
-        userId: scope.userId,
-        environmentId: scope.environmentId,
+        authorization: (
+          await requireCanonicalEnvironmentAuthorization({
+            request,
+            organizationSlug: routeScope.organization.slug,
+            projectSlug: routeScope.project.slug,
+            environmentSlug: routeScope.environment.slug,
+            access: "secret:mutate",
+          })
+        ).authorization,
         provider,
         referenceName,
         plaintext: credentialValue,
@@ -378,8 +399,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
         );
       }
       await rotateProviderCredential({
-        userId: scope.userId,
-        environmentId: scope.environmentId,
+        authorization: (
+          await requireCanonicalEnvironmentAuthorization({
+            request,
+            organizationSlug: routeScope.organization.slug,
+            projectSlug: routeScope.project.slug,
+            environmentSlug: routeScope.environment.slug,
+            access: "secret:mutate",
+          })
+        ).authorization,
         provider: providerId,
         keyId,
         credentialId,

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.chat/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agents.$agentId.chat/route.tsx
@@ -797,7 +797,7 @@ export default function AgentChatPage() {
 
   // PIFSP-9 Postman mode
   const [postmanMode, setPostmanMode] = useState(false);
-  const [postmanUserId, setPostmanUserId] = useState(userId);
+  const [postmanUserId, setPostmanUserId] = useState<string>(userId);
   const effectiveUserId = postmanMode ? postmanUserId : userId;
   const lastEffectiveUserIdRef = useRef<string>(effectiveUserId);
   // The reset effect lives AFTER the thread-reply state declarations

--- a/apps/webapp/app/routes/_app.orgs.$organizationSlug/route.tsx
+++ b/apps/webapp/app/routes/_app.orgs.$organizationSlug/route.tsx
@@ -7,7 +7,6 @@ import { prisma } from "~/db.server";
 import { useOptionalOrganization } from "~/hooks/useOrganizations";
 import { useTypedMatchesData } from "~/hooks/useTypedMatchData";
 import { OrganizationsPresenter } from "~/presenters/OrganizationsPresenter.server";
-import { getImpersonationId } from "~/services/impersonation.server";
 import { getCachedUsage, getCurrentPlan } from "~/services/platform.v3.server";
 import { requireUser } from "~/services/session.server";
 import { telemetry } from "~/services/telemetry.server";
@@ -75,7 +74,6 @@ export const shouldRevalidate: ShouldRevalidateFunction = (params) => {
 // IMPORTANT: Make sure to update shouldRevalidate if this loader depends on search params
 export const loader = async ({ request, params }: LoaderFunctionArgs) => {
   const user = await requireUser(request);
-  const impersonationId = await getImpersonationId(request);
 
   const { organizationSlug, projectParam, envParam } = ParamsSchema.parse(params);
 
@@ -162,7 +160,7 @@ export const loader = async ({ request, params }: LoaderFunctionArgs) => {
     organization,
     project,
     environment,
-    isImpersonating: !!impersonationId,
+    isImpersonating: user.isImpersonating,
     currentPlan: { ...plan, v3Usage: { ...usage, hasExceededFreeTier, usagePercentage } },
     customDashboards: customDashboardsWithWidgetCount,
     dashboardLimits: {

--- a/apps/webapp/app/routes/auth.github.callback.tsx
+++ b/apps/webapp/app/routes/auth.github.callback.tsx
@@ -1,13 +1,18 @@
-import type { LoaderFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
-import { prisma } from "~/db.server";
-import { getSession, redirectWithErrorMessage } from "~/models/message.server";
-import { authenticator } from "~/services/auth.server";
+import { redirect, type LoaderFunction } from "@remix-run/node";
+import { redirectWithErrorMessage } from "~/models/message.server";
+import { authenticator, clearOAuthSession } from "~/services/auth.server";
 import { setLastAuthMethodHeader } from "~/services/lastAuthMethod.server";
-import { commitSession } from "~/services/sessionStorage.server";
+import { commitSession, getSession } from "~/services/sessionStorage.server";
 import { trackAndClearReferralSource } from "~/services/referralSource.server";
+import { destroyImpersonationSession } from "~/services/impersonation.server";
 import { redirectCookie } from "./auth.github";
 import { sanitizeRedirectPath } from "~/utils";
+import {
+  bridgeVerifiedEmailToLegacyUser,
+  commitOperatorSession,
+  isMfaRequired,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
 
 export let loader: LoaderFunction = async ({ request }) => {
   const cookie = request.headers.get("Cookie");
@@ -19,43 +24,47 @@ export let loader: LoaderFunction = async ({ request }) => {
   });
 
   const session = await getSession(request.headers.get("cookie"));
-
-  const userRecord = await prisma.user.findFirst({
-    where: {
-      id: auth.userId,
-    },
-    select: {
-      id: true,
-      mfaEnabledAt: true,
-    },
-  });
-
-  if (!userRecord) {
-    return redirectWithErrorMessage(
+  const bridge = await bridgeVerifiedEmailToLegacyUser(auth.email);
+  if (!bridge) {
+    const response = await redirectWithErrorMessage(
       "/login",
       request,
-      "Could not find your account. Please contact support."
+      "Could not safely match your dashboard account. Please contact support."
     );
+    response.headers.append("Set-Cookie", await clearOAuthSession(request));
+    return response;
   }
 
-  if (userRecord.mfaEnabledAt) {
-    session.set("pending-mfa-user-id", userRecord.id);
+  try {
+    await platosDashboardAuth.authorizeOperatorSession(auth.sessionToken);
+  } catch (error) {
+    if (!isMfaRequired(error)) throw error;
     session.set("pending-mfa-redirect-to", redirectTo);
 
     const headers = new Headers();
     headers.append("Set-Cookie", await commitSession(session));
+    headers.append("Set-Cookie", await clearOAuthSession(request));
+    headers.append("Set-Cookie", await destroyImpersonationSession(request));
+    headers.append(
+      "Set-Cookie",
+      await commitOperatorSession(auth.sessionToken, new Date(auth.sessionExpiresAt))
+    );
     headers.append("Set-Cookie", await setLastAuthMethodHeader("github"));
 
     return redirect("/login/mfa", { headers });
   }
 
-  session.set(authenticator.sessionKey, auth);
-
   const headers = new Headers();
   headers.append("Set-Cookie", await commitSession(session));
+  headers.append("Set-Cookie", await clearOAuthSession(request));
+  headers.append("Set-Cookie", await destroyImpersonationSession(request));
+  headers.append(
+    "Set-Cookie",
+    await commitOperatorSession(auth.sessionToken, new Date(auth.sessionExpiresAt))
+  );
   headers.append("Set-Cookie", await setLastAuthMethodHeader("github"));
 
-  await trackAndClearReferralSource(request, auth.userId, headers);
+  await trackAndClearReferralSource(request, bridge.legacyUserId, headers);
 
   return redirect(redirectTo, { headers });
 };

--- a/apps/webapp/app/routes/auth.google.callback.tsx
+++ b/apps/webapp/app/routes/auth.google.callback.tsx
@@ -1,13 +1,18 @@
-import type { LoaderFunction } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
-import { prisma } from "~/db.server";
-import { getSession, redirectWithErrorMessage } from "~/models/message.server";
-import { authenticator } from "~/services/auth.server";
+import { redirect, type LoaderFunction } from "@remix-run/node";
+import { redirectWithErrorMessage } from "~/models/message.server";
+import { authenticator, clearOAuthSession } from "~/services/auth.server";
 import { setLastAuthMethodHeader } from "~/services/lastAuthMethod.server";
-import { commitSession } from "~/services/sessionStorage.server";
+import { commitSession, getSession } from "~/services/sessionStorage.server";
 import { trackAndClearReferralSource } from "~/services/referralSource.server";
+import { destroyImpersonationSession } from "~/services/impersonation.server";
 import { redirectCookie } from "./auth.google";
 import { sanitizeRedirectPath } from "~/utils";
+import {
+  bridgeVerifiedEmailToLegacyUser,
+  commitOperatorSession,
+  isMfaRequired,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
 
 export let loader: LoaderFunction = async ({ request }) => {
   const cookie = request.headers.get("Cookie");
@@ -19,44 +24,47 @@ export let loader: LoaderFunction = async ({ request }) => {
   });
 
   const session = await getSession(request.headers.get("cookie"));
-
-  const userRecord = await prisma.user.findFirst({
-    where: {
-      id: auth.userId,
-    },
-    select: {
-      id: true,
-      mfaEnabledAt: true,
-    },
-  });
-
-  if (!userRecord) {
-    return redirectWithErrorMessage(
+  const bridge = await bridgeVerifiedEmailToLegacyUser(auth.email);
+  if (!bridge) {
+    const response = await redirectWithErrorMessage(
       "/login",
       request,
-      "Could not find your account. Please contact support."
+      "Could not safely match your dashboard account. Please contact support."
     );
+    response.headers.append("Set-Cookie", await clearOAuthSession(request));
+    return response;
   }
 
-  if (userRecord.mfaEnabledAt) {
-    session.set("pending-mfa-user-id", userRecord.id);
+  try {
+    await platosDashboardAuth.authorizeOperatorSession(auth.sessionToken);
+  } catch (error) {
+    if (!isMfaRequired(error)) throw error;
     session.set("pending-mfa-redirect-to", redirectTo);
 
     const headers = new Headers();
     headers.append("Set-Cookie", await commitSession(session));
+    headers.append("Set-Cookie", await clearOAuthSession(request));
+    headers.append("Set-Cookie", await destroyImpersonationSession(request));
+    headers.append(
+      "Set-Cookie",
+      await commitOperatorSession(auth.sessionToken, new Date(auth.sessionExpiresAt))
+    );
     headers.append("Set-Cookie", await setLastAuthMethodHeader("google"));
 
     return redirect("/login/mfa", { headers });
   }
 
-  session.set(authenticator.sessionKey, auth);
-
   const headers = new Headers();
   headers.append("Set-Cookie", await commitSession(session));
+  headers.append("Set-Cookie", await clearOAuthSession(request));
+  headers.append("Set-Cookie", await destroyImpersonationSession(request));
+  headers.append(
+    "Set-Cookie",
+    await commitOperatorSession(auth.sessionToken, new Date(auth.sessionExpiresAt))
+  );
   headers.append("Set-Cookie", await setLastAuthMethodHeader("google"));
 
-  await trackAndClearReferralSource(request, auth.userId, headers);
+  await trackAndClearReferralSource(request, bridge.legacyUserId, headers);
 
   return redirect(redirectTo, { headers });
 };
-

--- a/apps/webapp/app/routes/login.magic/route.tsx
+++ b/apps/webapp/app/routes/login.magic/route.tsx
@@ -20,14 +20,12 @@ import { InputGroup } from "~/components/primitives/InputGroup";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Spinner } from "~/components/primitives/Spinner";
 import { TextLink } from "~/components/primitives/TextLink";
-import { authenticator } from "~/services/auth.server";
 import { commitSession, getUserSession } from "~/services/sessionStorage.server";
 import { setRedirectTo, commitSession as commitRedirectSession } from "~/services/redirectTo.server";
 import {
   checkMagicLinkEmailRateLimit,
   checkMagicLinkEmailDailyRateLimit,
   MagicLinkRateLimitError,
-  checkMagicLinkIpRateLimit,
 } from "~/services/magicLinkRateLimiter.server";
 // `logger` from `@platos/core/v3` is the TASK-scoped LoggerAPI — it
 // delegates to a NoopTaskLogger outside a trigger.dev task run, so every
@@ -37,7 +35,12 @@ import {
 import { tryCatch } from "@platos/core/v3";
 import { logger } from "~/services/logger.server";
 import { env } from "~/env.server";
-import { extractClientIp } from "~/utils/extractClientIp.server";
+import { getUserId } from "~/services/session.server";
+import {
+  authEmailRateLimitIdentifier,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
+import { sendDashboardMagicLink } from "~/services/email.server";
 
 export const meta: MetaFunction = ({ matches }) => {
   const parentMeta = matches
@@ -59,9 +62,7 @@ export const meta: MetaFunction = ({ matches }) => {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  await authenticator.isAuthenticated(request, {
-    successRedirect: "/",
-  });
+  if (await getUserId(request)) throw redirect("/");
 
   const session = await getUserSession(request);
   const error = session.get("auth:error");
@@ -117,59 +118,25 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (data.action) {
     case "send": {
-      if (!env.LOGIN_RATE_LIMITS_ENABLED) {
-        logger.info("Magic link: invoking authenticator.authenticate", {
-          email: data.email,
-          hasRedirectTo: new URL(request.url).searchParams.has("redirectTo"),
-        });
-        try {
-          return await authenticator.authenticate("email-link", request, {
-            successRedirect: "/login/magic",
-            failureRedirect: "/login/magic",
-          });
-        } catch (err: any) {
-          // `authenticator.authenticate` throws a Response for redirects
-          // (both success + failure) — re-throw those as-is. Only log when
-          // it throws a real Error (strategy-internal bug, signing failure,
-          // DB hiccup in the verify callback, etc.). Without this wrapper
-          // the error is silently swallowed into the failureRedirect and
-          // "auth:error" session message, leaving operators chasing ghosts.
-          if (err instanceof Response) {
-            throw err;
-          }
-          logger.error("Magic link: authenticator.authenticate threw", {
-            email: data.email,
-            error:
-              err instanceof Error
-                ? { name: err.name, message: err.message, stack: err.stack }
-                : JSON.stringify(err),
-          });
-          throw err;
-        }
-      }
-
       const { email } = data;
-      const xff = request.headers.get("x-forwarded-for");
-      const clientIp = extractClientIp(xff);
 
-      const [error] = await tryCatch(
-        Promise.all([
-          clientIp ? checkMagicLinkIpRateLimit(clientIp) : Promise.resolve(),
-          checkMagicLinkEmailRateLimit(email),
-          checkMagicLinkEmailDailyRateLimit(email),
-        ])
-      );
+      const [error] = env.LOGIN_RATE_LIMITS_ENABLED
+        ? await tryCatch(
+            Promise.all([
+              checkMagicLinkEmailRateLimit(email),
+              checkMagicLinkEmailDailyRateLimit(email),
+            ])
+          )
+        : [null];
 
       if (error) {
         if (error instanceof MagicLinkRateLimitError) {
           logger.warn("Login magic link rate limit exceeded", {
-            clientIp,
             email,
             error,
           });
         } else {
           logger.error("Failed sending login magic link", {
-            clientIp,
             email,
             error,
           });
@@ -191,9 +158,18 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       try {
-        return await authenticator.authenticate("email-link", request, {
-          successRedirect: "/login/magic",
-          failureRedirect: "/login/magic",
+        const issued = await platosDashboardAuth.issueMagicLink({
+          email,
+          rateLimitIdentifier: authEmailRateLimitIdentifier(email),
+        });
+        const link = new URL("/magic", env.LOGIN_ORIGIN);
+        link.searchParams.set("token", issued.token);
+        await sendDashboardMagicLink(email, link.toString());
+
+        const session = await getUserSession(request);
+        session.set("triggerdotdev:magiclink", true);
+        return redirect("/login/magic", {
+          headers: { "Set-Cookie": await commitSession(session) },
         });
       } catch (err: any) {
         if (err instanceof Response) {

--- a/apps/webapp/app/routes/login.mfa/route.tsx
+++ b/apps/webapp/app/routes/login.mfa/route.tsx
@@ -1,10 +1,9 @@
-import type {
-  ActionFunctionArgs,
-  LoaderFunctionArgs,
-  MetaFunction,
-  Session,
+import {
+  redirect,
+  type ActionFunctionArgs,
+  type LoaderFunctionArgs,
+  type MetaFunction,
 } from "@remix-run/node";
-import { redirect } from "@remix-run/node";
 import { Form, useNavigation } from "@remix-run/react";
 import * as React from "react";
 import { useState, useEffect } from "react";
@@ -20,14 +19,22 @@ import { InputGroup } from "~/components/primitives/InputGroup";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "~/components/primitives/InputOTP";
 import { Paragraph } from "~/components/primitives/Paragraph";
 import { Spinner } from "~/components/primitives/Spinner";
-import { authenticator } from "~/services/auth.server";
 import { commitSession, getUserSession } from "~/services/sessionStorage.server";
-import { getSession as getMessageSession } from "~/models/message.server";
-import { MultiFactorAuthenticationService } from "~/services/mfa/multiFactorAuthentication.server";
-import { redirectWithErrorMessage, redirectBackWithErrorMessage } from "~/models/message.server";
-import { ServiceValidationError } from "~/v3/services/baseService.server";
-import { checkMfaRateLimit, MfaRateLimitError } from "~/services/mfa/mfaRateLimiter.server";
+import {
+  getSession as getMessageSession,
+  redirectBackWithErrorMessage,
+  redirectWithErrorMessage,
+} from "~/models/message.server";
 import { trackAndClearReferralSource } from "~/services/referralSource.server";
+import { getUserId } from "~/services/session.server";
+import {
+  authSessionRateLimitIdentifier,
+  getDashboardIdentity,
+  getOperatorSessionToken,
+  isMfaRequired,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
+import { PlatosAuthError } from "@platos/tenancy-database";
 
 export const meta: MetaFunction = ({ matches }) => {
   const parentMeta = matches
@@ -49,18 +56,16 @@ export const meta: MetaFunction = ({ matches }) => {
 };
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  // Check if user is already fully authenticated
-  await authenticator.isAuthenticated(request, {
-    successRedirect: "/",
-  });
+  if (await getUserId(request)) return redirect("/");
 
   const session = await getUserSession(request);
-
-  // Check if there's a pending MFA user ID
-  const pendingUserId = session.get("pending-mfa-user-id");
-  if (!pendingUserId) {
-    // No pending MFA, redirect to login
-    return redirect("/login");
+  const sessionToken = await getOperatorSessionToken(request);
+  if (!sessionToken) return redirect("/login");
+  try {
+    await platosDashboardAuth.authorizeOperatorSession(sessionToken);
+    return redirect("/");
+  } catch (error) {
+    if (!isMfaRequired(error)) return redirect("/login");
   }
 
   // Get flash message for MFA errors
@@ -85,11 +90,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
 export async function action({ request }: ActionFunctionArgs) {
   try {
     const session = await getUserSession(request);
-    const pendingUserId = session.get("pending-mfa-user-id");
-
-    if (!pendingUserId) {
-      return redirect("/login");
-    }
+    const sessionToken = await getOperatorSessionToken(request);
+    if (!sessionToken) return redirect("/login");
 
     const payload = Object.fromEntries(await request.formData());
 
@@ -99,8 +101,6 @@ export async function action({ request }: ActionFunctionArgs) {
       })
       .parse(payload);
 
-    const mfaService = new MultiFactorAuthenticationService();
-
     if (action === "verify-recovery") {
       const recoveryCode = payload.recoveryCode as string;
 
@@ -108,16 +108,12 @@ export async function action({ request }: ActionFunctionArgs) {
         return redirectBackWithErrorMessage(request, "Recovery code is required");
       }
 
-      // Rate limit MFA verification attempts
-      await checkMfaRateLimit(pendingUserId);
-
-      const result = await mfaService.verifyRecoveryCodeForLogin(pendingUserId, recoveryCode);
-
-      if (!result.success) {
-        return redirectBackWithErrorMessage(request, result.error || "Invalid authentication code");
-      }
-      // Recovery code verified - complete the login
-      return await completeLogin(request, session, pendingUserId);
+      await platosDashboardAuth.verifyMfaForSession({
+        sessionToken,
+        recoveryCode,
+        rateLimitIdentifier: authSessionRateLimitIdentifier(sessionToken),
+      });
+      return await completeLogin(request, session);
     } else if (action === "verify-mfa") {
       const mfaCode = payload.mfaCode as string;
 
@@ -125,47 +121,39 @@ export async function action({ request }: ActionFunctionArgs) {
         return redirectBackWithErrorMessage(request, "Valid 6-digit code is required");
       }
 
-      // Rate limit MFA verification attempts
-      await checkMfaRateLimit(pendingUserId);
-
-      const result = await mfaService.verifyTotpForLogin(pendingUserId, mfaCode);
-
-      if (!result.success) {
-        return redirectBackWithErrorMessage(request, result.error || "Invalid authentication code");
-      }
-
-      // TOTP code verified - complete the login
-      return await completeLogin(request, session, pendingUserId);
+      await platosDashboardAuth.verifyMfaForSession({
+        sessionToken,
+        totpCode: mfaCode,
+        rateLimitIdentifier: authSessionRateLimitIdentifier(sessionToken),
+      });
+      return await completeLogin(request, session);
     }
 
     return redirect("/login");
   } catch (error) {
-    if (error instanceof ServiceValidationError) {
-      return redirectWithErrorMessage("/login", request, error.message);
-    }
-
-    if (error instanceof MfaRateLimitError) {
-      return redirectBackWithErrorMessage(request, error.message);
+    if (error instanceof PlatosAuthError) {
+      if (error.code === "rate_limited") return redirectBackWithErrorMessage(request, error.message);
+      if (error.code === "invalid_mfa") {
+        return redirectBackWithErrorMessage(request, "Invalid authentication code");
+      }
+      return redirectWithErrorMessage("/login", request, "Please log in again.");
     }
 
     throw error;
   }
 }
 
-async function completeLogin(request: Request, session: Session, userId: string) {
-  // Set the auth key on the same session object to avoid conflicting Set-Cookie headers
-  // (both authSession and session share the same __session cookie name)
-  session.set(authenticator.sessionKey, { userId });
-
+async function completeLogin(request: Request, session: Awaited<ReturnType<typeof getUserSession>>) {
+  const identity = await getDashboardIdentity(request);
+  if (!identity) return redirect("/login");
   // Get the redirect URL and clean up pending MFA data
   const redirectTo = session.get("pending-mfa-redirect-to") ?? "/";
-  session.unset("pending-mfa-user-id");
   session.unset("pending-mfa-redirect-to");
 
   const headers = new Headers();
   headers.append("Set-Cookie", await commitSession(session));
 
-  await trackAndClearReferralSource(request, userId, headers);
+  await trackAndClearReferralSource(request, identity.legacyUserId, headers);
 
   return redirect(redirectTo, { headers });
 }

--- a/apps/webapp/app/routes/logout.tsx
+++ b/apps/webapp/app/routes/logout.tsx
@@ -1,10 +1,25 @@
-import { type ActionFunction, type LoaderFunction } from "@remix-run/node";
-import { authenticator } from "~/services/auth.server";
+import { redirect, type ActionFunction, type LoaderFunction } from "@remix-run/node";
+import { clearOAuthSession } from "~/services/auth.server";
+import { destroyImpersonationSession } from "~/services/impersonation.server";
+import { destroySession, getUserSession } from "~/services/sessionStorage.server";
+import {
+  clearOperatorSession,
+  getOperatorSessionToken,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
 
-export const action: ActionFunction = async ({ request }) => {
-  return await authenticator.logout(request, { redirectTo: "/" });
-};
+async function logout(request: Request) {
+  const token = await getOperatorSessionToken(request);
+  if (token) await platosDashboardAuth.revokeOperatorSession(token).catch(() => false);
 
-export const loader: LoaderFunction = async ({ request }) => {
-  return await authenticator.logout(request, { redirectTo: "/" });
-};
+  const headers = new Headers();
+  headers.append("Set-Cookie", await clearOperatorSession());
+  headers.append("Set-Cookie", await clearOAuthSession(request));
+  headers.append("Set-Cookie", await destroyImpersonationSession(request));
+  headers.append("Set-Cookie", await destroySession(await getUserSession(request)));
+  return redirect("/", { headers });
+}
+
+export const action: ActionFunction = async ({ request }) => logout(request);
+
+export const loader: LoaderFunction = async ({ request }) => logout(request);

--- a/apps/webapp/app/routes/magic.tsx
+++ b/apps/webapp/app/routes/magic.tsx
@@ -1,60 +1,69 @@
-import type { LoaderFunctionArgs } from "@remix-run/server-runtime";
-import { redirect } from "@remix-run/server-runtime";
-import { prisma } from "~/db.server";
+import { redirect, type LoaderFunctionArgs } from "@remix-run/server-runtime";
 import { redirectWithErrorMessage } from "~/models/message.server";
-import { authenticator } from "~/services/auth.server";
 import { setLastAuthMethodHeader } from "~/services/lastAuthMethod.server";
 import { getRedirectTo } from "~/services/redirectTo.server";
 import { commitSession, getSession } from "~/services/sessionStorage.server";
 import { trackAndClearReferralSource } from "~/services/referralSource.server";
+import { destroyImpersonationSession } from "~/services/impersonation.server";
+import {
+  bridgeVerifiedEmailToLegacyUser,
+  canonicalEmailForUser,
+  commitOperatorSession,
+  isMfaRequired,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
+import type { CanonicalUserId } from "~/services/dashboardIdentity.server";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const redirectTo = await getRedirectTo(request);
 
-  const auth = await authenticator.authenticate("email-link", request, {
-    failureRedirect: "/login/magic", // If auth fails, the failureRedirect will be thrown as a Response
-  });
+  const token = new URL(request.url).searchParams.get("token");
+  if (!token) {
+    return redirectWithErrorMessage("/login/magic", request, "This magic link is invalid or expired.");
+  }
+
+  let auth;
+  try {
+    auth = await platosDashboardAuth.consumeMagicLink(token);
+  } catch {
+    return redirectWithErrorMessage("/login/magic", request, "This magic link is invalid or expired.");
+  }
 
   // manually get the session
   const session = await getSession(request.headers.get("cookie"));
 
-  const userRecord = await prisma.user.findFirst({
-    where: {
-      id: auth.userId,
-    },
-    select: {
-      id: true,
-      mfaEnabledAt: true,
-    },
-  });
-
-  if (!userRecord) {
+  const email = await canonicalEmailForUser(auth.userId as CanonicalUserId);
+  const bridge = email ? await bridgeVerifiedEmailToLegacyUser(email) : null;
+  if (!bridge) {
     return redirectWithErrorMessage(
       "/login/magic",
       request,
-      "Could not find your account. Please contact support."
+      "Could not safely match your dashboard account. Please contact support."
     );
   }
 
-  if (userRecord.mfaEnabledAt) {
-    session.set("pending-mfa-user-id", userRecord.id);
+  try {
+    await platosDashboardAuth.authorizeOperatorSession(auth.token);
+  } catch (error) {
+    if (!isMfaRequired(error)) throw error;
     session.set("pending-mfa-redirect-to", redirectTo ?? "/");
 
     const headers = new Headers();
     headers.append("Set-Cookie", await commitSession(session));
+    headers.append("Set-Cookie", await commitOperatorSession(auth.token, auth.expiresAt));
+    headers.append("Set-Cookie", await destroyImpersonationSession(request));
     headers.append("Set-Cookie", await setLastAuthMethodHeader("email"));
 
     return redirect("/login/mfa", { headers });
   }
 
-  // and store the user data
-  session.set(authenticator.sessionKey, auth);
-
   const headers = new Headers();
   headers.append("Set-Cookie", await commitSession(session));
+  headers.append("Set-Cookie", await commitOperatorSession(auth.token, auth.expiresAt));
+  headers.append("Set-Cookie", await destroyImpersonationSession(request));
   headers.append("Set-Cookie", await setLastAuthMethodHeader("email"));
 
-  await trackAndClearReferralSource(request, auth.userId, headers);
+  await trackAndClearReferralSource(request, bridge.legacyUserId, headers);
 
   return redirect(redirectTo ?? "/", { headers });
 }

--- a/apps/webapp/app/routes/resources.account.mfa.setup/route.tsx
+++ b/apps/webapp/app/routes/resources.account.mfa.setup/route.tsx
@@ -1,14 +1,18 @@
-import { ActionFunctionArgs } from "@remix-run/server-runtime";
+import type { ActionFunctionArgs } from "@remix-run/server-runtime";
 import { typedjson } from "remix-typedjson";
 import { z } from "zod";
 import { redirectWithSuccessMessage, redirectWithErrorMessage, typedJsonWithSuccessMessage } from "~/models/message.server";
-import { MultiFactorAuthenticationService } from "~/services/mfa/multiFactorAuthentication.server";
-import { requireUserId } from "~/services/session.server";
-import { ServiceValidationError } from "~/v3/services/baseService.server";
 import { useMfaSetup } from "./useMfaSetup";
 import { MfaToggle } from "./MfaToggle";
 import { MfaSetupDialog } from "./MfaSetupDialog";
 import { MfaDisableDialog } from "./MfaDisableDialog";
+import {
+  authSessionRateLimitIdentifier,
+  commitOperatorSession,
+  requireCanonicalAuthorization,
+  platosDashboardAuth,
+} from "~/services/platosDashboardAuth.server";
+import { PlatosAuthError } from "@platos/tenancy-database";
 
 const formSchema = z.discriminatedUnion("action", [
   z.object({
@@ -51,7 +55,7 @@ function validateForm(formData: FormData) {
 
 export async function action({ request }: ActionFunctionArgs) {
   try {
-    const userId = await requireUserId(request);
+    const operator = await requireCanonicalAuthorization(request);
 
     const formData = await request.formData();
 
@@ -64,11 +68,9 @@ export async function action({ request }: ActionFunctionArgs) {
       });
     }
 
-    const mfaSetupService = new MultiFactorAuthenticationService();
-
     switch (submission.data.action) {
       case "enable-mfa": {
-        const result = await mfaSetupService.enableTotp(userId);
+        const result = await platosDashboardAuth.beginTotpEnrollment(operator.canonicalUserId);
 
         return typedjson({
           action: "enable-mfa" as const,
@@ -77,46 +79,54 @@ export async function action({ request }: ActionFunctionArgs) {
         });
       }
       case "disable-mfa": {
-        const result = await mfaSetupService.disableTotp(userId, {
-          totpCode: submission.data.totpCode,
-          recoveryCode: submission.data.recoveryCode,
-        });
-
-        if (result.success) {
-          return typedJsonWithSuccessMessage(
-            {
-              action: "disable-mfa" as const,
-              success: true as const,
-            },
-            request,
-            "Successfully disabled MFA"
-          );
-        } else {
-          return typedjson({
-            action: "disable-mfa" as const,
-            success: false as const,
-            error: "Invalid code provided. Please try again.",
+        try {
+          await platosDashboardAuth.disableTotpForSession({
+            sessionToken: operator.token,
+            rateLimitIdentifier: authSessionRateLimitIdentifier(operator.token),
+            totpCode: submission.data.totpCode,
+            recoveryCode: submission.data.recoveryCode,
           });
+        } catch (error) {
+          if (error instanceof PlatosAuthError && error.code === "invalid_mfa") {
+            return typedjson({
+              action: "disable-mfa" as const,
+              success: false as const,
+              error: "Invalid code provided. Please try again.",
+            });
+          }
+          throw error;
         }
+        return typedJsonWithSuccessMessage(
+          {
+            action: "disable-mfa" as const,
+            success: true as const,
+          },
+          request,
+          "Successfully disabled MFA"
+        );
       }
       case "validate-totp": {
-        const result = await mfaSetupService.validateTotpSetup(userId, submission.data.totpCode);
-
-        if (result.success) {
-          return typedjson({
+        const result = await platosDashboardAuth.confirmTotpEnrollment(
+          operator.canonicalUserId,
+          submission.data.totpCode,
+          authSessionRateLimitIdentifier(operator.token)
+        );
+        const replacement = await platosDashboardAuth.issueOperatorSession({
+          userId: operator.canonicalUserId,
+          mfaVerifiedAt: new Date(),
+        });
+        return typedjson(
+          {
             action: "validate-totp" as const,
             success: true as const,
             recoveryCodes: result.recoveryCodes,
-          });
-        } else {
-          return typedjson({
-            action: "validate-totp" as const,
-            success: false as const,
-            error: "Invalid code provided. Please try again.",
-            otpAuthUrl: result.otpAuthUrl,
-            secret: result.secret,
-          });
-        }
+          },
+          {
+            headers: {
+              "Set-Cookie": await commitOperatorSession(replacement.token, replacement.expiresAt),
+            },
+          }
+        );
       }
       case "cancel-totp": {
         return typedjson({
@@ -129,7 +139,16 @@ export async function action({ request }: ActionFunctionArgs) {
       }
     }
   } catch (error) {
-    if (error instanceof ServiceValidationError) {
+    if (error instanceof PlatosAuthError) {
+      if (error.code === "invalid_mfa") {
+        return typedjson({
+          action: "validate-totp" as const,
+          success: false as const,
+          error: "Invalid code provided. Please try again.",
+          secret: undefined,
+          otpAuthUrl: undefined,
+        });
+      }
       return redirectWithErrorMessage("/account/security", request, error.message);
     }
     

--- a/apps/webapp/app/routes/resources.account.mfa.setup/useMfaSetup.ts
+++ b/apps/webapp/app/routes/resources.account.mfa.setup/useMfaSetup.ts
@@ -1,6 +1,6 @@
 import { useReducer, useEffect } from "react";
 import { useTypedFetcher } from "remix-typedjson";
-import { action } from "./route";
+import type { action } from "./route";
 
 export type MfaPhase = 'idle' | 'enabling' | 'validating' | 'showing-recovery' | 'disabling';
 
@@ -23,7 +23,7 @@ export type MfaAction =
   | { type: 'CANCEL_SETUP' }
   | { type: 'VALIDATE_TOTP'; code: string }
   | { type: 'VALIDATION_SUCCESS'; recoveryCodes: string[] }
-  | { type: 'VALIDATION_FAILED'; error: string; setupData: { secret: string; otpAuthUrl: string } }
+  | { type: 'VALIDATION_FAILED'; error: string }
   | { type: 'RECOVERY_CODES_SAVED' }
   | { type: 'OPEN_DISABLE_DIALOG' }
   | { type: 'DISABLE_MFA' }
@@ -35,7 +35,7 @@ export type MfaAction =
   | { type: 'CLEAR_ERROR' }
   | { type: 'SET_SUBMITTING'; isSubmitting: boolean };
 
-function mfaReducer(state: MfaState, action: MfaAction): MfaState {
+export function mfaReducer(state: MfaState, action: MfaAction): MfaState {
   switch (action.type) {
     case 'ENABLE_MFA':
       return {
@@ -85,7 +85,6 @@ function mfaReducer(state: MfaState, action: MfaAction): MfaState {
       return {
         ...state,
         phase: 'enabling',
-        setupData: action.setupData,
         error: action.error,
         isSubmitting: false,
       };
@@ -200,8 +199,7 @@ export function useMfaSetup(initialIsEnabled: boolean) {
           } else {
             dispatch({ 
               type: 'VALIDATION_FAILED', 
-              error: data.error || 'Invalid code',
-              setupData: { secret: data.secret!, otpAuthUrl: data.otpAuthUrl! }
+              error: data.error || 'Invalid code'
             });
           }
           break;
@@ -210,8 +208,8 @@ export function useMfaSetup(initialIsEnabled: boolean) {
           if (data.success) {
             dispatch({ type: 'DISABLE_SUCCESS' });
           } else {
-            dispatch({ 
-              type: 'DISABLE_FAILED', 
+            dispatch({
+              type: 'DISABLE_FAILED',
               error: data.error || 'Failed to disable MFA'
             });
           }

--- a/apps/webapp/app/services/auth.server.ts
+++ b/apps/webapp/app/services/auth.server.ts
@@ -1,14 +1,26 @@
+import { createCookieSessionStorage } from "@remix-run/node";
 import { Authenticator } from "remix-auth";
 import type { AuthUser } from "./authUser";
-import { addEmailLinkStrategy } from "./emailAuth.server";
 import { addGitHubStrategy } from "./gitHubAuth.server";
 import { addGoogleStrategy } from "./googleAuth.server";
-import { sessionStorage } from "./sessionStorage.server";
 import { env } from "~/env.server";
 
-// Create an instance of the authenticator, pass a generic with what
-// strategies will return and will store in the session
-const authenticator = new Authenticator<AuthUser>(sessionStorage);
+// Remix Auth is retained only for the OAuth handshake. Keep its transient
+// state isolated from the legacy dashboard `__session` cookie so an inherited
+// Trigger auth payload can never be treated as a successful OAuth result.
+const oauthSessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: env.NODE_ENV === "production" ? "__Host-platos_oauth" : "platos_oauth",
+    httpOnly: true,
+    path: "/",
+    sameSite: "lax",
+    secrets: [env.SESSION_SECRET],
+    secure: env.NODE_ENV === "production",
+    maxAge: 15 * 60,
+  },
+});
+
+const authenticator = new Authenticator<AuthUser>(oauthSessionStorage);
 
 const isGithubAuthSupported =
   typeof env.AUTH_GITHUB_CLIENT_ID === "string" &&
@@ -26,6 +38,9 @@ if (env.AUTH_GOOGLE_CLIENT_ID && env.AUTH_GOOGLE_CLIENT_SECRET) {
   addGoogleStrategy(authenticator, env.AUTH_GOOGLE_CLIENT_ID, env.AUTH_GOOGLE_CLIENT_SECRET);
 }
 
-addEmailLinkStrategy(authenticator);
-
 export { authenticator, isGithubAuthSupported, isGoogleAuthSupported };
+
+export async function clearOAuthSession(request: Request): Promise<string> {
+  const session = await oauthSessionStorage.getSession(request.headers.get("Cookie"));
+  return oauthSessionStorage.destroySession(session);
+}

--- a/apps/webapp/app/services/authUser.ts
+++ b/apps/webapp/app/services/authUser.ts
@@ -1,3 +1,10 @@
+import type { CanonicalUserId } from "./dashboardIdentity.server";
+
 export type AuthUser = {
-  userId: string;
+  /** Retained only for unconverted legacy impersonation cleanup code. */
+  userId?: string;
+  canonicalUserId: CanonicalUserId;
+  email: string;
+  sessionToken: string;
+  sessionExpiresAt: string;
 };

--- a/apps/webapp/app/services/dashboardAuthRateLimit.server.ts
+++ b/apps/webapp/app/services/dashboardAuthRateLimit.server.ts
@@ -1,0 +1,16 @@
+import { createHash } from "node:crypto";
+import { normalizeBridgeEmail } from "./dashboardIdentity.server";
+
+const OPERATOR_SESSION_RATE_LIMIT_DOMAIN = "platos-auth-rate-limit:operator-session\0";
+
+export function authEmailRateLimitIdentifier(email: string): string {
+  return `email:${normalizeBridgeEmail(email)}`;
+}
+
+export function authSessionRateLimitIdentifier(sessionToken: string): string {
+  const digest = createHash("sha256")
+    .update(OPERATOR_SESSION_RATE_LIMIT_DOMAIN)
+    .update(sessionToken)
+    .digest("hex");
+  return `operator-session:${digest}`;
+}

--- a/apps/webapp/app/services/dashboardIdentity.server.ts
+++ b/apps/webapp/app/services/dashboardIdentity.server.ts
@@ -1,0 +1,130 @@
+import type { OperatorAuthorization } from "@platos/tenancy-database";
+
+declare const canonicalUserIdBrand: unique symbol;
+declare const legacyUserIdBrand: unique symbol;
+
+export type CanonicalUserId = string & { readonly [canonicalUserIdBrand]: "CanonicalUserId" };
+export type LegacyUserId = string & { readonly [legacyUserIdBrand]: "LegacyUserId" };
+
+export interface DashboardIdentity {
+  authorization: OperatorAuthorization;
+  canonicalActorUserId: CanonicalUserId;
+  canonicalEffectiveUserId: CanonicalUserId;
+  /** Compatibility alias for the canonical effective user. */
+  canonicalUserId: CanonicalUserId;
+  legacyActorUserId: LegacyUserId;
+  legacyEffectiveUserId: LegacyUserId;
+  /** Compatibility alias for the legacy effective dashboard user. */
+  legacyUserId: LegacyUserId;
+  email: string;
+  mfaEnabledAt: Date | null;
+  isImpersonating: boolean;
+}
+
+export interface OperatorSessionAuthorizer {
+  authorizeOperatorSession(token: string): Promise<OperatorAuthorization>;
+}
+
+export interface LegacyIdentityBridgeReader {
+  findByNormalizedEmail(normalizedEmail: string): Promise<Array<{ id: string; email: string }>>;
+}
+
+export interface CanonicalMfaReader {
+  findEnabledAt(userId: CanonicalUserId): Promise<Date | null>;
+}
+
+export interface CanonicalIdentityReader {
+  findEmail(userId: CanonicalUserId): Promise<string | null>;
+}
+
+export function normalizeBridgeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function canonicalUserId(value: string): CanonicalUserId {
+  return value as CanonicalUserId;
+}
+
+export function legacyUserId(value: string): LegacyUserId {
+  return value as LegacyUserId;
+}
+
+export async function resolveDashboardIdentity(params: {
+  token: string | null | undefined;
+  authorizer: OperatorSessionAuthorizer;
+  legacyIdentityReader: LegacyIdentityBridgeReader;
+  canonicalMfaReader: CanonicalMfaReader;
+  canonicalIdentityReader: CanonicalIdentityReader;
+}): Promise<DashboardIdentity | null> {
+  if (!params.token) return null;
+
+  let authorization: OperatorAuthorization;
+  try {
+    authorization = await params.authorizer.authorizeOperatorSession(params.token);
+  } catch {
+    return null;
+  }
+
+  async function bridgeEmail(email: string): Promise<LegacyUserId | null> {
+    const normalizedEmail = normalizeBridgeEmail(email);
+    const matches = await params.legacyIdentityReader.findByNormalizedEmail(normalizedEmail);
+    if (
+      matches.length !== 1 ||
+      normalizeBridgeEmail(matches[0].email) !== normalizedEmail
+    ) {
+      return null;
+    }
+    return legacyUserId(matches[0].id);
+  }
+
+  const canonicalActorUserId = canonicalUserId(authorization.actorUserId);
+  const canonicalEffectiveUserId = canonicalUserId(authorization.effectiveUserId);
+  const legacyEffectiveUserId = await bridgeEmail(authorization.email);
+  if (!legacyEffectiveUserId) return null;
+
+  let legacyActorUserId = legacyEffectiveUserId;
+  if (canonicalActorUserId !== canonicalEffectiveUserId) {
+    const actorEmail = await params.canonicalIdentityReader.findEmail(canonicalActorUserId);
+    if (!actorEmail) return null;
+    const bridgedActor = await bridgeEmail(actorEmail);
+    if (!bridgedActor) return null;
+    legacyActorUserId = bridgedActor;
+  }
+
+  return {
+    authorization,
+    canonicalActorUserId,
+    canonicalEffectiveUserId,
+    canonicalUserId: canonicalEffectiveUserId,
+    legacyActorUserId,
+    legacyEffectiveUserId,
+    legacyUserId: legacyEffectiveUserId,
+    email: authorization.email,
+    mfaEnabledAt: await params.canonicalMfaReader.findEnabledAt(canonicalActorUserId),
+    isImpersonating: authorization.impersonation?.active === true,
+  };
+}
+
+export function applyLegacyImpersonation(params: {
+  identity: DashboardIdentity;
+  legacyTargetUserId: string | null | undefined;
+  legacyActorIsAdmin: boolean;
+  legacyTargetExists: boolean;
+}): DashboardIdentity {
+  if (
+    !params.legacyTargetUserId ||
+    !params.legacyActorIsAdmin ||
+    !params.legacyTargetExists ||
+    params.identity.authorization.impersonation
+  ) {
+    return params.identity;
+  }
+
+  const legacyEffectiveUserId = legacyUserId(params.legacyTargetUserId);
+  return {
+    ...params.identity,
+    legacyEffectiveUserId,
+    legacyUserId: legacyEffectiveUserId,
+    isImpersonating: true,
+  };
+}

--- a/apps/webapp/app/services/email.server.ts
+++ b/apps/webapp/app/services/email.server.ts
@@ -3,7 +3,6 @@ import { EmailClient, MailTransportOptions } from "emails";
 import type { SendEmailOptions } from "remix-auth-email-link";
 import { redirect } from "remix-typedjson";
 import { env } from "~/env.server";
-import type { AuthUser } from "./authUser";
 import { commonWorker } from "~/v3/commonWorker.server";
 import { logger } from "./logger.server";
 import { singleton } from "~/utils/singleton";
@@ -83,7 +82,9 @@ function buildTransportOptions(alerts?: boolean): MailTransportOptions {
   }
 }
 
-export async function sendMagicLinkEmail(options: SendEmailOptions<AuthUser>): Promise<void> {
+export async function sendMagicLinkEmail(
+  options: SendEmailOptions<{ userId: string }>
+): Promise<void> {
   // Promoted to INFO so operators can see the full dispatch timing on
   // every magic-link login attempt without flipping debug on. If a user
   // reports "no email received", grep for "Magic link email" in logs to
@@ -95,19 +96,8 @@ export async function sendMagicLinkEmail(options: SendEmailOptions<AuthUser>): P
     from: env.FROM_EMAIL ?? "(default)",
   });
 
-  assertEmailAllowed(options.emailAddress);
-
-  // Auto redirect when in development mode
-  if (env.NODE_ENV === "development") {
-    throw redirect(options.magicLink);
-  }
-
   try {
-    await client.send({
-      email: "magic_link",
-      to: options.emailAddress,
-      magicLink: options.magicLink,
-    });
+    await sendDashboardMagicLink(options.emailAddress, options.magicLink);
     logger.info("Magic link email: client.send resolved", {
       emailAddress: options.emailAddress,
     });
@@ -122,6 +112,22 @@ export async function sendMagicLinkEmail(options: SendEmailOptions<AuthUser>): P
     });
     throw error;
   }
+}
+
+export async function sendDashboardMagicLink(emailAddress: string, magicLink: string): Promise<void> {
+  assertEmailAllowed(emailAddress);
+
+  // Preserve the existing local-development UX: clicking "send" follows the
+  // generated link immediately instead of requiring an email transport.
+  if (env.NODE_ENV === "development") {
+    throw redirect(magicLink);
+  }
+
+  await client.send({
+    email: "magic_link",
+    to: emailAddress,
+    magicLink,
+  });
 }
 
 export async function sendPlainTextEmail(options: SendPlainTextOptions) {

--- a/apps/webapp/app/services/emailAuth.server.tsx
+++ b/apps/webapp/app/services/emailAuth.server.tsx
@@ -3,7 +3,6 @@ import { EmailLinkStrategy } from "remix-auth-email-link";
 import { env } from "~/env.server";
 import { findOrCreateUser } from "~/models/user.server";
 import { sendMagicLinkEmail } from "~/services/email.server";
-import type { AuthUser } from "./authUser";
 import { logger } from "./logger.server";
 
 import { postAuthentication } from "./postAuth.server";
@@ -45,6 +44,6 @@ const emailStrategy = new EmailLinkStrategy(
   }
 );
 
-export function addEmailLinkStrategy(authenticator: Authenticator<AuthUser>) {
+export function addEmailLinkStrategy(authenticator: Authenticator<{ userId: string }>) {
   authenticator.use(emailStrategy);
 }

--- a/apps/webapp/app/services/gitHubAuth.server.ts
+++ b/apps/webapp/app/services/gitHubAuth.server.ts
@@ -1,10 +1,16 @@
 import type { Authenticator } from "remix-auth";
 import { GitHubStrategy } from "remix-auth-github";
 import { env } from "~/env.server";
-import { findOrCreateUser } from "~/models/user.server";
 import type { AuthUser } from "./authUser";
 import { logger } from "./logger.server";
-import { postAuthentication } from "./postAuth.server";
+import { OperatorIdentityProvider } from "@platos/tenancy-database";
+import { assertEmailAllowed } from "~/utils/email";
+import { canonicalUserId } from "./dashboardIdentity.server";
+import {
+  authEmailRateLimitIdentifier,
+  canonicalEmailForUser,
+  platosDashboardAuth,
+} from "./platosDashboardAuth.server";
 
 export function addGitHubStrategy(
   authenticator: Authenticator<AuthUser>,
@@ -17,7 +23,7 @@ export function addGitHubStrategy(
       clientSecret,
       callbackURL: `${env.LOGIN_ORIGIN}/auth/github/callback`,
     },
-    async ({ extraParams, profile }) => {
+    async ({ profile }) => {
       const emails = profile.emails;
 
       if (!emails?.length) {
@@ -25,23 +31,26 @@ export function addGitHubStrategy(
       }
 
       try {
-        logger.debug("GitHub login", {
-          emails,
-          profile,
-          extraParams,
+        const email = emails[0].value;
+        assertEmailAllowed(email);
+        const session = await platosDashboardAuth.completeOAuthLogin({
+          provider: OperatorIdentityProvider.GITHUB,
+          subject: profile.id,
+          email,
+          // remix-auth-github requests user:email and filters the API response
+          // to verified addresses before constructing profile.emails.
+          emailVerified: true,
+          rateLimitIdentifier: authEmailRateLimitIdentifier(email),
         });
-
-        const { user, isNewUser } = await findOrCreateUser({
-          email: emails[0].value,
-          authenticationMethod: "GITHUB",
-          authenticationProfile: profile,
-          authenticationExtraParams: extraParams,
-        });
-
-        await postAuthentication({ user, isNewUser, loginMethod: "GITHUB" });
+        const canonicalId = canonicalUserId(session.userId);
+        const canonicalEmail = await canonicalEmailForUser(canonicalId);
+        if (!canonicalEmail) throw new Error("Canonical OAuth user was not found");
 
         return {
-          userId: user.id,
+          canonicalUserId: canonicalId,
+          email: canonicalEmail,
+          sessionToken: session.token,
+          sessionExpiresAt: session.expiresAt.toISOString(),
         };
       } catch (error) {
         logger.error("GitHub login failed", { error: JSON.stringify(error) });

--- a/apps/webapp/app/services/googleAuth.server.ts
+++ b/apps/webapp/app/services/googleAuth.server.ts
@@ -1,10 +1,16 @@
 import type { Authenticator } from "remix-auth";
 import { GoogleStrategy } from "remix-auth-google";
 import { env } from "~/env.server";
-import { findOrCreateUser } from "~/models/user.server";
 import type { AuthUser } from "./authUser";
 import { logger } from "./logger.server";
-import { postAuthentication } from "./postAuth.server";
+import { OperatorIdentityProvider } from "@platos/tenancy-database";
+import { assertEmailAllowed } from "~/utils/email";
+import { canonicalUserId } from "./dashboardIdentity.server";
+import {
+  authEmailRateLimitIdentifier,
+  canonicalEmailForUser,
+  platosDashboardAuth,
+} from "./platosDashboardAuth.server";
 
 export function addGoogleStrategy(
   authenticator: Authenticator<AuthUser>,
@@ -17,7 +23,7 @@ export function addGoogleStrategy(
       clientSecret,
       callbackURL: `${env.LOGIN_ORIGIN}/auth/google/callback`,
     },
-    async ({ extraParams, profile }) => {
+    async ({ profile }) => {
       const emails = profile.emails;
 
       if (!emails?.length) {
@@ -25,23 +31,24 @@ export function addGoogleStrategy(
       }
 
       try {
-        logger.debug("Google login", {
-          emails,
-          profile,
-          extraParams,
+        const email = emails[0].value;
+        assertEmailAllowed(email);
+        const session = await platosDashboardAuth.completeOAuthLogin({
+          provider: OperatorIdentityProvider.GOOGLE,
+          subject: profile.id,
+          email,
+          emailVerified: profile._json.email_verified === true,
+          rateLimitIdentifier: authEmailRateLimitIdentifier(email),
         });
-
-        const { user, isNewUser } = await findOrCreateUser({
-          email: emails[0].value,
-          authenticationMethod: "GOOGLE",
-          authenticationProfile: profile,
-          authenticationExtraParams: extraParams,
-        });
-
-        await postAuthentication({ user, isNewUser, loginMethod: "GOOGLE" });
+        const canonicalId = canonicalUserId(session.userId);
+        const canonicalEmail = await canonicalEmailForUser(canonicalId);
+        if (!canonicalEmail) throw new Error("Canonical OAuth user was not found");
 
         return {
-          userId: user.id,
+          canonicalUserId: canonicalId,
+          email: canonicalEmail,
+          sessionToken: session.token,
+          sessionExpiresAt: session.expiresAt.toISOString(),
         };
       } catch (error) {
         logger.error("Google login failed", { error: JSON.stringify(error) });

--- a/apps/webapp/app/services/impersonation.server.ts
+++ b/apps/webapp/app/services/impersonation.server.ts
@@ -21,6 +21,11 @@ export function commitImpersonationSession(session: Session) {
   return impersonationSessionStorage.commitSession(session);
 }
 
+export async function destroyImpersonationSession(request: Request) {
+  const session = await getImpersonationSession(request);
+  return impersonationSessionStorage.destroySession(session);
+}
+
 export async function getImpersonationId(request: Request) {
   const session = await getImpersonationSession(request);
 

--- a/apps/webapp/app/services/platosControlDatabase.server.ts
+++ b/apps/webapp/app/services/platosControlDatabase.server.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from "@platos/tenancy-database";
+import { env } from "~/env.server";
+import { singleton } from "~/utils/singleton";
+
+/**
+ * Canonical Platos control-plane client. The dashboard's general `prisma`
+ * client deliberately remains connected to the legacy resource database.
+ */
+export const platosControlDatabase = singleton(
+  "platos-control-prisma",
+  () => new PrismaClient({ datasourceUrl: env.PLATOS_CONTROL_DATABASE_URL })
+);

--- a/apps/webapp/app/services/platosCredentialStore.server.ts
+++ b/apps/webapp/app/services/platosCredentialStore.server.ts
@@ -2,25 +2,18 @@ import {
   CredentialRootKeyRing,
   PlatosSecretStore,
   PROVIDER_KEY_SAFE_SELECT,
-  PrismaClient,
-  authorizeEnvironmentOperator,
-  type EnvironmentAuthorizationAccess,
-  type OperatorAuthorization,
+  type EnvironmentOperatorAuthorization,
 } from "@platos/tenancy-database";
 import { singleton } from "~/utils/singleton";
+import { platosControlDatabase } from "./platosControlDatabase.server";
 
 const DEVELOPMENT_ROOT_KEY = "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface";
-
-const database = singleton(
-  "platos-tenancy-prisma",
-  () => new PrismaClient({ datasourceUrl: requiredEnvironmentValue("DATABASE_URL") })
-);
 
 const secretStore = singleton(
   "platos-credential-store",
   () =>
     new PlatosSecretStore(
-      database,
+      platosControlDatabase,
       new CredentialRootKeyRing({
         activeVersion: credentialRootKeyVersion(),
         keys: credentialRootKeys(),
@@ -29,16 +22,11 @@ const secretStore = singleton(
 );
 
 export async function listProviderCredentialMetadata(params: {
-  userId: string;
-  environmentId: string;
+  authorization: EnvironmentOperatorAuthorization;
 }) {
-  const authorization = await environmentAuthorization(
-    params.userId,
-    params.environmentId,
-    "metadata"
-  );
+  const authorization = params.authorization;
   const [providerKeys, credentials] = await Promise.all([
-    database.providerKey.findMany({
+    platosControlDatabase.providerKey.findMany({
       where: { environmentId: authorization.environmentId },
       orderBy: [{ provider: "asc" }, { isDefault: "desc" }, { createdAt: "asc" }],
       select: PROVIDER_KEY_SAFE_SELECT,
@@ -63,19 +51,14 @@ export async function listProviderCredentialMetadata(params: {
 }
 
 export async function createProviderCredential(params: {
-  userId: string;
-  environmentId: string;
+  authorization: EnvironmentOperatorAuthorization;
   provider: string;
   referenceName: string;
   plaintext: string;
   label: string;
   isDefault: boolean;
 }) {
-  const authorization = await environmentAuthorization(
-    params.userId,
-    params.environmentId,
-    "secret:mutate"
-  );
+  const authorization = params.authorization;
   return secretStore.createProviderCredentialAndKey({
     authorization,
     name: params.referenceName,
@@ -87,18 +70,13 @@ export async function createProviderCredential(params: {
 }
 
 export async function rotateProviderCredential(params: {
-  userId: string;
-  environmentId: string;
+  authorization: EnvironmentOperatorAuthorization;
   provider: string;
   keyId: string;
   credentialId: string;
   plaintext: string;
 }) {
-  const authorization = await environmentAuthorization(
-    params.userId,
-    params.environmentId,
-    "secret:mutate"
-  );
+  const authorization = params.authorization;
   return secretStore.rotateProviderCredentialAndKey({
     authorization,
     keyId: params.keyId,
@@ -106,23 +84,6 @@ export async function rotateProviderCredential(params: {
     provider: params.provider,
     plaintext: params.plaintext,
   });
-}
-
-async function environmentAuthorization(
-  userId: string,
-  environmentId: string,
-  access: EnvironmentAuthorizationAccess
-) {
-  const operator: OperatorAuthorization = {
-    sessionId: "platos-webapp-session",
-    actorUserId: userId,
-    effectiveUserId: userId,
-    email: "",
-    expiresAt: new Date(Date.now() + 60_000),
-    mfaVerifiedAt: null,
-    impersonation: null,
-  };
-  return authorizeEnvironmentOperator(database, operator, environmentId, access);
 }
 
 function credentialRootKeyVersion(): number {
@@ -164,10 +125,4 @@ function credentialRootKeys(): Record<number, string> {
   }
   if (Object.keys(keys).length === 0) throw new Error("Credential store configuration is invalid");
   return keys;
-}
-
-function requiredEnvironmentValue(name: string): string {
-  const value = process.env[name];
-  if (!value) throw new Error(`${name} is required`);
-  return value;
 }

--- a/apps/webapp/app/services/platosDashboardAuth.server.ts
+++ b/apps/webapp/app/services/platosDashboardAuth.server.ts
@@ -1,0 +1,220 @@
+import { createCookie, redirect } from "@remix-run/node";
+import {
+  PlatosAuthError,
+  PlatosAuthService,
+  authorizeEnvironmentOperator,
+  type EnvironmentAuthorizationAccess,
+  type EnvironmentOperatorAuthorization,
+  type OperatorAuthorization,
+} from "@platos/tenancy-database";
+import { Prisma as LegacyPrisma } from "@platos/database";
+import { prisma } from "~/db.server";
+import { env } from "~/env.server";
+import { getImpersonationId } from "./impersonation.server";
+import { platosControlDatabase } from "./platosControlDatabase.server";
+export {
+  authEmailRateLimitIdentifier,
+  authSessionRateLimitIdentifier,
+} from "./dashboardAuthRateLimit.server";
+import {
+  applyLegacyImpersonation,
+  canonicalUserId,
+  legacyUserId,
+  normalizeBridgeEmail,
+  resolveDashboardIdentity,
+  type CanonicalUserId,
+  type DashboardIdentity,
+  type LegacyUserId,
+} from "./dashboardIdentity.server";
+
+export const platosDashboardAuth = new PlatosAuthService(platosControlDatabase, {
+  encryptionKey: env.ENCRYPTION_KEY,
+});
+
+export const OPERATOR_SESSION_COOKIE_NAME =
+  env.NODE_ENV === "production" ? "__Host-platos_operator_session" : "platos_operator_session";
+
+const operatorSessionCookie = createCookie(OPERATOR_SESSION_COOKIE_NAME, {
+  httpOnly: true,
+  path: "/",
+  sameSite: "lax",
+  secure: env.NODE_ENV === "production",
+});
+
+export async function getOperatorSessionToken(request: Request): Promise<string | null> {
+  const value = await operatorSessionCookie.parse(request.headers.get("Cookie"));
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export function commitOperatorSession(token: string, expiresAt: Date): Promise<string> {
+  return operatorSessionCookie.serialize(token, { expires: expiresAt });
+}
+
+export function clearOperatorSession(): Promise<string> {
+  return operatorSessionCookie.serialize("", { expires: new Date(0), maxAge: 0 });
+}
+
+export async function getDashboardIdentity(request: Request): Promise<DashboardIdentity | null> {
+  const identity = await resolveDashboardIdentity({
+    token: await getOperatorSessionToken(request),
+    authorizer: platosDashboardAuth,
+    legacyIdentityReader: {
+      async findByNormalizedEmail(normalizedEmail) {
+        return prisma.$queryRaw<Array<{ id: string; email: string }>>(LegacyPrisma.sql`
+          SELECT "id", "email"
+          FROM "User"
+          WHERE LOWER(BTRIM("email")) = ${normalizedEmail}
+          ORDER BY "id"
+          LIMIT 2
+        `);
+      },
+    },
+    canonicalMfaReader: {
+      async findEnabledAt(userId) {
+        const credential = await platosControlDatabase.operatorMfaTotp.findUnique({
+          where: { userId },
+          select: { enabledAt: true },
+        });
+        return credential?.enabledAt ?? null;
+      },
+    },
+    canonicalIdentityReader: {
+      async findEmail(userId) {
+        return canonicalEmailForUser(userId);
+      },
+    },
+  });
+  if (!identity) return null;
+
+  const legacyTargetUserId = await getImpersonationId(request);
+  if (!legacyTargetUserId || identity.authorization.impersonation) return identity;
+
+  const [legacyActor, legacyTarget] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: identity.legacyActorUserId },
+      select: { admin: true },
+    }),
+    prisma.user.findUnique({
+      where: { id: legacyTargetUserId },
+      select: { id: true },
+    }),
+  ]);
+  return applyLegacyImpersonation({
+    identity,
+    legacyTargetUserId,
+    legacyActorIsAdmin: legacyActor?.admin === true,
+    legacyTargetExists: legacyTarget !== null,
+  });
+}
+
+export async function requireDashboardIdentity(
+  request: Request,
+  redirectTo?: string
+): Promise<DashboardIdentity> {
+  const identity = await getDashboardIdentity(request);
+  if (identity) return identity;
+
+  const url = new URL(request.url);
+  const search = new URLSearchParams([
+    ["redirectTo", redirectTo ?? `${url.pathname}${url.search}`],
+  ]);
+  throw redirect(`/login?${search}`);
+}
+
+export async function bridgeVerifiedEmailToLegacyUser(email: string): Promise<{
+  canonicalEmail: string;
+  legacyUserId: LegacyUserId;
+} | null> {
+  const canonicalEmail = normalizeBridgeEmail(email);
+  const matches = await prisma.$queryRaw<Array<{ id: string }>>(LegacyPrisma.sql`
+    SELECT "id"
+    FROM "User"
+    WHERE LOWER(BTRIM("email")) = ${canonicalEmail}
+    ORDER BY "id"
+    LIMIT 2
+  `);
+  if (matches.length !== 1) return null;
+  return { canonicalEmail, legacyUserId: legacyUserId(matches[0].id) };
+}
+
+export async function canonicalEmailForUser(userId: CanonicalUserId): Promise<string | null> {
+  const user = await platosControlDatabase.user.findUnique({
+    where: { id: userId },
+    select: { email: true },
+  });
+  return user?.email ?? null;
+}
+
+export async function requireCanonicalAuthorization(request: Request): Promise<{
+  token: string;
+  authorization: OperatorAuthorization;
+  canonicalActorUserId: CanonicalUserId;
+  canonicalEffectiveUserId: CanonicalUserId;
+  canonicalUserId: CanonicalUserId;
+}> {
+  const token = await getOperatorSessionToken(request);
+  if (!token) throw new PlatosAuthError("unauthorized", 401, "Invalid operator session");
+  const authorization = await platosDashboardAuth.authorizeOperatorSession(token);
+  return {
+    token,
+    authorization,
+    canonicalActorUserId: canonicalUserId(authorization.actorUserId),
+    canonicalEffectiveUserId: canonicalUserId(authorization.effectiveUserId),
+    canonicalUserId: canonicalUserId(authorization.effectiveUserId),
+  };
+}
+
+export async function requireCanonicalEnvironmentAuthorization(params: {
+  request: Request;
+  organizationSlug: string;
+  projectSlug: string;
+  environmentSlug: string;
+  access: EnvironmentAuthorizationAccess;
+}): Promise<{
+  authorization: EnvironmentOperatorAuthorization;
+  scope: {
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    userId: CanonicalUserId;
+  };
+}> {
+  const operator = await requireCanonicalAuthorization(params.request);
+  const environment = await platosControlDatabase.environment.findFirst({
+    where: {
+      slug: params.environmentSlug,
+      project: {
+        slug: params.projectSlug,
+        organization: { slug: params.organizationSlug },
+      },
+    },
+    select: {
+      id: true,
+      projectId: true,
+      project: { select: { organizationId: true } },
+    },
+  });
+  if (!environment) {
+    throw new PlatosAuthError("forbidden", 403, "Operator is not authorized for this environment");
+  }
+
+  const authorization = await authorizeEnvironmentOperator(
+    platosControlDatabase,
+    operator.authorization,
+    environment.id,
+    params.access
+  );
+  return {
+    authorization,
+    scope: {
+      organizationId: authorization.organizationId,
+      projectId: authorization.projectId,
+      environmentId: authorization.environmentId,
+      userId: operator.canonicalUserId,
+    },
+  };
+}
+
+export function isMfaRequired(error: unknown): boolean {
+  return error instanceof PlatosAuthError && error.code === "mfa_required";
+}

--- a/apps/webapp/app/services/session.server.ts
+++ b/apps/webapp/app/services/session.server.ts
@@ -1,26 +1,13 @@
 import { redirect } from "@remix-run/node";
 import { getUserById } from "~/models/user.server";
-import { authenticator } from "./auth.server";
-import { getImpersonationId } from "./impersonation.server";
+import {
+  getDashboardIdentity,
+  requireDashboardIdentity,
+} from "./platosDashboardAuth.server";
+import type { LegacyUserId } from "./dashboardIdentity.server";
 
-export async function getUserId(request: Request): Promise<string | undefined> {
-  const impersonatedUserId = await getImpersonationId(request);
-
-  if (impersonatedUserId) {
-    // Verify the real user (from the session cookie) is still an admin
-    const authUser = await authenticator.isAuthenticated(request);
-    if (authUser?.userId) {
-      const realUser = await getUserById(authUser.userId);
-      if (realUser?.admin) {
-        return impersonatedUserId;
-      }
-    }
-    // Admin revoked or session invalid — fall through to return the real user's ID
-    return authUser?.userId;
-  }
-
-  let authUser = await authenticator.isAuthenticated(request);
-  return authUser?.userId;
+export async function getUserId(request: Request): Promise<LegacyUserId | undefined> {
+  return (await getDashboardIdentity(request))?.legacyEffectiveUserId;
 }
 
 export async function getUser(request: Request) {
@@ -34,23 +21,14 @@ export async function getUser(request: Request) {
 }
 
 export async function requireUserId(request: Request, redirectTo?: string) {
-  const userId = await getUserId(request);
-  if (!userId) {
-    const url = new URL(request.url);
-    const searchParams = new URLSearchParams([
-      ["redirectTo", redirectTo ?? `${url.pathname}${url.search}`],
-    ]);
-    throw redirect(`/login?${searchParams}`);
-  }
-  return userId;
+  return (await requireDashboardIdentity(request, redirectTo)).legacyEffectiveUserId;
 }
 
 export type UserFromSession = Awaited<ReturnType<typeof requireUser>>;
 
 export async function requireUser(request: Request) {
-  const userId = await requireUserId(request);
-
-  const impersonationId = await getImpersonationId(request);
+  const identity = await requireDashboardIdentity(request);
+  const userId = identity.legacyEffectiveUserId;
   const user = await getUserById(userId);
   if (user) {
     return {
@@ -64,8 +42,8 @@ export async function requireUser(request: Request) {
       updatedAt: user.updatedAt,
       dashboardPreferences: user.dashboardPreferences,
       confirmedBasicDetails: user.confirmedBasicDetails,
-      mfaEnabledAt: user.mfaEnabledAt,
-      isImpersonating: !!impersonationId && impersonationId === userId,
+      mfaEnabledAt: identity.mfaEnabledAt,
+      isImpersonating: identity.isImpersonating,
     };
   }
 

--- a/apps/webapp/test/dashboardAuthBoundary.test.ts
+++ b/apps/webapp/test/dashboardAuthBoundary.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+describe("dashboard auth route boundary", () => {
+  it("uses the explicit clean control datasource without repointing legacy URLs", () => {
+    const control = source("../app/services/platosControlDatabase.server.ts");
+    const compose = source("../../../docker-compose.platos.yml");
+    expect(control).toContain("env.PLATOS_CONTROL_DATABASE_URL");
+    expect(control).not.toContain("env.DATABASE_URL");
+    expect(compose).toContain("PLATOS_CONTROL_DATABASE_URL:");
+    expect(compose).toContain("POSTGRES_LEGACY_DB:-platos_legacy");
+    expect(compose).toContain("POSTGRES_DB:-platos_control");
+    expect(compose).not.toContain("POSTGRES_DB:-postgres");
+    expect(compose).toContain("[migrations-init] ensuring the clean control database exists");
+    expect(compose).toContain("SELECT 1 FROM pg_database WHERE datname='${POSTGRES_DB:-platos_control}'");
+  });
+
+  it("uses server-controlled rate-limit identities instead of caller-supplied XFF", () => {
+    const magic = source("../app/routes/login.magic/route.tsx");
+    const mfa = source("../app/routes/login.mfa/route.tsx");
+    const setup = source("../app/routes/resources.account.mfa.setup/route.tsx");
+    const github = source("../app/services/gitHubAuth.server.ts");
+    const google = source("../app/services/googleAuth.server.ts");
+
+    expect(magic).toContain("authEmailRateLimitIdentifier(email)");
+    expect(magic).not.toContain("x-forwarded-for");
+    expect(magic).not.toContain("checkMagicLinkIpRateLimit");
+    expect(github).toContain("authEmailRateLimitIdentifier(email)");
+    expect(google).toContain("authEmailRateLimitIdentifier(email)");
+    expect(mfa).toContain("authSessionRateLimitIdentifier(sessionToken)");
+    expect(setup).toContain("authSessionRateLimitIdentifier(operator.token)");
+  });
+
+  it("routes login callbacks, MFA verification, and logout through PlatosAuthService", () => {
+    const files = [
+      "../app/routes/magic.tsx",
+      "../app/routes/auth.github.callback.tsx",
+      "../app/routes/auth.google.callback.tsx",
+      "../app/routes/login.mfa/route.tsx",
+      "../app/routes/resources.account.mfa.setup/route.tsx",
+      "../app/routes/logout.tsx",
+    ].map(source);
+    expect(files[0]).toContain("platosDashboardAuth.consumeMagicLink");
+    expect(files[1]).toContain("commitOperatorSession");
+    expect(files[2]).toContain("commitOperatorSession");
+    expect(files[3]).toContain("platosDashboardAuth.verifyMfaForSession");
+    expect(files[4]).toContain("platosDashboardAuth.confirmTotpEnrollment");
+    expect(files[5]).toContain("platosDashboardAuth.revokeOperatorSession");
+  });
+
+  it("bridges OAuth callbacks from the canonical user email, not mutable provider profile data", () => {
+    const github = source("../app/services/gitHubAuth.server.ts");
+    const google = source("../app/services/googleAuth.server.ts");
+    for (const strategy of [github, google]) {
+      expect(strategy).toContain("canonicalEmailForUser(canonicalId)");
+      expect(strategy).toContain("email: canonicalEmail");
+    }
+  });
+
+  it("isolates transient OAuth state from the inherited dashboard session cookie", () => {
+    const auth = source("../app/services/auth.server.ts");
+    const logout = source("../app/routes/logout.tsx");
+    expect(auth).toContain("new Authenticator<AuthUser>(oauthSessionStorage)");
+    expect(auth).not.toContain("new Authenticator<AuthUser>(sessionStorage)");
+    expect(auth).toContain('"__Host-platos_oauth"');
+    expect(source("../app/routes/auth.github.callback.tsx")).toContain(
+      "clearOAuthSession(request)"
+    );
+    expect(source("../app/routes/auth.google.callback.tsx")).toContain(
+      "clearOAuthSession(request)"
+    );
+    expect(logout).toContain("clearOAuthSession(request)");
+  });
+
+  it("keeps legacy resources on bridged legacy IDs and credentials on canonical authorization", () => {
+    const session = source("../app/services/session.server.ts");
+    const credentials = source("../app/services/platosCredentialStore.server.ts");
+    expect(session).toContain(".legacyEffectiveUserId");
+    expect(credentials).toContain("authorization: EnvironmentOperatorAuthorization");
+    expect(credentials).not.toContain('sessionId: "platos-webapp-session"');
+  });
+
+  it("keeps legacy impersonation isolated from clean auth and uses the clean session for STOP audit", () => {
+    const identity = source("../app/services/platosDashboardAuth.server.ts");
+    const admin = source("../app/models/admin.server.ts");
+    expect(identity).toContain("legacyActorUserId");
+    expect(identity).toContain("legacyTargetUserId");
+    expect(admin).toContain("getDashboardIdentity(request)");
+    expect(admin).toContain("where: { id: identity.legacyActorUserId }");
+    expect(admin).toContain("adminId: actor.id");
+    expect(admin).not.toContain("authenticator.isAuthenticated(request)");
+  });
+
+  it("maps canonical provider authorization failures to a generic forbidden response", () => {
+    const route = source(
+      "../app/routes/_app.orgs.$organizationSlug.projects.$projectParam.env.$envParam.agent-providers._index/route.tsx"
+    );
+    expect(route).toContain('error instanceof PlatosAuthError && error.code === "forbidden"');
+    expect(route).toContain("Project admin or organization admin access is required.");
+  });
+});

--- a/apps/webapp/test/dashboardAuthRateLimit.test.ts
+++ b/apps/webapp/test/dashboardAuthRateLimit.test.ts
@@ -1,0 +1,36 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  authEmailRateLimitIdentifier,
+  authSessionRateLimitIdentifier,
+} from "../app/services/dashboardAuthRateLimit.server";
+
+describe("dashboard auth rate-limit identity", () => {
+  it("uses only normalized email even when the request carries an arbitrary single XFF", () => {
+    const request = new Request("https://dashboard.example/login", {
+      headers: { "x-forwarded-for": "arbitrary-caller-value" },
+    });
+
+    expect(request.headers.get("x-forwarded-for")).toBe("arbitrary-caller-value");
+    expect(authEmailRateLimitIdentifier(" Operator@Example.com ")).toBe(
+      "email:operator@example.com"
+    );
+    expect(authEmailRateLimitIdentifier("operator@example.com")).toBe(
+      authEmailRateLimitIdentifier(" Operator@Example.com ")
+    );
+  });
+
+  it("uses a domain-prefixed SHA-256 session digest without exposing the opaque token", () => {
+    const token = "plt_os_non-secret-test-token";
+    const digest = createHash("sha256")
+      .update("platos-auth-rate-limit:operator-session\0")
+      .update(token)
+      .digest("hex");
+
+    const identifier = authSessionRateLimitIdentifier(token);
+    expect(identifier).toBe(`operator-session:${digest}`);
+    expect(identifier).not.toContain(token);
+    expect(identifier).toBe(authSessionRateLimitIdentifier(token));
+    expect(identifier).not.toBe(authSessionRateLimitIdentifier(`${token}-other`));
+  });
+});

--- a/apps/webapp/test/dashboardAuthRoutes.test.ts
+++ b/apps/webapp/test/dashboardAuthRoutes.test.ts
@@ -1,0 +1,519 @@
+import { PlatosAuthError } from "@platos/tenancy-database";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const sessionValues = new Map<string, unknown>();
+  const session = {
+    get: vi.fn((key: string) => sessionValues.get(key)),
+    set: vi.fn((key: string, value: unknown) => sessionValues.set(key, value)),
+    unset: vi.fn((key: string) => sessionValues.delete(key)),
+  };
+
+  return {
+    sessionValues,
+    session,
+    getRedirectTo: vi.fn(),
+    getSession: vi.fn(),
+    getUserSession: vi.fn(),
+    commitSession: vi.fn(),
+    destroySession: vi.fn(),
+    redirectWithErrorMessage: vi.fn(),
+    redirectBackWithErrorMessage: vi.fn(),
+    redirectWithSuccessMessage: vi.fn(),
+    typedJsonWithSuccessMessage: vi.fn(),
+    getMessageSession: vi.fn(),
+    setLastAuthMethodHeader: vi.fn(),
+    trackAndClearReferralSource: vi.fn(),
+    consumeMagicLink: vi.fn(),
+    authorizeOperatorSession: vi.fn(),
+    verifyMfaForSession: vi.fn(),
+    beginTotpEnrollment: vi.fn(),
+    confirmTotpEnrollment: vi.fn(),
+    issueOperatorSession: vi.fn(),
+    disableTotpForSession: vi.fn(),
+    bridgeVerifiedEmailToLegacyUser: vi.fn(),
+    canonicalEmailForUser: vi.fn(),
+    commitOperatorSession: vi.fn(),
+    clearOperatorSession: vi.fn(),
+    getOperatorSessionToken: vi.fn(),
+    getDashboardIdentity: vi.fn(),
+    requireCanonicalAuthorization: vi.fn(),
+    getUserId: vi.fn(),
+    authenticate: vi.fn(),
+    clearOAuthSession: vi.fn(),
+    destroyImpersonationSession: vi.fn(),
+    githubRedirectParse: vi.fn(),
+    googleRedirectParse: vi.fn(),
+  };
+});
+
+function redirectResponse(path: string, cookie?: string) {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: path,
+      ...(cookie ? { "Set-Cookie": cookie } : {}),
+    },
+  });
+}
+
+vi.mock("~/services/redirectTo.server", () => ({
+  getRedirectTo: mocks.getRedirectTo,
+}));
+vi.mock("~/services/sessionStorage.server", () => ({
+  getSession: mocks.getSession,
+  getUserSession: mocks.getUserSession,
+  commitSession: mocks.commitSession,
+  destroySession: mocks.destroySession,
+}));
+vi.mock("~/models/message.server", () => ({
+  getSession: mocks.getMessageSession,
+  redirectWithErrorMessage: mocks.redirectWithErrorMessage,
+  redirectBackWithErrorMessage: mocks.redirectBackWithErrorMessage,
+  redirectWithSuccessMessage: mocks.redirectWithSuccessMessage,
+  typedJsonWithSuccessMessage: mocks.typedJsonWithSuccessMessage,
+}));
+vi.mock("~/services/lastAuthMethod.server", () => ({
+  setLastAuthMethodHeader: mocks.setLastAuthMethodHeader,
+}));
+vi.mock("~/services/referralSource.server", () => ({
+  trackAndClearReferralSource: mocks.trackAndClearReferralSource,
+}));
+vi.mock("~/services/platosDashboardAuth.server", () => ({
+  authEmailRateLimitIdentifier: vi.fn((email: string) => `email:${email.trim().toLowerCase()}`),
+  authSessionRateLimitIdentifier: vi.fn(() => "operator-session:session-digest"),
+  bridgeVerifiedEmailToLegacyUser: mocks.bridgeVerifiedEmailToLegacyUser,
+  canonicalEmailForUser: mocks.canonicalEmailForUser,
+  commitOperatorSession: mocks.commitOperatorSession,
+  clearOperatorSession: mocks.clearOperatorSession,
+  getOperatorSessionToken: mocks.getOperatorSessionToken,
+  getDashboardIdentity: mocks.getDashboardIdentity,
+  requireCanonicalAuthorization: mocks.requireCanonicalAuthorization,
+  isMfaRequired: vi.fn(
+    (error: unknown) => error instanceof PlatosAuthError && error.code === "mfa_required"
+  ),
+  platosDashboardAuth: {
+    consumeMagicLink: mocks.consumeMagicLink,
+    authorizeOperatorSession: mocks.authorizeOperatorSession,
+    verifyMfaForSession: mocks.verifyMfaForSession,
+    beginTotpEnrollment: mocks.beginTotpEnrollment,
+    confirmTotpEnrollment: mocks.confirmTotpEnrollment,
+    issueOperatorSession: mocks.issueOperatorSession,
+    disableTotpForSession: mocks.disableTotpForSession,
+    revokeOperatorSession: vi.fn(),
+  },
+}));
+vi.mock("~/services/session.server", () => ({
+  getUserId: mocks.getUserId,
+}));
+vi.mock("~/services/auth.server", () => ({
+  authenticator: { authenticate: mocks.authenticate },
+  clearOAuthSession: mocks.clearOAuthSession,
+}));
+vi.mock("~/services/impersonation.server", () => ({
+  destroyImpersonationSession: mocks.destroyImpersonationSession,
+}));
+vi.mock("~/routes/auth.github", () => ({
+  redirectCookie: { parse: mocks.githubRedirectParse },
+}));
+vi.mock("~/routes/auth.google", () => ({
+  redirectCookie: { parse: mocks.googleRedirectParse },
+}));
+vi.mock("~/utils", () => ({
+  sanitizeRedirectPath: vi.fn((value: unknown) =>
+    typeof value === "string" && value.startsWith("/") ? value : "/"
+  ),
+}));
+
+import { loader as magicLoader } from "~/routes/magic";
+import {
+  action as mfaLoginAction,
+  loader as mfaLoginLoader,
+} from "~/routes/login.mfa/route";
+import { action as logoutAction } from "~/routes/logout";
+import { loader as githubCallbackLoader } from "~/routes/auth.github.callback";
+import { loader as googleCallbackLoader } from "~/routes/auth.google.callback";
+import { action as mfaSetupAction } from "~/routes/resources.account.mfa.setup/route";
+import {
+  mfaReducer,
+  type MfaState,
+} from "~/routes/resources.account.mfa.setup/useMfaSetup";
+import { platosDashboardAuth } from "~/services/platosDashboardAuth.server";
+
+const expiresAt = new Date("2026-08-20T00:00:00.000Z");
+
+function formRequest(path: string, values: Record<string, string>, cookie = "session=cookie") {
+  return new Request(`https://dashboard.example${path}`, {
+    method: "POST",
+    headers: {
+      Cookie: cookie,
+      "Content-Type": "application/x-www-form-urlencoded",
+      "X-Forwarded-For": "arbitrary-caller-value",
+    },
+    body: new URLSearchParams(values),
+  });
+}
+
+function setCookies(response: Response): string[] {
+  const headers = response.headers as Headers & { getSetCookie?: () => string[] };
+  return headers.getSetCookie?.() ?? [response.headers.get("Set-Cookie") ?? ""];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.sessionValues.clear();
+  mocks.getSession.mockResolvedValue(mocks.session);
+  mocks.getUserSession.mockResolvedValue(mocks.session);
+  mocks.commitSession.mockResolvedValue("__session=committed; Path=/");
+  mocks.destroySession.mockResolvedValue("__session=; Max-Age=0; Path=/");
+  mocks.getMessageSession.mockResolvedValue({ get: vi.fn(() => undefined) });
+  mocks.getRedirectTo.mockResolvedValue("/projects");
+  mocks.redirectWithErrorMessage.mockImplementation(async (path: string) =>
+    redirectResponse(path, "__message=error; Path=/")
+  );
+  mocks.redirectBackWithErrorMessage.mockImplementation(async (request: Request) =>
+    redirectResponse(new URL(request.url).pathname, "__message=error; Path=/")
+  );
+  mocks.redirectWithSuccessMessage.mockImplementation(async (path: string) =>
+    redirectResponse(path, "__message=success; Path=/")
+  );
+  mocks.typedJsonWithSuccessMessage.mockImplementation(async (data: unknown) =>
+    Response.json(data, { headers: { "Set-Cookie": "__message=success; Path=/" } })
+  );
+  mocks.setLastAuthMethodHeader.mockResolvedValue("last-auth=email; Path=/");
+  mocks.commitOperatorSession.mockResolvedValue("platos_operator_session=operator; Path=/");
+  mocks.clearOperatorSession.mockResolvedValue(
+    "platos_operator_session=; Max-Age=0; Path=/"
+  );
+  mocks.clearOAuthSession.mockResolvedValue("platos_oauth=; Max-Age=0; Path=/");
+  mocks.destroyImpersonationSession.mockResolvedValue(
+    "__impersonate=; Max-Age=0; Path=/"
+  );
+  mocks.getOperatorSessionToken.mockResolvedValue("operator-token");
+  mocks.authorizeOperatorSession.mockResolvedValue({});
+  mocks.bridgeVerifiedEmailToLegacyUser.mockResolvedValue({
+    canonicalEmail: "operator@example.com",
+    legacyUserId: "legacy-user",
+  });
+  mocks.canonicalEmailForUser.mockResolvedValue("operator@example.com");
+  mocks.getDashboardIdentity.mockResolvedValue({ legacyUserId: "legacy-user" });
+  mocks.requireCanonicalAuthorization.mockResolvedValue({
+    token: "operator-token",
+    canonicalUserId: "canonical-user",
+  });
+  mocks.getUserId.mockResolvedValue(undefined);
+  mocks.githubRedirectParse.mockResolvedValue("/projects");
+  mocks.googleRedirectParse.mockResolvedValue("/projects");
+});
+
+describe("magic login route", () => {
+  it("completes a valid magic login and rejects replay of the consumed token", async () => {
+    mocks.consumeMagicLink
+      .mockResolvedValueOnce({
+        userId: "canonical-user",
+        token: "operator-token",
+        expiresAt,
+      })
+      .mockRejectedValueOnce(new PlatosAuthError("magic_invalid", 401, "Magic link invalid"));
+
+    const request = new Request("https://dashboard.example/magic?token=one-time-token", {
+      headers: { Cookie: "magic=cookie; __impersonate=stale-account-target" },
+    });
+    const success = await magicLoader({ request, params: {}, context: {} } as never);
+    expect(success.status).toBe(302);
+    expect(success.headers.get("Location")).toBe("/projects");
+    expect(mocks.canonicalEmailForUser).toHaveBeenCalledWith("canonical-user");
+    expect(mocks.bridgeVerifiedEmailToLegacyUser).toHaveBeenCalledWith(
+      "operator@example.com"
+    );
+    expect(mocks.trackAndClearReferralSource).toHaveBeenCalledWith(
+      request,
+      "legacy-user",
+      expect.any(Headers)
+    );
+    expect(setCookies(success).join(" ")).toContain("platos_operator_session=operator");
+    expect(setCookies(success).join(" ")).toContain("__impersonate=; Max-Age=0");
+    expect(mocks.destroyImpersonationSession).toHaveBeenCalledWith(request);
+
+    const replay = await magicLoader({ request, params: {}, context: {} } as never);
+    expect(replay.status).toBe(302);
+    expect(replay.headers.get("Location")).toBe("/login/magic");
+    expect(mocks.redirectWithErrorMessage).toHaveBeenCalledWith(
+      "/login/magic",
+      request,
+      "This magic link is invalid or expired."
+    );
+    expect(mocks.trackAndClearReferralSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("stores the pending destination and redirects an MFA-enabled session", async () => {
+    mocks.consumeMagicLink.mockResolvedValue({
+      userId: "canonical-user",
+      token: "operator-token",
+      expiresAt,
+    });
+    mocks.authorizeOperatorSession.mockRejectedValue(
+      new PlatosAuthError("mfa_required", 401, "MFA required")
+    );
+    const request = new Request("https://dashboard.example/magic?token=valid", {
+      headers: { Cookie: "magic=cookie" },
+    });
+
+    const response = await magicLoader({ request, params: {}, context: {} } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/login/mfa");
+    expect(mocks.session.set).toHaveBeenCalledWith("pending-mfa-redirect-to", "/projects");
+    expect(setCookies(response).join(" ")).toContain("platos_operator_session=operator");
+    expect(mocks.trackAndClearReferralSource).not.toHaveBeenCalled();
+  });
+});
+
+describe("MFA login route", () => {
+  it.each([
+    {
+      name: "TOTP",
+      form: { action: "verify-mfa", mfaCode: "123456" },
+      expected: { totpCode: "123456" },
+    },
+    {
+      name: "recovery code",
+      form: { action: "verify-recovery", recoveryCode: "recovery-code" },
+      expected: { recoveryCode: "recovery-code" },
+    },
+  ])("completes login with a valid $name", async ({ form, expected }) => {
+    mocks.sessionValues.set("pending-mfa-redirect-to", "/projects/project-one");
+    const request = formRequest("/login/mfa", form);
+
+    const response = await mfaLoginAction({ request, params: {}, context: {} } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/projects/project-one");
+    expect(mocks.verifyMfaForSession).toHaveBeenCalledWith({
+      sessionToken: "operator-token",
+      rateLimitIdentifier: "operator-session:session-digest",
+      ...expected,
+    });
+    expect(mocks.session.unset).toHaveBeenCalledWith("pending-mfa-redirect-to");
+    expect(mocks.trackAndClearReferralSource).toHaveBeenCalledWith(
+      request,
+      "legacy-user",
+      expect.any(Headers)
+    );
+  });
+
+  it("sends a bad operator session back through the login boundary", async () => {
+    mocks.verifyMfaForSession.mockRejectedValue(
+      new PlatosAuthError("revoked", 401, "Session revoked")
+    );
+    const request = formRequest("/login/mfa", {
+      action: "verify-mfa",
+      mfaCode: "123456",
+    });
+
+    const response = await mfaLoginAction({ request, params: {}, context: {} } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/login");
+    expect(mocks.redirectWithErrorMessage).toHaveBeenCalledWith(
+      "/login",
+      request,
+      "Please log in again."
+    );
+    expect(mocks.getDashboardIdentity).not.toHaveBeenCalled();
+  });
+
+  it("redirects an invalid session from the MFA loader", async () => {
+    mocks.authorizeOperatorSession.mockRejectedValue(
+      new PlatosAuthError("revoked", 401, "Session revoked")
+    );
+    const request = new Request("https://dashboard.example/login/mfa");
+
+    const response = await mfaLoginLoader({ request, params: {}, context: {} } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/login");
+  });
+});
+
+describe("logout route", () => {
+  it("revokes the operator session and destroys operator, OAuth, impersonation, and legacy cookies", async () => {
+    const revokeOperatorSession = vi.mocked(platosDashboardAuth.revokeOperatorSession);
+    revokeOperatorSession.mockResolvedValue(true as never);
+    const request = new Request("https://dashboard.example/logout", {
+      method: "POST",
+      headers: { Cookie: "all=present" },
+    });
+
+    const response = await logoutAction({ request, params: {}, context: {} } as never);
+
+    expect(revokeOperatorSession).toHaveBeenCalledWith("operator-token");
+    expect(mocks.clearOAuthSession).toHaveBeenCalledWith(request);
+    expect(mocks.destroyImpersonationSession).toHaveBeenCalledWith(request);
+    expect(mocks.destroySession).toHaveBeenCalledWith(mocks.session);
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/");
+    const cookies = setCookies(response).join(" ");
+    expect(cookies).toContain("platos_operator_session=; Max-Age=0");
+    expect(cookies).toContain("platos_oauth=; Max-Age=0");
+    expect(cookies).toContain("__impersonate=; Max-Age=0");
+    expect(cookies).toContain("__session=; Max-Age=0");
+  });
+});
+
+describe.each([
+  ["github", githubCallbackLoader],
+  ["google", googleCallbackLoader],
+] as const)("%s OAuth callback route", (provider, callbackLoader) => {
+  it("commits the mocked provider completion and clears transient OAuth state", async () => {
+    mocks.authenticate.mockResolvedValue({
+      canonicalUserId: "canonical-user",
+      email: "operator@example.com",
+      sessionToken: "oauth-operator-token",
+      sessionExpiresAt: expiresAt.toISOString(),
+    });
+    const request = new Request(`https://dashboard.example/auth/${provider}/callback`, {
+      headers: { Cookie: "oauth=state; __impersonate=stale-account-target" },
+    });
+
+    const response = await callbackLoader({ request, params: {}, context: {} } as never);
+
+    expect(mocks.authenticate).toHaveBeenCalledWith(provider, request, {
+      failureRedirect: "/login",
+    });
+    expect(mocks.bridgeVerifiedEmailToLegacyUser).toHaveBeenCalledWith(
+      "operator@example.com"
+    );
+    expect(mocks.clearOAuthSession).toHaveBeenCalledWith(request);
+    expect(mocks.destroyImpersonationSession).toHaveBeenCalledWith(request);
+    expect(mocks.commitOperatorSession).toHaveBeenCalledWith(
+      "oauth-operator-token",
+      expiresAt
+    );
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/projects");
+    expect(setCookies(response).join(" ")).toContain("platos_oauth=; Max-Age=0");
+    expect(setCookies(response).join(" ")).toContain("__impersonate=; Max-Age=0");
+    expect(mocks.trackAndClearReferralSource).toHaveBeenCalledWith(
+      request,
+      "legacy-user",
+      expect.any(Headers)
+    );
+  });
+
+  it("fails closed on bridge failure and still clears transient OAuth state", async () => {
+    mocks.authenticate.mockResolvedValue({
+      canonicalUserId: "canonical-user",
+      email: "ambiguous@example.com",
+      sessionToken: "oauth-operator-token",
+      sessionExpiresAt: expiresAt.toISOString(),
+    });
+    mocks.bridgeVerifiedEmailToLegacyUser.mockResolvedValue(null);
+    const request = new Request(`https://dashboard.example/auth/${provider}/callback`, {
+      headers: { Cookie: "oauth=state" },
+    });
+
+    const response = await callbackLoader({ request, params: {}, context: {} } as never);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/login");
+    expect(mocks.clearOAuthSession).toHaveBeenCalledWith(request);
+    expect(setCookies(response).join(" ")).toContain("platos_oauth=; Max-Age=0");
+    expect(mocks.authorizeOperatorSession).not.toHaveBeenCalled();
+    expect(mocks.commitOperatorSession).not.toHaveBeenCalled();
+    expect(mocks.trackAndClearReferralSource).not.toHaveBeenCalled();
+  });
+});
+
+describe("MFA setup route", () => {
+  it("confirms TOTP enrollment and replaces the operator session", async () => {
+    mocks.confirmTotpEnrollment.mockResolvedValue({
+      recoveryCodes: ["recovery-one", "recovery-two"],
+    });
+    mocks.issueOperatorSession.mockResolvedValue({
+      token: "replacement-token",
+      expiresAt,
+    });
+    const request = formRequest("/resources/account/mfa/setup", {
+      action: "validate-totp",
+      totpCode: "123456",
+    });
+
+    const response = await mfaSetupAction({ request, params: {}, context: {} } as never);
+
+    expect(mocks.confirmTotpEnrollment).toHaveBeenCalledWith(
+      "canonical-user",
+      "123456",
+      "operator-session:session-digest"
+    );
+    expect(mocks.issueOperatorSession).toHaveBeenCalledWith({
+      userId: "canonical-user",
+      mfaVerifiedAt: expect.any(Date),
+    });
+    expect(await response.json()).toMatchObject({
+      action: "validate-totp",
+      success: true,
+      recoveryCodes: ["recovery-one", "recovery-two"],
+    });
+    expect(setCookies(response).join(" ")).toContain("platos_operator_session=operator");
+  });
+
+  it("disables MFA through the current operator session", async () => {
+    const request = formRequest("/resources/account/mfa/setup", {
+      action: "disable-mfa",
+      recoveryCode: "recovery-code",
+    });
+
+    const response = await mfaSetupAction({ request, params: {}, context: {} } as never);
+
+    expect(mocks.disableTotpForSession).toHaveBeenCalledWith({
+      sessionToken: "operator-token",
+      rateLimitIdentifier: "operator-session:session-digest",
+      totpCode: undefined,
+      recoveryCode: "recovery-code",
+    });
+    expect(await response.json()).toEqual({ action: "disable-mfa", success: true });
+    expect(setCookies(response).join(" ")).toContain("__message=success");
+  });
+
+  it("keeps the enrollment QR state available after an invalid confirmation retry", async () => {
+    mocks.confirmTotpEnrollment.mockRejectedValue(
+      new PlatosAuthError("invalid_mfa", 401, "Invalid code")
+    );
+    const request = formRequest("/resources/account/mfa/setup", {
+      action: "validate-totp",
+      totpCode: "000000",
+    });
+
+    const response = await mfaSetupAction({ request, params: {}, context: {} } as never);
+    expect(await response.json()).toMatchObject({
+      action: "validate-totp",
+      success: false,
+      error: "Invalid code provided. Please try again.",
+    });
+
+    const setupData = {
+      secret: "JBSWY3DPEHPK3PXP",
+      otpAuthUrl: "otpauth://totp/Platos:operator",
+    };
+    const initial: MfaState = {
+      phase: "enabling",
+      isEnabled: false,
+      setupData,
+      isSubmitting: false,
+      disableMethod: "totp",
+    };
+    const validating = mfaReducer(initial, { type: "VALIDATE_TOTP", code: "000000" });
+    const retriable = mfaReducer(validating, {
+      type: "VALIDATION_FAILED",
+      error: "Invalid code provided. Please try again.",
+    });
+
+    expect(retriable).toMatchObject({
+      phase: "enabling",
+      setupData,
+      isSubmitting: false,
+      error: "Invalid code provided. Please try again.",
+    });
+  });
+});

--- a/apps/webapp/test/dashboardIdentity.test.ts
+++ b/apps/webapp/test/dashboardIdentity.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OperatorAuthorization } from "@platos/tenancy-database";
+import {
+  applyLegacyImpersonation,
+  canonicalUserId,
+  normalizeBridgeEmail,
+  resolveDashboardIdentity,
+} from "../app/services/dashboardIdentity.server";
+
+const AUTHORIZATION: OperatorAuthorization = {
+  sessionId: "6be52196-613e-4c2c-9fd6-246a254ff491",
+  actorUserId: "47bda732-e958-4098-8769-d103d2f2ee82",
+  effectiveUserId: "47bda732-e958-4098-8769-d103d2f2ee82",
+  email: " Operator+tag@Example.COM ",
+  expiresAt: new Date("2026-08-20T00:00:00.000Z"),
+  mfaVerifiedAt: null,
+  impersonation: null,
+};
+
+function dependencies(params?: {
+  authorization?: OperatorAuthorization | Error;
+  matches?: Array<{ id: string; email: string }>;
+}) {
+  const authorization = params?.authorization ?? AUTHORIZATION;
+  return {
+    authorizer: {
+      authorizeOperatorSession: vi.fn(async () => {
+        if (authorization instanceof Error) throw authorization;
+        return authorization;
+      }),
+    },
+    legacyIdentityReader: {
+      findByNormalizedEmail: vi.fn(async () => params?.matches ?? []),
+    },
+    canonicalMfaReader: {
+      findEnabledAt: vi.fn(async () => null),
+    },
+    canonicalIdentityReader: {
+      findEmail: vi.fn(async () => null),
+    },
+  };
+}
+
+describe("dashboard clean-session identity bridge", () => {
+  it("normalizes with trim and case folding only", () => {
+    expect(normalizeBridgeEmail(" Operator+tag@Example.COM ")).toBe(
+      "operator+tag@example.com"
+    );
+    expect(normalizeBridgeEmail("first.last@gmail.com")).toBe("first.last@gmail.com");
+  });
+
+  it("fails closed without a session", async () => {
+    const deps = dependencies();
+    await expect(resolveDashboardIdentity({ token: null, ...deps })).resolves.toBeNull();
+    expect(deps.authorizer.authorizeOperatorSession).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a bad clean session", async () => {
+    const deps = dependencies({ authorization: new Error("bad session") });
+    await expect(resolveDashboardIdentity({ token: "bad", ...deps })).resolves.toBeNull();
+    expect(deps.legacyIdentityReader.findByNormalizedEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns separately branded canonical and legacy IDs for one exact normalized match", async () => {
+    const deps = dependencies({
+      matches: [{ id: "clz8legacycuid", email: "operator+tag@example.com" }],
+    });
+    await expect(resolveDashboardIdentity({ token: "valid", ...deps })).resolves.toMatchObject({
+      canonicalActorUserId: canonicalUserId(AUTHORIZATION.actorUserId),
+      canonicalEffectiveUserId: canonicalUserId(AUTHORIZATION.effectiveUserId),
+      canonicalUserId: canonicalUserId(AUTHORIZATION.effectiveUserId),
+      legacyActorUserId: "clz8legacycuid",
+      legacyEffectiveUserId: "clz8legacycuid",
+      legacyUserId: "clz8legacycuid",
+      email: AUTHORIZATION.email,
+      isImpersonating: false,
+    });
+    expect(deps.legacyIdentityReader.findByNormalizedEmail).toHaveBeenCalledWith(
+      "operator+tag@example.com"
+    );
+  });
+
+  it("fails closed when a legacy principal does not belong to the clean session email", async () => {
+    const deps = dependencies({
+      matches: [{ id: "wrong-legacy-cuid", email: "someone-else@example.com" }],
+    });
+    await expect(resolveDashboardIdentity({ token: "valid", ...deps })).resolves.toBeNull();
+    expect(deps.canonicalMfaReader.findEnabledAt).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["zero legacy matches", []],
+    [
+      "ambiguous legacy matches",
+      [
+        { id: "legacy-one", email: "operator+tag@example.com" },
+        { id: "legacy-two", email: "OPERATOR+TAG@example.com" },
+      ],
+    ],
+  ])("fails closed for %s", async (_name, matches) => {
+    const deps = dependencies({ matches });
+    await expect(resolveDashboardIdentity({ token: "valid", ...deps })).resolves.toBeNull();
+    expect(deps.canonicalMfaReader.findEnabledAt).not.toHaveBeenCalled();
+  });
+
+  it("keeps canonical actor/effective and bridged legacy actor/effective identities separate", async () => {
+    const authorization: OperatorAuthorization = {
+      ...AUTHORIZATION,
+      actorUserId: "canonical-actor",
+      effectiveUserId: "canonical-effective",
+      email: "target@example.com",
+      impersonation: {
+        active: true,
+        actorUserId: "canonical-actor",
+        targetUserId: "canonical-effective",
+      },
+    };
+    const deps = dependencies({ authorization });
+    deps.canonicalIdentityReader.findEmail.mockResolvedValue("admin@example.com");
+    deps.legacyIdentityReader.findByNormalizedEmail.mockImplementation(async (email) =>
+      email === "admin@example.com"
+        ? [{ id: "legacy-admin", email }]
+        : [{ id: "legacy-target", email }]
+    );
+
+    await expect(resolveDashboardIdentity({ token: "valid", ...deps })).resolves.toMatchObject({
+      canonicalActorUserId: "canonical-actor",
+      canonicalEffectiveUserId: "canonical-effective",
+      legacyActorUserId: "legacy-admin",
+      legacyEffectiveUserId: "legacy-target",
+      isImpersonating: true,
+    });
+  });
+
+  it("layers legacy impersonation over legacy IDs without changing canonical authorization", async () => {
+    const deps = dependencies({
+      matches: [{ id: "legacy-admin", email: "operator+tag@example.com" }],
+    });
+    const identity = await resolveDashboardIdentity({ token: "valid", ...deps });
+    expect(identity).not.toBeNull();
+
+    const impersonated = applyLegacyImpersonation({
+      identity: identity!,
+      legacyTargetUserId: "legacy-target",
+      legacyActorIsAdmin: true,
+      legacyTargetExists: true,
+    });
+    expect(impersonated).toMatchObject({
+      canonicalActorUserId: AUTHORIZATION.actorUserId,
+      canonicalEffectiveUserId: AUTHORIZATION.effectiveUserId,
+      legacyActorUserId: "legacy-admin",
+      legacyEffectiveUserId: "legacy-target",
+      isImpersonating: true,
+    });
+    expect(impersonated.authorization).toBe(identity!.authorization);
+  });
+});

--- a/apps/webapp/test/registryConfig.test.ts
+++ b/apps/webapp/test/registryConfig.test.ts
@@ -6,9 +6,11 @@ describe("getRegistryConfig", () => {
     NODE_ENV: "test" as const,
     DATABASE_URL: "postgresql://test:test@localhost:5432/test",
     DIRECT_URL: "postgresql://test:test@localhost:5432/test",
+    PLATOS_CONTROL_DATABASE_URL: "postgresql://test:test@localhost:5432/control",
     SESSION_SECRET: "test-session-secret",
     MAGIC_LINK_SECRET: "test-magic-link-secret",
     ENCRYPTION_KEY: "test-encryption-keeeeey-32-bytes",
+    MANAGED_WORKER_SECRET: "test-managed-worker-secret",
     CLICKHOUSE_URL: "http://localhost:8123",
   };
 

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -73,7 +73,7 @@ services:
       # Leaving it at the default makes the Postgres instance trivially
       # compromisable.
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:?required — see .env.example}"
-      POSTGRES_DB: "${POSTGRES_DB:-postgres}"
+      POSTGRES_DB: "${POSTGRES_DB:-platos_control}"
     command: ["-c", "wal_level=logical"]
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "postgres"]
@@ -292,8 +292,9 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
-      DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      PGPASSWORD: "${POSTGRES_PASSWORD}"
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-platos_control}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-platos_control}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
     volumes:
       - ./internal-packages/tenancy-database:/work
     working_dir: /work
@@ -302,6 +303,12 @@ services:
       - -c
       - |
         set -e
+        echo '[migrations-init] ensuring the clean control database exists...'
+        apk add --no-cache postgresql-client > /dev/null
+        psql -h postgres -U "${POSTGRES_USER:-postgres}" -d postgres -tAc \
+          "SELECT 1 FROM pg_database WHERE datname='${POSTGRES_DB:-platos_control}'" \
+          | grep -q 1 || psql -h postgres -U "${POSTGRES_USER:-postgres}" -d postgres \
+          -c "CREATE DATABASE \"${POSTGRES_DB:-platos_control}\""
         echo '[migrations-init] installing prisma...'
         npm install --no-audit --no-fund --silent prisma@6.14.0 @prisma/client@6.14.0
         echo '[migrations-init] deploying the clean tenancy schema...'
@@ -389,7 +396,7 @@ services:
     environment:
       PLATOS_PUBLIC_BASE_URL: "${PLATOS_PUBLIC_BASE_URL:-}"
       PLATOS_AGENT_PORT: "3100"
-      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-postgres}?schema=public&connection_limit=30&pool_timeout=20"
+      DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-platos_control}?schema=public&connection_limit=30&pool_timeout=20"
       REDIS_URL: "redis://redis:6379"
       # Test mode selects deterministic local providers. Token-minting test
       # controllers are not registered and are removed from production builds.
@@ -539,6 +546,8 @@ services:
         condition: service_healthy
       migrations-init-legacy:
         condition: service_completed_successfully
+      migrations-init:
+        condition: service_completed_successfully
       clickhouse-migrate:
         condition: service_completed_successfully
     environment:
@@ -553,6 +562,9 @@ services:
       # The dashboard still reads the legacy schema; see migrations-init-legacy.
       DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
       DIRECT_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_LEGACY_DB:-platos_legacy}?schema=public&sslmode=disable&connection_limit=30&pool_timeout=20"
+      # Explicit clean control-plane connection. Never substitute either of the
+      # legacy URLs above: the dashboard remains split until the M4 cutover.
+      PLATOS_CONTROL_DATABASE_URL: "postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-platos_control}?schema=public&sslmode=disable&connection_limit=10&pool_timeout=20"
       DATABASE_HOST: "postgres:5432"
       REDIS_HOST: redis
       REDIS_PORT: "6379"

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -12,8 +12,9 @@ Every environment variable Platos reads. Sourced from `.env` for the webapp and 
 
 | Variable | Default | Required | Purpose |
 |---|---|---|---|
-| `DATABASE_URL` | — | Yes | Postgres connection string. Use `postgresql://user:pass@host:5432/db?schema=public`. Both webapp and agent read this. |
-| `DIRECT_URL` | `$DATABASE_URL` | No | Unpooled connection used for Prisma migrations. Set to bypass PgBouncer. |
+| `DATABASE_URL` | — | Yes | Service-primary Postgres connection string. During the dashboard M1–M4 split, the webapp must point this at the legacy dashboard database (for example `platos_legacy`), while the agent points it at the clean control database (for example `platos_control`). Never repoint the webapp value globally before M4. |
+| `DIRECT_URL` | `$DATABASE_URL` | No | Unpooled connection used for migrations against the same database as that service's `DATABASE_URL`. The webapp value remains legacy until M4. |
+| `PLATOS_CONTROL_DATABASE_URL` | — | **Yes (webapp)** | Webapp-only connection to the distinct clean control database used for `OperatorSession`, canonical authorization, MFA, and credential metadata/mutations. It must not name the legacy `DATABASE_URL` database. |
 | `REDIS_URL` | — | Yes | Redis connection string. Both services. ACL-enabled URIs supported. |
 | `REDIS_TLS_DISABLED` | `false` | No | Set `true` to disable TLS for Redis (e.g. local Docker). |
 | `SESSION_SECRET` | — | Yes | Strong random value (minimum 16 chars; recommended: `openssl rand -base64 24`). Signs webapp cookies and platform bridge JWTs; the same value is supplied to the agent. Rotating invalidates all sessions. |
@@ -178,7 +179,9 @@ Platos stores multimodal attachments (images, audio, video, documents) in MinIO 
 The shortest env file that will boot a working Platos:
 
 ```bash
-DATABASE_URL=postgresql://platos:platos@localhost:5432/platos
+DATABASE_URL=postgresql://platos:platos@localhost:5432/platos_legacy
+DIRECT_URL=postgresql://platos:platos@localhost:5432/platos_legacy
+PLATOS_CONTROL_DATABASE_URL=postgresql://platos:platos@localhost:5432/platos_control
 REDIS_URL=redis://localhost:6379
 SESSION_SECRET=$(openssl rand -base64 24 | tr -d '\n')
 MAGIC_LINK_SECRET=$(openssl rand -base64 24 | tr -d '\n')
@@ -190,4 +193,6 @@ PLATOS_INTERNAL_AUTH_TOKEN=$(openssl rand -hex 32)
 ANTHROPIC_API_KEY=sk-ant-...
 ```
 
-That's it. Everything else has sensible defaults.
+The agent's `DATABASE_URL` must use the same `platos_control` database named by
+the webapp's `PLATOS_CONTROL_DATABASE_URL`. The two webapp database URLs remain
+distinct until the M4 dashboard resource cutover.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -53,12 +53,66 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_DB: platos
+      POSTGRES_DB: platos_control
     volumes:
       - pgdata:/var/lib/postgresql/data
     command:
       ["postgres", "-c", "max_connections=200", "-c", "shared_buffers=2GB"]
     restart: always
+
+  migrations-control:
+    image: node:22-alpine
+    depends_on:
+      postgres:
+        condition: service_started
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_control?schema=public
+      DIRECT_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_control?schema=public
+    volumes:
+      - ./internal-packages/tenancy-database:/work
+    working_dir: /work
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        apk add --no-cache postgresql-client > /dev/null
+        until pg_isready -h postgres -U "${POSTGRES_USER}"; do sleep 1; done
+        psql -h postgres -U "${POSTGRES_USER}" -d postgres -tAc \
+          "SELECT 1 FROM pg_database WHERE datname='platos_control'" \
+          | grep -q 1 || psql -h postgres -U "${POSTGRES_USER}" -d postgres \
+          -c 'CREATE DATABASE "platos_control"'
+        npm install --no-audit --no-fund --silent prisma@6.14.0 @prisma/client@6.14.0
+        npx prisma migrate deploy
+    restart: "no"
+
+  migrations-legacy:
+    image: node:22-alpine
+    depends_on:
+      postgres:
+        condition: service_started
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_legacy?schema=public
+      DIRECT_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_legacy?schema=public
+    volumes:
+      - ./internal-packages/database:/work
+    working_dir: /work
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        apk add --no-cache postgresql-client > /dev/null
+        until pg_isready -h postgres -U "${POSTGRES_USER}"; do sleep 1; done
+        psql -h postgres -U "${POSTGRES_USER}" -d postgres -tAc \
+          "SELECT 1 FROM pg_database WHERE datname='platos_legacy'" \
+          | grep -q 1 || psql -h postgres -U "${POSTGRES_USER}" -d postgres \
+          -c 'CREATE DATABASE "platos_legacy"'
+        npm install --no-audit --no-fund --silent prisma@6.14.0 @prisma/client@6.14.0
+        npx prisma migrate deploy
+    restart: "no"
 
   redis:
     image: redis:7-alpine
@@ -70,7 +124,9 @@ services:
   webapp:
     image: ghcr.io/platos-dev/platos-webapp:${PLATOS_VERSION:-latest}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_legacy
+      DIRECT_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_legacy
+      PLATOS_CONTROL_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_control
       REDIS_URL: redis://redis:6379
       SESSION_SECRET: ${SESSION_SECRET}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY}
@@ -81,7 +137,13 @@ services:
       OTEL_SERVICE_NAME: platos-webapp
       PROMETHEUS_METRICS_ENABLED: "true"
     ports: ["3030:3030"]
-    depends_on: [postgres, redis]
+    depends_on:
+      migrations-control:
+        condition: service_completed_successfully
+      migrations-legacy:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
     restart: always
     deploy:
       replicas: 2
@@ -89,7 +151,7 @@ services:
   agent:
     image: ghcr.io/platos-dev/platos-agent:${PLATOS_VERSION:-latest}
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/platos_control
       REDIS_URL: redis://redis:6379
       PLATOS_ENCRYPTION_KEY: ${PLATOS_ENCRYPTION_KEY}
       PLATOS_MESSAGE_ENCRYPTION_KEY: ${PLATOS_MESSAGE_ENCRYPTION_KEY}
@@ -100,7 +162,13 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
       OTEL_SERVICE_NAME: platos-agent
     ports: ["3100:3100"]
-    depends_on: [postgres, redis, webapp]
+    depends_on:
+      migrations-control:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+      webapp:
+        condition: service_started
     restart: always
     deploy:
       replicas: 2
@@ -124,7 +192,11 @@ TRIGGER_INTERNAL_SECRET=...  # any strong random string
 # DB
 POSTGRES_USER=platos
 POSTGRES_PASSWORD=<strong-random>
-DATABASE_URL=postgresql://platos:xxx@postgres:5432/platos
+POSTGRES_DB=platos_control
+POSTGRES_LEGACY_DB=platos_legacy
+DATABASE_URL=postgresql://platos:xxx@postgres:5432/platos_legacy
+DIRECT_URL=postgresql://platos:xxx@postgres:5432/platos_legacy
+PLATOS_CONTROL_DATABASE_URL=postgresql://platos:xxx@postgres:5432/platos_control
 
 # Redis
 REDIS_URL=redis://redis:6379
@@ -141,6 +213,12 @@ PLATOS_VERSION=0.5.2
 ```
 
 **Never** use `latest` in production; pin to a release tag for reproducible deploys.
+
+The dashboard split requires both `platos_legacy` and `platos_control` to exist
+before the webapp starts. The webapp uses the first for retained dashboard
+resources and the second for Platos auth/MFA/credentials; the agent uses only
+`platos_control`. The repository `docker-compose.platos.yml` creates and
+migrates both databases in the required order.
 
 ## First production boot
 
@@ -174,6 +252,11 @@ Plus the application config — most have safe defaults but a production deploy 
 | `NODE_ENV` | `production` |
 | `LOGIN_ORIGIN` | `https://your.host` |
 | `APP_ORIGIN` | `https://your.host` |
+| `POSTGRES_DB` | `platos_control` |
+| `POSTGRES_LEGACY_DB` | `platos_legacy` |
+| `DATABASE_URL` / `DIRECT_URL` (webapp) | legacy `platos_legacy` connection |
+| `PLATOS_CONTROL_DATABASE_URL` (webapp) | clean `platos_control` connection |
+| `DATABASE_URL` (agent) | clean `platos_control` connection |
 | `PLATOS_CORS_ORIGIN` | `https://your.host` (comma-separated for multiple) |
 | `MINIO_PUBLIC_ENDPOINT` | `https://minio.your.host` (see §3 below — **boot will fail without this**) |
 | `ANTHROPIC_API_KEY` (or other provider) | your key |
@@ -196,35 +279,30 @@ docker compose -f docker-compose.platos.yml up -d --no-deps \
 # Wait for healthchecks (~15-20s).
 docker compose -f docker-compose.platos.yml ps
 
-# 2. Webapp first (it bootstraps the worker token — see §4).
-docker compose -f docker-compose.platos.yml up -d --no-deps webapp
+# 2. Create/migrate both database graphs before webapp startup. The legacy
+#    initializer targets POSTGRES_LEGACY_DB; the clean initializer targets
+#    POSTGRES_DB. Do not point either initializer at the other database.
+docker compose -f docker-compose.platos.yml up \
+  migrations-init-legacy migrations-init clickhouse-migrate
 
-# 3. Run Postgres migrations from inside the webapp container. The
-#    `migrations-init` sidecar uses goose from ghcr.io which is sometimes
-#    rate-limited on first pull — running migrations via Prisma directly
-#    is more reliable and produces identical schema.
-PG_PWD=$(grep ^POSTGRES_PASSWORD .env | cut -d= -f2)
-docker exec -e DIRECT_URL="postgresql://postgres:${PG_PWD}@postgres:5432/postgres?schema=public" \
-  platos-webapp-1 \
-  /triggerdotdev/node_modules/.bin/prisma migrate deploy \
-  --schema /triggerdotdev/internal-packages/database/prisma/schema.prisma
+# 3. Start webapp after both migration jobs complete. It bootstraps the worker
+#    token on the retained legacy resource graph (see §4).
+docker compose -f docker-compose.platos.yml up -d webapp
 
-# 4. Restart webapp so its bootstrap routine sees the full schema +
-#    creates the `bootstrap` worker group (see §4).
-docker compose -f docker-compose.platos.yml restart webapp
-
-# 5. Capture the worker token from webapp logs (see §4).
+# 4. Capture the worker token from webapp logs (see §4).
 docker logs platos-webapp-1 2>&1 | grep TRIGGER_WORKER_TOKEN
 
 # Append the token to .env, then bring up agent + worker.
 echo "TRIGGER_WORKER_TOKEN=tr_wgt_..." >> .env
 docker compose -f docker-compose.platos.yml up -d --no-deps agent worker
 
-# 6. Verify all services healthy.
+# 5. Verify all services healthy.
 docker compose -f docker-compose.platos.yml ps
 ```
 
-If you used `up -d` once and Compose failed pulling `ghcr.io/pressly/goose:3` (registry denial), this is harmless — that's the optional ClickHouse-migrate sidecar we're skipping above. Run the migration manually via the agent container as shown.
+If an initializer fails, do not bypass it by repointing `DATABASE_URL` or
+`PLATOS_CONTROL_DATABASE_URL`. Resolve the image/database failure and rerun the
+same one-shot service so the legacy and clean graphs remain isolated.
 
 ### 3. MinIO needs a public-reachable endpoint
 

--- a/docs/self-hosting/env/webapp.mdx
+++ b/docs/self-hosting/env/webapp.mdx
@@ -20,8 +20,9 @@ mode: "wide"
 | `STREAM_ORIGIN`                                  | No       | `APP_ORIGIN`          | Realtime stream origin URL.                                                                                        |
 | `ELECTRIC_ORIGIN`                                | No       | http://localhost:3060 | Electric origin URL.                                                                                               |
 | **Postgres**                                     |          |                       |                                                                                                                    |
-| `DATABASE_URL`                                   | Yes      | —                     | PostgreSQL connection string.                                                                                      |
-| `DIRECT_URL`                                     | Yes      | —                     | Direct DB connection string used for migrations etc.                                                               |
+| `DATABASE_URL`                                   | Yes      | —                     | Legacy dashboard PostgreSQL connection string until the M4 resource cutover.                                       |
+| `DIRECT_URL`                                     | Yes      | —                     | Direct connection to the same legacy dashboard database as `DATABASE_URL`.                                         |
+| `PLATOS_CONTROL_DATABASE_URL`                    | Yes      | —                     | Distinct clean control database used for OperatorSession, canonical auth/MFA, and credentials. Never point it at the legacy dashboard database. |
 | `DATABASE_CONNECTION_LIMIT`                      | No       | 10                    | Max DB connections.                                                                                                |
 | `DATABASE_POOL_TIMEOUT`                          | No       | 60                    | DB pool timeout (s).                                                                                               |
 | `DATABASE_CONNECTION_TIMEOUT`                    | No       | 20                    | DB connect timeout (s).                                                                                            |

--- a/docs/upgrading-from-trigger.md
+++ b/docs/upgrading-from-trigger.md
@@ -65,6 +65,10 @@ services:
 services:
   webapp:
     image: ghcr.io/platos-dev/platos-webapp:latest
+    environment:
+      DATABASE_URL: ${DATABASE_URL} # retained legacy dashboard database
+      DIRECT_URL: ${DIRECT_URL}
+      PLATOS_CONTROL_DATABASE_URL: ${PLATOS_CONTROL_DATABASE_URL}
   agent:
     image: ghcr.io/platos-dev/platos-agent:latest
     ports: ["3100:3100"]
@@ -83,17 +87,23 @@ On boot, migrations run additively. Existing tables are unchanged. New tables ar
 
 ### Step 2 — Update `.env`
 
-Add the three required Platos env vars:
+Add the required Platos env vars, including a distinct clean control database:
 
 ```bash
 PLATOS_ENCRYPTION_KEY=$(openssl rand -hex 32)              # 64 hex chars = 32 bytes
 PLATOS_MESSAGE_ENCRYPTION_KEY=$(openssl rand -hex 32)      # distinct 64-hex value
 ANTHROPIC_API_KEY=sk-ant-...
+PLATOS_CONTROL_DATABASE_URL=postgresql://user:pass@postgres:5432/platos_control?schema=public
 ```
 
 > Generate new encryption-domain keys as 64 hex chars (32 bytes decoded), with a different value for every domain. Existing exact 32-byte UTF-8 `ENCRYPTION_KEY` values continue working verbatim and must not be replaced without re-encryption. See [env-vars.md](./env-vars.md#core).
 
-Nothing else changes. Your existing `SESSION_SECRET`, `ENCRYPTION_KEY`, `DATABASE_URL`, `REDIS_URL`, `TRIGGER_SECRET_KEY` keep working verbatim.
+Your existing `SESSION_SECRET`, `ENCRYPTION_KEY`, legacy dashboard
+`DATABASE_URL`/`DIRECT_URL`, `REDIS_URL`, and `TRIGGER_SECRET_KEY` keep working
+verbatim. Provision and migrate the clean database separately, point the agent's
+`DATABASE_URL` at it, and point only the webapp's
+`PLATOS_CONTROL_DATABASE_URL` at it. Do not globally repoint the webapp's legacy
+URLs before M4.
 
 ### Step 3 — (Optional) Rename SDK imports
 

--- a/internal-packages/tenancy-database/src/auth.integration.test.ts
+++ b/internal-packages/tenancy-database/src/auth.integration.test.ts
@@ -8,7 +8,7 @@ import {
   OrganizationRole,
   PrismaClient,
 } from "../generated/control";
-import { generateTotp, PlatosAuthError, PlatosAuthService } from "./auth";
+import { generateTotp, hashSecret, PlatosAuthError, PlatosAuthService } from "./auth";
 
 const encryptionKey = "0123456789abcdef0123456789abcdef";
 
@@ -205,6 +205,136 @@ describe("Platos-native auth integration", () => {
         recoveryCode: recoveryCodes[0],
       })
     ).rejects.toEqual(expectAuthError("invalid_mfa"));
+
+    await auth.disableTotpForSession({
+      sessionToken: recoverySession.token,
+      rateLimitIdentifier: "mfa-disable:127.0.0.1",
+      recoveryCode: recoveryCodes[1],
+    });
+    await expect(
+      database.operatorMfaTotp.findUnique({ where: { userId: user.id } })
+    ).resolves.toBeNull();
+    await expect(
+      database.operatorMfaRecoveryCode.count({ where: { userId: user.id } })
+    ).resolves.toBe(0);
+    await expect(auth.authorizeOperatorSession(recoverySession.token)).resolves.toMatchObject({
+      effectiveUserId: user.id,
+      mfaVerifiedAt: null,
+    });
+    await expect(auth.authorizeOperatorSession(totpSession.token)).rejects.toEqual(
+      expectAuthError("revoked")
+    );
+  });
+
+  test("does not disable MFA when concurrent revocation wins the session lock", async () => {
+    const user = await database.user.create({ data: { email: "mfa-revoke-race@example.test" } });
+    const enrollment = await auth.beginTotpEnrollment(user.id);
+    const { recoveryCodes } = await auth.confirmTotpEnrollment(
+      user.id,
+      generateTotp(enrollment.secret, now),
+      "mfa-revoke-race-enrollment"
+    );
+    const issued = await auth.issueOperatorSession({ userId: user.id });
+    const session = await database.operatorSession.findUniqueOrThrow({
+      where: { tokenHash: hashSecret(issued.token) },
+    });
+
+    let signalLocked!: () => void;
+    let releaseLock!: () => void;
+    const locked = new Promise<void>((resolve) => {
+      signalLocked = resolve;
+    });
+    const release = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+    const revocation = database.$transaction(async (tx) => {
+      await tx.$queryRaw`
+        SELECT "id"
+        FROM "OperatorSession"
+        WHERE "id" = ${session.id}::uuid
+        FOR UPDATE
+      `;
+      await tx.operatorSession.update({
+        where: { id: session.id },
+        data: { revokedAt: now },
+      });
+      signalLocked();
+      await release;
+    });
+
+    await locked;
+    const disable = auth.disableTotpForSession({
+      sessionToken: issued.token,
+      rateLimitIdentifier: "mfa-revoke-race-session",
+      recoveryCode: recoveryCodes[0],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    releaseLock();
+    await revocation;
+
+    await expect(disable).rejects.toEqual(expectAuthError("unauthorized"));
+    await expect(
+      database.operatorMfaTotp.findUnique({ where: { userId: user.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      database.operatorMfaRecoveryCode.count({
+        where: { userId: user.id, consumedAt: { not: null } },
+      })
+    ).resolves.toBe(0);
+  });
+
+  test("rolls back recovery consumption when the disable transition fails", async () => {
+    const user = await database.user.create({ data: { email: "mfa-disable-rollback@example.test" } });
+    const enrollment = await auth.beginTotpEnrollment(user.id);
+    const { recoveryCodes } = await auth.confirmTotpEnrollment(
+      user.id,
+      generateTotp(enrollment.secret, now),
+      "mfa-disable-rollback-enrollment"
+    );
+    const issued = await auth.issueOperatorSession({ userId: user.id });
+
+    await database.$executeRawUnsafe(`
+      CREATE FUNCTION fail_mfa_factor_delete() RETURNS trigger AS $$
+      BEGIN
+        RAISE EXCEPTION 'forced MFA factor deletion failure';
+      END;
+      $$ LANGUAGE plpgsql
+    `);
+    await database.$executeRawUnsafe(`
+      CREATE TRIGGER fail_mfa_factor_delete
+      BEFORE DELETE ON "OperatorMfaTotp"
+      FOR EACH ROW EXECUTE FUNCTION fail_mfa_factor_delete()
+    `);
+    try {
+      await expect(
+        auth.disableTotpForSession({
+          sessionToken: issued.token,
+          rateLimitIdentifier: "mfa-disable-rollback-session",
+          recoveryCode: recoveryCodes[0],
+        })
+      ).rejects.toThrow("forced MFA factor deletion failure");
+    } finally {
+      await database.$executeRawUnsafe(
+        `DROP TRIGGER IF EXISTS fail_mfa_factor_delete ON "OperatorMfaTotp"`
+      );
+      await database.$executeRawUnsafe(`DROP FUNCTION IF EXISTS fail_mfa_factor_delete()`);
+    }
+
+    await expect(
+      database.operatorMfaTotp.findUnique({ where: { userId: user.id } })
+    ).resolves.not.toBeNull();
+    await expect(
+      database.operatorMfaRecoveryCode.count({
+        where: { userId: user.id, consumedAt: { not: null } },
+      })
+    ).resolves.toBe(0);
+    await expect(
+      auth.disableTotpForSession({
+        sessionToken: issued.token,
+        rateLimitIdentifier: "mfa-disable-rollback-session",
+        recoveryCode: recoveryCodes[0],
+      })
+    ).resolves.toBeUndefined();
   });
 
   test("keeps active MFA usable during re-enrollment and rate limits online verification", async () => {

--- a/internal-packages/tenancy-database/src/auth.ts
+++ b/internal-packages/tenancy-database/src/auth.ts
@@ -591,11 +591,61 @@ export class PlatosAuthService {
     totpCode?: string;
     recoveryCode?: string;
   }): Promise<void> {
-    const session = await this.#database.operatorSession.findUnique({
-      where: { tokenHash: hashSecret(params.sessionToken) },
-      include: { user: { include: { mfaTotp: true } } },
-    });
     const now = this.#now();
+    await this.#database.$transaction(async (tx) => {
+      const session = await this.#verifyMfaForActiveSession(tx, params, now);
+      await tx.operatorSession.update({
+        where: { id: session.id },
+        data: { mfaVerifiedAt: now },
+      });
+    });
+  }
+
+  async disableTotpForSession(params: {
+    sessionToken: string;
+    rateLimitIdentifier: string;
+    totpCode?: string;
+    recoveryCode?: string;
+  }): Promise<void> {
+    const now = this.#now();
+    await this.#database.$transaction(async (tx) => {
+      const session = await this.#verifyMfaForActiveSession(tx, params, now);
+      await tx.operatorMfaRecoveryCode.deleteMany({ where: { userId: session.userId } });
+      await tx.operatorMfaTotp.delete({ where: { userId: session.userId } });
+      await tx.operatorSession.updateMany({
+        where: { userId: session.userId, id: { not: session.id }, revokedAt: null },
+        data: { revokedAt: now },
+      });
+      await tx.operatorSession.update({
+        where: { id: session.id },
+        data: { mfaVerifiedAt: null },
+      });
+    });
+  }
+
+  async #verifyMfaForActiveSession(
+    database: Prisma.TransactionClient,
+    params: {
+      sessionToken: string;
+      rateLimitIdentifier: string;
+      totpCode?: string;
+      recoveryCode?: string;
+    },
+    now: Date
+  ): Promise<{ id: string; userId: string }> {
+    const tokenHash = hashSecret(params.sessionToken);
+    const lockedSession = await database.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "OperatorSession"
+      WHERE "tokenHash" = ${tokenHash}
+      FOR UPDATE
+    `;
+    if (lockedSession.length !== 1) throw unauthorized();
+
+    const session = await database.operatorSession.findUnique({
+      where: { id: lockedSession[0].id },
+      include: { user: true },
+    });
     if (
       !session ||
       session.user.disabledAt ||
@@ -604,22 +654,27 @@ export class PlatosAuthService {
     ) {
       throw unauthorized();
     }
-    const credential = session.user.mfaTotp;
+
+    await database.$queryRaw<Array<{ id: string }>>`
+      SELECT "id"
+      FROM "OperatorMfaTotp"
+      WHERE "userId" = ${session.userId}::uuid
+      FOR UPDATE
+    `;
+    const credential = await database.operatorMfaTotp.findUnique({
+      where: { userId: session.userId },
+    });
     if (!credential?.enabledAt || !credential.encryptedSecret) {
       throw new PlatosAuthError("invalid_mfa", 401, "Invalid authentication code");
     }
-    await this.#consumeRateLimit(
-      AuthRateLimitAction.MFA_VERIFY,
-      `session:${session.userId}:${params.rateLimitIdentifier}`,
-      this.#mfaVerifyRateLimit
-    );
+    await this.#consumeMfaRateLimit(params.rateLimitIdentifier);
 
     let verified = false;
     if (params.totpCode) {
       const secret = decryptSecret(credential.encryptedSecret, this.#encryptionKey);
       const counter = verifyTotp(secret, params.totpCode, now);
       if (counter !== null) {
-        const updated = await this.#database.operatorMfaTotp.updateMany({
+        const updated = await database.operatorMfaTotp.updateMany({
           where: {
             id: credential.id,
             OR: [{ lastUsedCounter: null }, { lastUsedCounter: { lt: counter } }],
@@ -629,7 +684,7 @@ export class PlatosAuthService {
         verified = updated.count === 1;
       }
     } else if (params.recoveryCode) {
-      const consumed = await this.#database.operatorMfaRecoveryCode.updateMany({
+      const consumed = await database.operatorMfaRecoveryCode.updateMany({
         where: {
           userId: session.userId,
           codeHash: hashSecret(normalizeRecoveryCode(params.recoveryCode)),
@@ -641,10 +696,15 @@ export class PlatosAuthService {
     }
     if (!verified) throw new PlatosAuthError("invalid_mfa", 401, "Invalid authentication code");
 
-    await this.#database.operatorSession.update({
-      where: { id: session.id },
-      data: { mfaVerifiedAt: now },
-    });
+    return { id: session.id, userId: session.userId };
+  }
+
+  async #consumeMfaRateLimit(rateLimitIdentifier: string): Promise<void> {
+    await this.#consumeRateLimit(
+      AuthRateLimitAction.MFA_VERIFY,
+      `session:${rateLimitIdentifier}`,
+      this.#mfaVerifyRateLimit
+    );
   }
 
   async issueInvitation(params: {


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
## Summary

Moves dashboard browser login, session validation, MFA, and logout to Platos-owned opaque `OperatorSession` records while preserving the deliberately split deployment: dashboard resources remain on the legacy database and clean auth/credentials use the clean control database.

The temporary compatibility boundary is deliberately narrow. A validated canonical operator is bridged to one legacy dashboard principal by verified email using trim + case folding only. Canonical UUIDs and legacy CUIDs are separately branded, absence or ambiguity fails closed, and the bridge never writes/backfills or infers organization/project/environment IDs. Removal during M4 is tracked by [WIN-217](https://linear.app/winsen-labs/issue/WIN-217/m4-remove-temporary-dashboard-auth-identity-bridge).

## Changes

- Adds mandatory `PLATOS_CONTROL_DATABASE_URL`; keeps webapp `DATABASE_URL` / `DIRECT_URL` on `platos_legacy` and agent/control storage on `platos_control`.
- Idempotently creates and migrates both databases for existing Compose volumes and documents the split for self-hosted upgrades.
- Issues and validates opaque Platos session cookies for magic-link, GitHub, and Google completion.
- Moves login MFA, enrollment, recovery, disable, replay prevention, and logout revocation to `PlatosAuthService`.
- Makes MFA disable an atomic verified state transition under row locks.
- Uses server-controlled rate-limit identities: normalized email for initial login and a domain-prefixed SHA-256 session-token digest for MFA/session operations; caller-supplied forwarding headers are ignored.
- Isolates transient OAuth state in a short-lived cookie and clears stale legacy impersonation state on every successful login/logout.
- Preserves legacy impersonation only for legacy resource resolution and audit, with separately typed canonical/legacy actor and effective identities.
- Authorizes provider credentials with the real canonical session and clean environment ancestry instead of synthetic legacy IDs.
- Maps canonical credential role denials to generic HTTP 403 responses.
- Keeps legacy invitation and membership routes on legacy IDs until their M4 clean-native route cutover; no cross-database mapping or data migration is added.
- Refreshed post-rebase schema pins: 81 control models / 65 domain models.
- Refreshed generated control-plane artifacts: unchanged at 206 MCP tools / 285 REST operations.

## Testing

- PASS — full tenancy database suite with disposable pgvector PostgreSQL fixtures, 9 files / 68 tests:
  `pnpm --filter @platos/tenancy-database test`
- PASS — tenancy typecheck:
  `pnpm --filter @platos/tenancy-database typecheck`
- PASS — executable focused dashboard auth suite, 5 files / 39 tests:
  `pnpm exec vitest run test/dashboardIdentity.test.ts test/dashboardAuthBoundary.test.ts test/dashboardAuthRateLimit.test.ts test/dashboardAuthRoutes.test.ts test/registryConfig.test.ts`
- PASS — additional focused auth/security suite, 43 tests, including stale impersonation cleanup and rate-limit identity handling.
- PASS — production webapp build:
  `pnpm run build:components`
- PASS — Docker Compose configuration validation with distinct `platos_control` / `platos_legacy` fixture values.
- PASS — generated control-plane drift check:
  `pnpm --filter platos-agent generate:control-plane`
- PASS — `git diff --check`.
- PASS — disposable two-database runtime fixture: no/bad/revoked/MFA-required sessions; absent/ambiguous/exact bridge; canonical credential authorization; magic success/replay; MFA redirect/TOTP/recovery; logout revocation and cookie destruction.
- PASS — public login preview HTTP 200 with rendered app and no browser console/page errors:
  https://pe2sm3a65xux.preview.us1.vorflux.com/login
- Visual evidence:
- PARTIAL — live third-party GitHub/Google provider handshakes were not executed because disposable OAuth client credentials are not configured. Provider identity behavior and callback/cookie branches are covered by tenancy integration and executable route tests; no production OAuth credentials were used.
- The repository-wide webapp typecheck remains blocked before source checking by unchanged baseline `TS5103: Invalid value for '--ignoreDeprecations'`. Production build and focused changed-file validation passed.
- No production, `test.platos`, or `play.platos` database was accessed or modified.

---
**Attached Images and Videos**

![win157-final-login.png](https://api.us1.vorflux.com/assets/artifacts/OGI2OThmNDEtOGRmYS01NzVlLWE2MDItYmNmMjVlZjY1M2NiOmY6ODk3.ktRvmskWEyAsO1CbOyP0x7tEY1sphsvt0cj1Sto6WT4.png)

![win157-login-mfa.png](https://api.us1.vorflux.com/assets/artifacts/OGI2OThmNDEtOGRmYS01NzVlLWE2MDItYmNmMjVlZjY1M2NiOmY6ODk4.hfTgVXzupSgm4zsMtIV4kRrgJkLpkADS5eNUX-3scK4.png)

🎥 [View recording: win157-magic-to-mfa.webm](https://api.us1.vorflux.com/assets/artifacts/OGI2OThmNDEtOGRmYS01NzVlLWE2MDItYmNmMjVlZjY1M2NiOmY6ODk5.4ulPVUJcsSXc1iGfxJUZiX_r44wYgyVUiBXXKBzr_bA.mp4)

![win157-mfa-recovery.png](https://api.us1.vorflux.com/assets/artifacts/OGI2OThmNDEtOGRmYS01NzVlLWE2MDItYmNmMjVlZjY1M2NiOmY6OTAw.fMci2pLhVBmS1-guZngrQpK58VIS_5GKHQk-erwK5uk.png)

🎥 [View recording: win157-mfa-recovery-state.webm](https://api.us1.vorflux.com/assets/artifacts/OGI2OThmNDEtOGRmYS01NzVlLWE2MDItYmNmMjVlZjY1M2NiOmY6OTAx.HI0DOnpwyIV8s2w96H_IJsc8MxmxtJ5hsBjHBv0GGAo.mp4)
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
