### PR TITLE
fix(agent): replace stale clean Prisma delegates

### DIFF
--- a/apps/agent/src/admin/admin-canonical-tenancy.test.ts
+++ b/apps/agent/src/admin/admin-canonical-tenancy.test.ts
@@ -14,7 +14,7 @@ function organizationService(prisma: Record<string, unknown>) {
 }
 
 function environmentService(prisma: Record<string, unknown>) {
-  return new EnvironmentService(prisma, { invalidate: vi.fn() } as any);
+  return new EnvironmentService(prisma as unknown as ControlDatabaseClient);
 }
 
 describe("admin canonical organization tenancy", () => {

--- a/apps/agent/src/admin/admin.module.ts
+++ b/apps/agent/src/admin/admin.module.ts
@@ -1,22 +1,19 @@
 import { Module } from "@nestjs/common";
 import { OrganizationService } from "./organization.service";
 import { EnvironmentService } from "./environment.service";
-import { ProvidersModule } from "../providers/providers.module";
 
 /**
  * Theme MCPF-W6 — Admin module.
  *
- * Bundles two services for org/env/secret management:
+ * Bundles two services for organization and Environment management:
  *   - `OrganizationService` — list/get/update orgs + member CRUD.
- *   - `EnvironmentService`  — list/create/delete RuntimeEnvironment +
- *                              SecretStore name/value CRUD.
+ *   - `EnvironmentService`  — list/create/delete canonical Environments;
+ *                              credential management is paused for WIN-124.
  *
- * Both consume the shared Prisma client + (in EnvironmentService's case)
- * `ScopedEnvService` for cache invalidation. Re-exports the services so
- * `McpPlatformModule` can wire them into `buildPlatformToolHandlers`.
+ * Both consume the shared canonical Prisma client. Re-exports the services
+ * so `McpPlatformModule` can wire them into `buildPlatformToolHandlers`.
  */
 @Module({
-  imports: [ProvidersModule],
   providers: [OrganizationService, EnvironmentService],
   exports: [OrganizationService, EnvironmentService],
 })

--- a/apps/agent/src/admin/environment.service.ts
+++ b/apps/agent/src/admin/environment.service.ts
@@ -1,99 +1,34 @@
 import { Injectable, Inject } from "@nestjs/common";
-import { createCipheriv, randomBytes } from "node:crypto";
-import { PRISMA_TOKEN } from "../shared/database.provider";
-import { env } from "../shared/env";
+import {
+  PRISMA_TOKEN,
+  type ControlDatabaseClient,
+} from "../shared/database.provider";
 import type { RequestScope } from "../auth/scope.guard";
-import { ScopedEnvService } from "../providers/scoped-env.service";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
 
-const FRIENDLY_ID_ALPHABET = "123456789abcdefghijkmnopqrstuvwxyz";
-
 /**
- * Mirror of `generateFriendlyId("envvar")` (`@trigger.dev/core/isomorphic`).
- * Produces `envvar_<21-char nanoid>` so MCP-written EnvironmentVariable
- * rows match the format the webapp UI uses for keying friendly IDs.
- */
-function envvarFriendlyId(): string {
-  const buf = randomBytes(21);
-  let id = "";
-  for (let i = 0; i < 21; i++) {
-    id += FRIENDLY_ID_ALPHABET[(buf[i] ?? 0) % FRIENDLY_ID_ALPHABET.length];
-  }
-  return `envvar_${id}`;
-}
-
-/**
- * Theme MCPF-W6 — RuntimeEnvironment + secret management service.
+ * Theme MCPF-W6 — Environment management service.
  *
- * Wraps `RuntimeEnvironment` (trigger.dev's per-project env model) +
- * `SecretStore` (the AES-256-GCM-encrypted key/value table that backs
- * scoped env vars). Used by the MCP `environments.*` tools.
+ * Environment credential management remains unavailable until WIN-124 moves
+ * those operations onto the canonical Environment-owned credential store.
  *
  * Three architectural rules baked in:
  *   1. **Cross-tenant scope filtering** — every read scopes by
  *      `(organizationId, projectId)`. Caller must be a member of the
  *      org via OrgMember.
- *   2. **Owner-gated mutations** — create/delete env + secret writes
- *      require `OrgMember.role = ADMIN`.
- *   3. **Secrets never leak through MCP** — `listSecrets` returns NAMES
- *      ONLY. Audit logs record names but never values. `setSecret`
- *      reuses the webapp `encryptSecret` AES-256-GCM format so existing
- *      SecretStore rows remain decryptable by either side.
+ *   2. **Owner-gated mutations** — create/delete Environment writes require
+ *      an Organization ADMIN or OWNER role.
+ *   3. **Secrets never leak through MCP** — credential methods fail with a
+ *      stable error before reading, writing, logging, or auditing plaintext.
  */
 
 const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,30}$/;
-
-interface EncryptedValue {
-  nonce: string;
-  ciphertext: string;
-  tag: string;
-}
-
-function encryptValue(plaintext: string): EncryptedValue {
-  const raw = env.ENCRYPTION_KEY;
-  if (!raw) throw new Error("encryption_key_not_set");
-  let key: Buffer;
-  if (raw.length === 64 && /^[0-9a-f]{64}$/i.test(raw)) {
-    key = Buffer.from(raw, "hex");
-  } else if (Buffer.from(raw, "utf8").length === 32) {
-    key = Buffer.from(raw, "utf8");
-  } else {
-    throw new Error("encryption_key_invalid_length");
-  }
-  const nonce = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, nonce);
-  let encrypted = cipher.update(plaintext, "utf8", "hex");
-  encrypted += cipher.final("hex");
-  const tag = cipher.getAuthTag().toString("hex");
-  return {
-    nonce: nonce.toString("hex"),
-    ciphertext: encrypted,
-    tag,
-  };
-}
-
-const ALPHABET = "123456789abcdefghijkmnopqrstuvwxyz";
-
-function randomAlphaNumId(length: number): string {
-  const buf = randomBytes(length);
-  let out = "";
-  for (let i = 0; i < length; i++) {
-    out += ALPHABET[(buf[i] ?? 0) % ALPHABET.length];
-  }
-  return out;
-}
-
-function shortcode(): string {
-  return randomAlphaNumId(12);
-}
+const ENVIRONMENT_CREDENTIALS_UNAVAILABLE = "environment_credentials_unavailable";
 
 @Injectable()
 export class EnvironmentService {
-  constructor(
-    @Inject(PRISMA_TOKEN) private readonly prisma: any,
-    private readonly scopedEnv: ScopedEnvService,
-  ) {}
+  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
 
   /**
    * List runtime environments visible inside the caller's project scope.
@@ -122,9 +57,8 @@ export class EnvironmentService {
   }
 
   /**
-   * Create a new RuntimeEnvironment in the caller's project. Owner-gated.
-   * Validates slug format. Mints fresh apiKey + pkApiKey (Trigger.dev
-   * convention) so the env is immediately addressable.
+   * Create a new Environment in the caller's project. Owner-gated.
+   * Validates slug format.
    *
    * Note: this is a power-user surface. Most operators should use the
    * webapp UI which also wires up the dev sentinel + member binding.
@@ -173,8 +107,8 @@ export class EnvironmentService {
   }
 
   /**
-   * Delete (archive) a RuntimeEnvironment. Owner-gated. Refuses when
-   * any PlatosAgent or PlatosAgentThread references the env (would
+   * Delete (archive) an Environment. Owner-gated. Refuses when
+   * any active AgentBinding or Thread references the Environment (would
    * break running agents). Soft-deletes by setting `archivedAt = now()`
    * — same semantic the webapp uses.
    */
@@ -227,270 +161,24 @@ export class EnvironmentService {
     return { archived: true };
   }
 
-  /**
-   * List secret NAMES only (NEVER values) for the caller's scope.
-   * Backs `environments.list_secrets`.
-   *
-   * MCPF-W6 followup — query through `EnvironmentVariable` +
-   * `EnvironmentVariableValue` (the webapp UI's source of truth) instead
-   * of the raw `SecretStore` table, so MCP-written secrets and UI-written
-   * secrets show up consistently. Falls back to `SecretStore` for any
-   * orphan rows (e.g. legacy entries written before this followup).
-   */
-  async listSecrets(scope: ScopeTuple, userId: string | null) {
-    await this.requireMember(scope.organizationId, userId);
-
-    // 1) Canonical: EnvironmentVariable join (matches the dashboard list).
-    const variables = await this.prisma.environmentVariable.findMany({
-      where: {
-        project: { id: scope.projectId, organizationId: scope.organizationId },
-        values: { some: { environmentId: scope.environmentId } },
-      },
-      select: {
-        key: true,
-        createdAt: true,
-        updatedAt: true,
-        values: {
-          where: { environmentId: scope.environmentId },
-          select: { isSecret: true, version: true, updatedAt: true },
-        },
-      },
-      orderBy: { key: "asc" },
-    });
-
-    const seen = new Set<string>();
-    const out: Array<{
-      name: string;
-      version: string;
-      createdAt: Date;
-      updatedAt: Date;
-      isSecret: boolean;
-    }> = [];
-    for (const v of variables as Array<{
-      key: string;
-      createdAt: Date;
-      updatedAt: Date;
-      values: Array<{ isSecret: boolean; version: number; updatedAt: Date }>;
-    }>) {
-      const value = v.values[0];
-      if (!value) continue;
-      seen.add(v.key);
-      out.push({
-        name: v.key,
-        version: String(value.version),
-        createdAt: v.createdAt,
-        updatedAt: value.updatedAt ?? v.updatedAt,
-        isSecret: !!value.isSecret,
-      });
-    }
-
-    // 2) Fallback: legacy SecretStore-only rows (no EnvironmentVariable
-    //    twin). Pre-followup MCP `setSecret` calls landed here, plus any
-    //    out-of-band CLI writes. Surface them so operators can see + delete
-    //    them via MCP, even though the UI won't list them until rewritten.
-    const prefix = `environmentvariable:${scope.projectId}:${scope.environmentId}:`;
-    const rows = await this.prisma.secretStore.findMany({
-      where: { key: { startsWith: prefix } },
-      select: { key: true, version: true, createdAt: true, updatedAt: true },
-      orderBy: { key: "asc" },
-    });
-    for (const r of rows as Array<{
-      key: string;
-      version: string;
-      createdAt: Date;
-      updatedAt: Date;
-    }>) {
-      const name = r.key.slice(prefix.length);
-      if (seen.has(name)) continue;
-      out.push({
-        name,
-        version: r.version,
-        createdAt: r.createdAt,
-        updatedAt: r.updatedAt,
-        isSecret: true,
-      });
-    }
-
-    out.sort((a, b) => a.name.localeCompare(b.name));
-    return out;
+  async listSecrets(_scope: ScopeTuple, _userId: string | null): Promise<never> {
+    throw new Error(ENVIRONMENT_CREDENTIALS_UNAVAILABLE);
   }
 
-  /**
-   * Set / update a secret. Owner-gated. The plaintext is encrypted
-   * with the webapp-shared `ENCRYPTION_KEY` so the existing scoped-env
-   * resolver picks it up instantly.
-   *
-   * This method NEVER returns the value. The MCP tool wrapper audits
-   * the NAME only.
-   *
-   * MCPF-W6 followup — also writes the `EnvironmentVariable` +
-   * `SecretReference` + `EnvironmentVariableValue` triple that the webapp
-   * UI lists from. Without this triple, MCP-set secrets are usable by
-   * the agent (which only reads SecretStore) but invisible in the
-   * dashboard. Mirrors the webapp's
-   * `EnvironmentVariablesRepository.create` transactional pattern.
-   */
   async setSecret(
-    scope: ScopeTuple,
-    userId: string | null,
-    opts: { name: string; value: string },
-  ): Promise<{ ok: true; name: string }> {
-    await this.requireAdmin(scope.organizationId, userId);
-    const name = (opts.name || "").trim();
-    if (!name || !/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
-      throw new Error("name_invalid");
-    }
-    if (typeof opts.value !== "string" || opts.value.length === 0) {
-      throw new Error("value_required");
-    }
-    if (opts.value.length > 8192) {
-      throw new Error("value_too_long");
-    }
-    // Match webapp `setSecret` shape: { secret: string } as the
-    // JSON payload, then AES-256-GCM encrypt with shared key.
-    const encrypted = encryptValue(JSON.stringify({ secret: opts.value }));
-    const storeKey = `environmentvariable:${scope.projectId}:${scope.environmentId}:${name}`;
-
-    // Single transaction so the SecretStore row + EnvironmentVariable
-    // join rows are always in sync. If any branch throws, no half-state.
-    await this.prisma.$transaction(async (tx: any) => {
-      // 1) SecretStore — the actual ciphertext the agent decrypts on read.
-      await tx.secretStore.upsert({
-        where: { key: storeKey },
-        create: { key: storeKey, value: encrypted, version: "2" },
-        update: { value: encrypted, version: "2" },
-      });
-
-      // 2) SecretReference — the dashboard's join target. Webapp uses
-      //    `provider: "DATABASE"` for SecretStore-backed values.
-      const secretReference = await tx.secretReference.upsert({
-        where: { key: storeKey },
-        create: { key: storeKey, provider: "DATABASE" },
-        update: {},
-      });
-
-      // 3) EnvironmentVariable — keyed by (projectId, key). Friendly ID
-      //    follows the webapp's `envvar_<nanoid>` convention.
-      const envVar = await tx.environmentVariable.upsert({
-        where: { projectId_key: { projectId: scope.projectId, key: name } },
-        create: {
-          key: name,
-          friendlyId: envvarFriendlyId(),
-          project: { connect: { id: scope.projectId } },
-        },
-        update: {},
-      });
-
-      // 4) EnvironmentVariableValue — per-environment join row. Bumps
-      //    `version` on update so the UI shows the value rotated.
-      const existing = await tx.environmentVariableValue.findFirst({
-        where: { variableId: envVar.id, environmentId: scope.environmentId },
-        select: { id: true, version: true },
-      });
-      if (existing) {
-        await tx.environmentVariableValue.update({
-          where: { id: existing.id },
-          data: {
-            valueReferenceId: secretReference.id,
-            version: { increment: 1 },
-            isSecret: true,
-          },
-        });
-      } else {
-        await tx.environmentVariableValue.create({
-          data: {
-            variableId: envVar.id,
-            environmentId: scope.environmentId,
-            valueReferenceId: secretReference.id,
-            version: 1,
-            isSecret: true,
-          },
-        });
-      }
-    });
-
-    // Invalidate the agent's in-memory ScopedEnvService cache so the
-    // new value is read on the next provider call (otherwise the
-    // 30-second TTL would delay propagation).
-    this.scopedEnv.invalidate(scope, name);
-    return { ok: true, name };
+    _scope: ScopeTuple,
+    _userId: string | null,
+    _opts: { name: string; value: string },
+  ): Promise<never> {
+    throw new Error(ENVIRONMENT_CREDENTIALS_UNAVAILABLE);
   }
 
-  /**
-   * Delete a secret. Owner-gated. Idempotent — already-missing rows
-   * return `{ deleted: false }` instead of throwing.
-   *
-   * MCPF-W6 followup — also cascades through the
-   * `EnvironmentVariableValue` → `SecretReference` → `EnvironmentVariable`
-   * join chain so the UI no longer shows the deleted secret. Mirrors the
-   * webapp's `deleteValue` (drops the per-env row first, the variable
-   * itself only when this was its last value).
-   */
   async deleteSecret(
-    scope: ScopeTuple,
-    userId: string | null,
-    opts: { name: string },
-  ): Promise<{ deleted: boolean; name: string }> {
-    await this.requireAdmin(scope.organizationId, userId);
-    const name = (opts.name || "").trim();
-    if (!name || !/^[A-Z][A-Z0-9_]{0,63}$/.test(name)) {
-      throw new Error("name_invalid");
-    }
-    const storeKey = `environmentvariable:${scope.projectId}:${scope.environmentId}:${name}`;
-
-    let anyDeleted = false;
-    await this.prisma.$transaction(async (tx: any) => {
-      // 1) Drop the SecretStore ciphertext row.
-      const ssResult = await tx.secretStore.deleteMany({ where: { key: storeKey } });
-      if (ssResult.count > 0) anyDeleted = true;
-
-      // 2) Find the EnvironmentVariable + per-env value within the scope.
-      const envVar = await tx.environmentVariable.findFirst({
-        where: {
-          key: name,
-          project: { id: scope.projectId, organizationId: scope.organizationId },
-        },
-        select: {
-          id: true,
-          values: {
-            select: { id: true, environmentId: true, valueReferenceId: true },
-          },
-        },
-      });
-      if (!envVar) return;
-
-      const value = envVar.values.find(
-        (v: { environmentId: string }) => v.environmentId === scope.environmentId,
-      );
-      if (value) {
-        anyDeleted = true;
-        // Drop the per-env value first.
-        await tx.environmentVariableValue.delete({ where: { id: value.id } });
-        // Drop the SecretReference (no other env should be sharing it
-        // since `key` is the scope-specific store key).
-        if (value.valueReferenceId) {
-          await tx.secretReference.deleteMany({
-            where: { id: value.valueReferenceId },
-          });
-        }
-      }
-
-      // 3) If this was the last value across any env, drop the
-      //    EnvironmentVariable row too. Matches the webapp's "delete
-      //    last value also drops the variable" semantic so the
-      //    dashboard doesn't show an orphan no-value row.
-      const remaining = await tx.environmentVariableValue.count({
-        where: { variableId: envVar.id },
-      });
-      if (remaining === 0) {
-        await tx.environmentVariable.delete({ where: { id: envVar.id } });
-      }
-    });
-
-    // Invalidate the cache regardless — even if the row didn't exist
-    // here, the cache layer might be holding a stale positive lookup.
-    this.scopedEnv.invalidate(scope, name);
-    return { deleted: anyDeleted, name };
+    _scope: ScopeTuple,
+    _userId: string | null,
+    _opts: { name: string },
+  ): Promise<never> {
+    throw new Error(ENVIRONMENT_CREDENTIALS_UNAVAILABLE);
   }
 
   // ── Authz helpers ─────────────────────────────────────────────────

--- a/apps/agent/src/agent-runtime/agent-crud-version-skills.test.ts
+++ b/apps/agent/src/agent-runtime/agent-crud-version-skills.test.ts
@@ -93,6 +93,7 @@ function makeHarness(options: { cloneError?: Error; targetVersion?: ReturnType<t
         : vi.fn().mockResolvedValue({ count: assignedSkills.length }),
     },
     agentBinding: { update: vi.fn().mockResolvedValue({}) },
+    adminAudit: { create: vi.fn().mockResolvedValue({}) },
   };
   const findBinding = vi.fn().mockResolvedValue(binding);
   const prisma = {
@@ -176,6 +177,53 @@ describe("AgentCrudService AgentSkill version rollover", () => {
     expect(h.tx.agentVersion.create).toHaveBeenCalledOnce();
     expect(h.tx.agentSkill.createMany).toHaveBeenCalledOnce();
     expect(h.tx.agentBinding.update).not.toHaveBeenCalled();
+    expect(h.redis.del).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentCrudService canary promotion audit", () => {
+  it("writes the binding promotion and immutable audit in one transaction", async () => {
+    const h = makeHarness();
+    vi.spyOn(h.service, "findById").mockResolvedValue({ id: "agent-a" } as any);
+
+    await h.service.promoteCanary("agent-a", scope);
+
+    expect(h.tx.agentBinding.update).toHaveBeenCalledWith({
+      where: { id: "binding-a" },
+      data: {
+        activeAgentVersionId: "version-canary",
+        canaryAgentVersionId: null,
+        canaryPercent: 0,
+      },
+    });
+    expect(h.tx.adminAudit.create).toHaveBeenCalledWith({
+      data: {
+        environmentId: "env-a",
+        actorUserId: "user-a",
+        action: "agent.canary.promote",
+        subjectType: "Agent",
+        subjectId: "agent-a",
+        before: {
+          previousCurrentVersionId: "version-current",
+          previousCanaryVersionId: "version-canary",
+          previousCanaryPercent: 25,
+        },
+        after: { currentVersionId: "version-canary" },
+        source: "api",
+      },
+    });
+    expect(h.tx.agentBinding.update.mock.invocationCallOrder[0]).toBeLessThan(
+      h.tx.adminAudit.create.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("fails promotion without cache invalidation when the audit insert fails", async () => {
+    const h = makeHarness();
+    h.tx.adminAudit.create.mockRejectedValueOnce(new Error("audit unavailable"));
+
+    await expect(h.service.promoteCanary("agent-a", scope)).rejects.toThrow("audit unavailable");
+
+    expect(h.tx.agentBinding.update).toHaveBeenCalledOnce();
     expect(h.redis.del).not.toHaveBeenCalled();
   });
 });

--- a/apps/agent/src/agent-runtime/agent-crud.service.ts
+++ b/apps/agent/src/agent-runtime/agent-crud.service.ts
@@ -1041,27 +1041,33 @@ export class AgentCrudService {
     if (!binding) throw new Error("Agent not found");
     if (!binding.canaryAgentVersionId) throw new Error("No canary to promote — canaryVersionId is null");
     const canaryId = binding.canaryAgentVersionId;
-    await this.prisma.agentBinding.update({
-      where: { id: binding.id },
-      data: {
-        activeAgentVersionId: canaryId,
-        canaryAgentVersionId: null,
-        canaryPercent: 0,
-      },
+    await this.prisma.$transaction(async (tx: any) => {
+      await tx.agentBinding.update({
+        where: { id: binding.id },
+        data: {
+          activeAgentVersionId: canaryId,
+          canaryAgentVersionId: null,
+          canaryPercent: 0,
+        },
+      });
+      await tx.adminAudit.create({
+        data: {
+          environmentId: scope.environmentId,
+          actorUserId: scope.userId ?? null,
+          action: "agent.canary.promote",
+          subjectType: "Agent",
+          subjectId: agentId,
+          before: {
+            previousCurrentVersionId: binding.activeAgentVersionId,
+            previousCanaryVersionId: canaryId,
+            previousCanaryPercent: binding.canaryPercent,
+          },
+          after: { currentVersionId: canaryId },
+          source: "api",
+        },
+      });
     });
     await this.invalidate(agentId, scope);
-    this.adminAudit?.record(scope, {
-      action: "agent.canary.promote",
-      subjectType: "Agent",
-      subjectId: agentId,
-      beforeJson: {
-        previousCurrentVersionId: binding.activeAgentVersionId,
-        previousCanaryVersionId: canaryId,
-        previousCanaryPercent: binding.canaryPercent,
-      },
-      afterJson: { currentVersionId: canaryId },
-      source: "api",
-    });
     return (await this.findById(agentId, scope))!;
   }
 

--- a/apps/agent/src/agent-runtime/agent.controller.entity.test.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.entity.test.ts
@@ -51,6 +51,7 @@ describe("AgentController clean Entity transport routes", () => {
         environmentId: scope.environmentId,
         entityId: "support-core",
       }),
+      scope
     );
     expect(result.plaintextSecret).toBe("shown-once");
   });
@@ -123,6 +124,33 @@ describe("AgentController clean Entity transport routes", () => {
       bearerTokenCount: 2,
       consentCopy: null,
       exists: true,
+    });
+  });
+
+  it("rejects legacy linked-agent and test-credential mutations", async () => {
+    const h = harness();
+
+    await expect(
+      h.controller.patchEntity(h.req, "support-core", { linkedAgentIds: ["agent-1"] })
+    ).rejects.toMatchObject({ status: 501 });
+    await expect(
+      h.controller.patchEntity(h.req, "support-core", {
+        testCredentials: { headers: [{ name: "Authorization", value: "sentinel" }] },
+      })
+    ).rejects.toMatchObject({ status: 501 });
+  });
+
+  it("returns a stable unsupported response for legacy test-credential reads", async () => {
+    const h = harness();
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+
+    await h.controller.getEntityTestCredentials(h.req, "support-core", { status } as any);
+
+    expect(status).toHaveBeenCalledWith(501);
+    expect(json).toHaveBeenCalledWith({
+      error: "unsupported",
+      message: "Entity test credentials are not supported.",
     });
   });
 });

--- a/apps/agent/src/agent-runtime/agent.controller.monitoring-identities.test.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.monitoring-identities.test.ts
@@ -1,0 +1,169 @@
+import { NotFoundException } from "@nestjs/common";
+import { describe, expect, it, vi } from "vitest";
+import { AgentController } from "./agent.controller";
+
+const scope = {
+  organizationId: "org-a",
+  projectId: "project-a",
+  environmentId: "env-a",
+  userId: "operator-external",
+  principal: "operator" as const,
+};
+const req = { scope } as any;
+
+function controller(prisma: any) {
+  const value: any = Object.create(AgentController.prototype);
+  value.agentService = { prisma };
+  value.costService = { getCostByUser: vi.fn(), getCostByAgent: vi.fn() };
+  value.safetyEventService = { list: vi.fn() };
+  value.budgetService = { getUserConsumptionSummary: vi.fn() };
+  value.agentCrud = { list: vi.fn() };
+  value.ratingService = { satisfactionByAgent: vi.fn() };
+  return value;
+}
+
+const externalIdentity = {
+  issuer: "platos:external",
+  channel: "external",
+  subject: "customer-external",
+  profile: null,
+};
+
+describe("AgentController monitoring identity domains", () => {
+  it("returns 404 when the canonical EndUser has no current-Environment presence", async () => {
+    const threadFindMany = vi.fn();
+    const value = controller({
+      endUser: { findFirst: vi.fn().mockResolvedValue(null) },
+      thread: { findMany: threadFindMany },
+    });
+
+    const error = await value.monitoringUserDetail(req, "end-user-a").catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(NotFoundException);
+    expect(threadFindMany).not.toHaveBeenCalled();
+  });
+
+  it("uses canonical ids for relational joins and the external subject for runtime metadata/cost", async () => {
+    const threadFindMany = vi.fn().mockResolvedValue([]);
+    const value = controller({
+      endUser: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "end-user-a",
+          displayName: "Ada",
+          identities: [externalIdentity],
+        }),
+      },
+      thread: { findMany: threadFindMany },
+      agent: { findMany: vi.fn().mockResolvedValue([]) },
+      memory: { findMany: vi.fn().mockResolvedValue([]), groupBy: vi.fn().mockResolvedValue([]) },
+      messageRating: { findMany: vi.fn().mockResolvedValue([]) },
+    });
+    value.safetyEventService.list.mockResolvedValue({ rows: [] });
+    value.costService.getCostByUser
+      .mockResolvedValueOnce([{ userId: "customer-external", costCents: 7 }])
+      .mockResolvedValueOnce([{ userId: "customer-external", costCents: 30 }]);
+
+    const result = await value.monitoringUserDetail(req, "end-user-a");
+
+    expect(threadFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ endUserId: "end-user-a", environmentId: "env-a" }),
+    }));
+    expect(value.safetyEventService.list).toHaveBeenCalledWith(
+      { organizationId: "org-a", projectId: "project-a", environmentId: "env-a" },
+      { userId: "customer-external", limit: 50 },
+    );
+    expect(result).toMatchObject({
+      userId: "end-user-a",
+      externalUserId: "customer-external",
+      cost7dCents: 7,
+      cost30dCents: 30,
+    });
+  });
+
+  it("uses the external subject for Redis-backed consumption", async () => {
+    const value = controller({
+      endUser: {
+        findFirst: vi.fn().mockResolvedValue({ identities: [{ subject: "customer-external" }] }),
+      },
+    });
+    value.budgetService.getUserConsumptionSummary.mockResolvedValue({ userId: "customer-external" });
+
+    await value.monitoringUserConsumption(req, "end-user-a");
+
+    expect(value.budgetService.getUserConsumptionSummary).toHaveBeenCalledWith(
+      scope,
+      "customer-external",
+    );
+  });
+});
+
+describe("AgentController canonical monitoring projections", () => {
+  it("counts Turn input and one assistant side even when the response has multiple Steps", async () => {
+    const turnFindMany = vi.fn().mockResolvedValue([
+      {
+        threadId: "thread-a",
+        inputText: "hello",
+        input: null,
+        outputText: "world",
+        output: null,
+        _count: { steps: 2 },
+      },
+    ]);
+    const value = controller({
+      thread: {
+        findMany: vi.fn().mockResolvedValue([{ id: "thread-a", agentId: "agent-a" }]),
+        groupBy: vi.fn().mockResolvedValue([{ agentId: "agent-a", _max: { updatedAt: new Date() } }]),
+      },
+      turn: { findMany: turnFindMany },
+    });
+    value.agentCrud.list.mockResolvedValue([{ id: "agent-a", name: "Agent", isActive: true }]);
+    value.costService.getCostByAgent.mockResolvedValue([]);
+    value.ratingService.satisfactionByAgent.mockResolvedValue([]);
+
+    const result = await value.agentScorecard(req, "7");
+
+    expect(result.agents[0].messages).toBe(2);
+    expect(turnFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      select: {
+        threadId: true,
+        inputText: true,
+        input: true,
+        outputText: true,
+        output: true,
+        _count: { select: { steps: true } },
+      },
+    }));
+  });
+
+  it("projects immutable promotion audit events rather than AgentVersion.createdAt", async () => {
+    const adminAuditFindMany = vi.fn().mockResolvedValue([
+      {
+        subjectId: "agent-a",
+        createdAt: new Date("2026-08-19T12:00:00.000Z"),
+        before: { previousCanaryVersionId: "version-a" },
+        after: { currentVersionId: "version-a" },
+      },
+    ]);
+    const value = controller({
+      thread: { findMany: vi.fn().mockResolvedValue([]) },
+      entity: { findMany: vi.fn().mockResolvedValue([]) },
+      memory: { findMany: vi.fn().mockResolvedValue([]) },
+      adminAudit: { findMany: adminAuditFindMany },
+      safetyEvent: { findMany: vi.fn().mockResolvedValue([]) },
+    });
+
+    const result = await value.recentActivity(req, "10");
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        kind: "version.promoted",
+        at: "2026-08-19T12:00:00.000Z",
+        agentId: "agent-a",
+        payload: { currentVersionId: "version-a" },
+      }),
+    ]);
+    expect(adminAuditFindMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({ action: "agent.canary.promote" }),
+    }));
+  });
+});

--- a/apps/agent/src/agent-runtime/agent.controller.ts
+++ b/apps/agent/src/agent-runtime/agent.controller.ts
@@ -81,6 +81,29 @@ import {
   type UpdateGoldenSetDto,
 } from "../evals/golden-set.service";
 import { env } from "../shared/env";
+import { Prisma } from "@platos/tenancy-database";
+import {
+  type ControlDatabaseClient,
+  environmentScopeWhere,
+} from "../shared/database.provider";
+
+const EXTERNAL_END_USER_IDENTITY = {
+  issuer: "platos:external",
+  channel: "external",
+  disabledAt: null,
+} as const;
+
+function currentEnvironmentEndUserPresence(environmentId: string) {
+  return {
+    OR: [
+      { threads: { some: { environmentId } } },
+      { memories: { some: { environmentId } } },
+      { messageAttachments: { some: { environmentId } } },
+      { toolCallAudits: { some: { environmentId } } },
+      { safetyEvents: { some: { environmentId } } },
+    ],
+  };
+}
 
 /**
  * Agent REST API — every endpoint calls real services.
@@ -157,6 +180,10 @@ export class AgentController {
       projectId: scope.projectId,
       environmentId: scope.environmentId,
     };
+  }
+
+  private get prisma(): ControlDatabaseClient {
+    return (this.agentService as unknown as { prisma: ControlDatabaseClient }).prisma;
   }
 
   /**
@@ -1194,7 +1221,7 @@ export class AgentController {
       entityExternalId: string | null;
       environmentId: string;
       lastStatus: string | null;
-    }> = await (this.agentService as any).prisma.toolHealth.findMany({
+    }> = await this.prisma.toolHealth.findMany({
       where: { environmentId: scope.environmentId },
     });
     const healthByKey = new Map<string, string | null>();
@@ -1672,7 +1699,7 @@ export class AgentController {
       enabledOnly: false,
     });
 
-    const healthRows = await (this.agentService as any).prisma.toolHealth.findMany({
+    const healthRows = await this.prisma.toolHealth.findMany({
       where: { environmentId: scope.environmentId },
     });
     const healthByKey = new Map<string, any>();
@@ -1868,170 +1895,38 @@ export class AgentController {
       );
     }
 
-    // Load entity for serviceSecret (HMAC signing). Scope-gate via
-    // organizationId + projectId so a token from another scope can't hit this.
-    const prisma = (this.agentService as any).prisma;
-    const entity = await prisma.platosConnectedEntity.findFirst({
+    // Canonical Entity rows do not carry a legacy serviceSecret. Verify the
+    // entity through Project ancestry, then dispatch through the canonical
+    // executor for both wire and MCP transports.
+    const entity = await this.prisma.entity.findFirst({
       where: {
         id: toolEntry.entityPk,
-        organizationId: scope.organizationId,
         projectId: scope.projectId,
+        project: { organizationId: scope.organizationId },
       },
-      // GAP-4 — also load the transport discriminator so mcp-kind entities take
-      // the executor-delegated path below instead of the wire HMAC-POST.
-      select: { serviceSecret: true, entityId: true, connectionKind: true },
+      select: { id: true },
     });
     if (!entity) {
       throw new NotFoundException({ error: "Entity not found for this tool", toolId });
     }
 
-    // GAP-4 (design §4) — mcp-kind entities have no serviceSecret to HMAC-sign
-    // and no callbackUrl to POST (dummy secret + "mcp:noop"/null callback), so
-    // the wire dispatch below is meaningless for them. Delegate to the executor
-    // so the call runs through the mcpDispatch branch (pooled SDK client.callTool
-    // + per-user {{endUserId}} resolution) — full parity, one branch. This
-    // dashboard test carries no end-user context, so a {{endUserId}}-templated
-    // tool fails closed at the §3.2 boundary (never a shared identity). The
-    // endpoint must NEVER read entity.serviceSecret or toolEntry.callbackUrl for
-    // an mcp row — the branch returns before either is touched.
-    if (entity.connectionKind === "mcp") {
-      const t0 = Date.now();
-      const execResult = await this.toolExecutor.execute(
-        { tool: toolEntry.toolName, params: body.params ?? {}, purpose: "ui_test" },
-        scope,
-        { source: "wire_test" },
-      );
-      const durationMs = Date.now() - t0;
-      const ok = execResult.status === "success";
-      return {
-        status: ok ? 200 : 502,
-        headers: {},
-        body: ok
-          ? execResult.result ?? null
-          : { error: execResult.error ?? "MCP dispatch failed" },
-        durationMs,
-        ...(ok ? {} : { error: execResult.error ?? "MCP dispatch failed" }),
-      };
-    }
-
-    // Build request body — same shape as production path.
-    const requestParams = body.params ?? {};
-    const mcpBody = JSON.stringify({
-      method: "tools/call",
-      params: { name: toolEntry.toolName, arguments: requestParams },
-    });
-
-    const timestamp = new Date().toISOString();
-    const nonce = crypto.randomBytes(16).toString("hex");
-    const sigMessage = `${timestamp}.${nonce}.${mcpBody}`;
-    const signature = crypto
-      .createHmac("sha256", entity.serviceSecret)
-      .update(sigMessage)
-      .digest("hex");
-
-    // Validate callback URL against SSRF blocklist (same check as production).
-    {
-      const { validatePublicUrl, describeUrlValidationError } = await import("../shared/url-validator");
-      const check = await validatePublicUrl(toolEntry.callbackUrl);
-      if (!check.ok) {
-        throw new HttpException(
-          { error: `Blocked: ${describeUrlValidationError(check.error)}` },
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-    }
-
-    const callId = crypto.randomUUID();
-    const startTime = Date.now();
-
-    // Merge test headers + Platos standard headers. Caller-supplied headers
-    // go first so they can be overridden by the platform X-Platos-* ones.
-    const mergedHeaders: Record<string, string> = {
-      ...(body.headers ?? {}),
-      "Content-Type": "application/json",
-      "X-Platos-Signature": signature,
-      "X-Platos-Organization-Id": scope.organizationId,
-      "X-Platos-Project-Id": scope.projectId,
-      "X-Platos-Environment-Id": scope.environmentId,
-      "X-Platos-Entity-Id": entity.entityId,
-      "X-Platos-User-Id": scope.userId,
-      "X-Platos-Agent-Id": "dashboard",
-      "X-Platos-Thread-Id": "",
-      "X-Platos-Call-Id": callId,
-      "X-Platos-Timestamp": timestamp,
-      "X-Platos-Nonce": nonce,
-      "X-Platos-Test": "true",
+    const startedAt = Date.now();
+    const execResult = await this.toolExecutor.execute(
+      { tool: toolEntry.toolName, params: body.params ?? {}, purpose: "ui_test" },
+      scope,
+      { source: "wire_test" },
+    );
+    const durationMs = Date.now() - startedAt;
+    const ok = execResult.status === "success";
+    return {
+      status: ok ? 200 : 502,
+      headers: {},
+      body: ok
+        ? execResult.result ?? null
+        : { error: execResult.error ?? "Tool dispatch failed" },
+      durationMs,
+      ...(ok ? {} : { error: execResult.error ?? "Tool dispatch failed" }),
     };
-
-    try {
-      const abortCtl = new AbortController();
-      const timeout = setTimeout(() => abortCtl.abort(), 30_000);
-      // Rename to `fetchResp` to avoid shadowing the Express `Response` import.
-      let fetchResp: globalThis.Response;
-      try {
-        fetchResp = await fetch(toolEntry.callbackUrl, {
-          method: "POST",
-          headers: mergedHeaders,
-          body: mcpBody,
-          signal: abortCtl.signal,
-        });
-      } finally {
-        clearTimeout(timeout);
-      }
-
-      const durationMs = Date.now() - startTime;
-      const respHeaders: Record<string, string> = {};
-      fetchResp.headers.forEach((v: string, k: string) => { respHeaders[k] = v; });
-
-      let respBody: unknown;
-      const contentType = fetchResp.headers.get("content-type") ?? "";
-      if (contentType.includes("application/json")) {
-        respBody = await fetchResp.json().catch(() => null);
-      } else {
-        respBody = await fetchResp.text().catch(() => "");
-      }
-
-      // Write audit row tagged as wire_test (dashboard tool-test button).
-      try {
-        await this.toolAuditService.record({
-          scope: this.scopeTuple(scope),
-          toolId: toolEntry.toolId,
-          toolName: toolEntry.toolName,
-          entityId: toolEntry.sourceEntityId,
-          entityPk: toolEntry.entityPk,
-          agentId: "dashboard",
-          threadId: "",
-          userId: scope.userId,
-          args: requestParams,
-          result: fetchResp.ok ? respBody ?? null : null,
-          error: fetchResp.ok ? null : `HTTP ${fetchResp.status}`,
-          status: fetchResp.ok ? "success" : "failed",
-          latencyMs: durationMs,
-          source: "wire_test",
-          mcpUserId: null,
-          mcpClientId: null,
-        });
-      } catch {
-        // Audit is best-effort — never fail the test call for it.
-      }
-
-      if (!fetchResp.ok) {
-        return {
-          status: fetchResp.status,
-          headers: respHeaders,
-          body: respBody,
-          durationMs,
-          error: `HTTP ${fetchResp.status}`,
-          upstreamStatus: fetchResp.status,
-        };
-      }
-      return { status: fetchResp.status, headers: respHeaders, body: respBody, durationMs };
-    } catch (err: unknown) {
-      const durationMs = Date.now() - startTime;
-      const isAbort = err instanceof Error && err.name === "AbortError";
-      const msg = isAbort ? "Request timed out (30s)" : (err instanceof Error ? err.message : "fetch failed");
-      throw new HttpException({ error: msg, durationMs }, HttpStatus.BAD_GATEWAY);
-    }
   }
 
   // ═══════════════════════════════════════════════════════
@@ -2141,7 +2036,7 @@ export class AgentController {
     ).filter((c) => AgentController.ENTITY_ID_REGEX.test(c));
 
     // One bulk lookup — filter out any suggestions that are also taken.
-    const prisma = (this.agentService as any).prisma;
+    const prisma = this.prisma;
     const taken = new Set<string>();
     try {
       const rows = await prisma.entity.findMany({
@@ -2531,52 +2426,12 @@ export class AgentController {
     }
 
     if (body.linkedAgentIds !== undefined) {
-      if (!Array.isArray(body.linkedAgentIds)) {
-        throw new HttpException(
-          { error: "linkedAgentIds must be an array of agent IDs" },
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-      const cleaned = Array.from(
-        new Set(
-          body.linkedAgentIds
-            .map((x) => (typeof x === "string" ? x.trim() : ""))
-            .filter((x) => x.length > 0),
-        ),
-      );
-      // Validate every id belongs to THIS scope so a forged agent id from
-      // another org can't be persisted into the allow-list.
-      if (cleaned.length > 0) {
-        const prisma = (this.agentService as any).prisma;
-        const known = await prisma.agentBinding.findMany({
-          where: {
-            environmentId: scope.environmentId,
-            agentId: { in: cleaned },
-            environment: {
-              projectId: scope.projectId,
-              project: { organizationId: scope.organizationId },
-            },
-          },
-          select: { agentId: true },
-        });
-        const knownIds = new Set(known.map((binding: { agentId: string }) => binding.agentId));
-        const bogus = cleaned.filter((id) => !knownIds.has(id));
-        if (bogus.length > 0) {
-          throw new HttpException(
-            {
-              error: "One or more agent IDs are not in this scope",
-              unknownAgentIds: bogus,
-            },
-            HttpStatus.BAD_REQUEST,
-          );
-        }
-      }
-      // The retired Entity-linked allowlist has no clean persistence column.
-      // Canonical visibility is AgentToolPolicy-owned; retain this boundary as
-      // a compatibility no-op until the route moves to policy mutations.
-      this.toolRegistry.syncEntityLinkedAgents(
-        (entity as { id: string }).id,
-        cleaned,
+      throw new HttpException(
+        {
+          error: "unsupported",
+          message: "Entity-level agent allow-lists are not supported.",
+        },
+        HttpStatus.NOT_IMPLEMENTED,
       );
     }
 
@@ -2643,98 +2498,13 @@ export class AgentController {
       );
     }
 
-    // PIFSP-3 Deliverable 9 — test-credentials write path.
+    // The canonical Entity graph has no testCredentials field. Do not persist
+    // secret material in an unrelated JSON column.
     if (body.testCredentials !== undefined) {
-      const prisma = (this.agentService as any).prisma;
-      if (body.testCredentials === null) {
-        await prisma.platosConnectedEntity.update({
-          where: { id: (entity as { id: string }).id },
-          data: { testCredentials: null },
-        });
-      } else {
-        const raw = body.testCredentials;
-        if (
-          !raw ||
-          typeof raw !== "object" ||
-          !Array.isArray(raw.headers)
-        ) {
-          throw new HttpException(
-            { error: "testCredentials.headers must be an array" },
-            HttpStatus.BAD_REQUEST,
-          );
-        }
-        if (raw.headers.length > 32) {
-          throw new HttpException(
-            {
-              error: "Too many test-credential headers (max 32).",
-              limit: 32,
-            },
-            HttpStatus.BAD_REQUEST,
-          );
-        }
-        // RFC 7230 token regex for header names. Enforced server-side to
-        // mirror the form-level validation, so direct API callers can't
-        // smuggle in \r\n and split a header.
-        const HEADER_NAME_RE = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
-        const invalidHeaders: string[] = [];
-        const cleaned: Array<{ name: string; value: string }> = [];
-        for (const h of raw.headers) {
-          if (
-            !h ||
-            typeof h !== "object" ||
-            typeof h.name !== "string" ||
-            typeof h.value !== "string"
-          ) {
-            throw new HttpException(
-              { error: "Every header needs a string name + string value." },
-              HttpStatus.BAD_REQUEST,
-            );
-          }
-          const name = h.name.trim();
-          const value = h.value.trim();
-          if (!HEADER_NAME_RE.test(name)) {
-            invalidHeaders.push(name);
-            continue;
-          }
-          if (value.length > 4096) {
-            throw new HttpException(
-              {
-                error:
-                  "Header values capped at 4096 chars (matches most gateway limits).",
-                headerName: name,
-              },
-              HttpStatus.BAD_REQUEST,
-            );
-          }
-          cleaned.push({ name, value });
-        }
-        if (invalidHeaders.length > 0) {
-          throw new HttpException(
-            {
-              error: "One or more header names violate RFC 7230.",
-              invalidHeaders,
-            },
-            HttpStatus.BAD_REQUEST,
-          );
-        }
-        const userId =
-          typeof raw.userId === "string" && raw.userId.trim().length > 0
-            ? raw.userId.trim()
-            : undefined;
-        const stash = {
-          headers: cleaned,
-          userId,
-          updatedAt: new Date().toISOString(),
-          updatedByUserId: scope.userId,
-        };
-        // Encrypt via the standard JSON envelope (reused from H.4). Stored
-        // as TEXT — opaque base64 ciphertext, not indexable JSON.
-        const encrypted = this.messageCrypto.encryptJsonField(stash);
-        await prisma.platosConnectedEntity.update({
-          where: { id: (entity as { id: string }).id },
-          data: { testCredentials: JSON.stringify(encrypted) },
-        });
-      }
+      throw new HttpException(
+        { error: "unsupported", message: "Entity test credentials are not supported." },
+        HttpStatus.NOT_IMPLEMENTED,
+      );
     }
 
     const updated = await this.authService.getEntity(
@@ -2745,15 +2515,7 @@ export class AgentController {
     return updated;
   }
 
-  /**
-   * PIFSP-3 Deliverable 9 — decrypted test-credentials fetch used by the
-   * entity detail page + the PIFSP-4 Postman-style test sheet. Scope-gated
-   * via the same (org, project, entityId) lookup as GET /entities/:entityId.
-   *
-   * Returns 204 when no stash has been saved. Header values are returned
-   * in plaintext — operator already has scope access, encryption is purely
-   * an at-rest defence.
-   */
+  /** Legacy route retained as an explicit unsupported boundary. */
   @Get("entities/:entityId/test-credentials")
   async getEntityTestCredentials(
     @Req() req: Request,
@@ -2772,42 +2534,10 @@ export class AgentController {
       res.status(404).json({ error: "Entity not found", entityId });
       return;
     }
-    const encrypted = (entity as { testCredentials?: string | null })
-      .testCredentials;
-    if (!encrypted) {
-      res.status(204).end();
-      return;
-    }
-    try {
-      const envelope = JSON.parse(encrypted);
-      const decrypted = this.messageCrypto.decryptJsonField(envelope) as {
-        headers?: Array<{ name: string; value: string }>;
-        userId?: string;
-        updatedAt?: string;
-        updatedByUserId?: string;
-      } | null;
-      if (
-        !decrypted ||
-        (decrypted as any).__platos_enc === 1 // decryption failed sentinel
-      ) {
-        res.status(500).json({
-          error: "decryption_failed",
-          message: "Test credentials present but the encryption key changed.",
-        });
-        return;
-      }
-      res.status(200).json({
-        headers: decrypted.headers ?? [],
-        userId: decrypted.userId,
-        updatedAt: decrypted.updatedAt,
-        updatedByUserId: decrypted.updatedByUserId,
-      });
-    } catch (err: any) {
-      res.status(500).json({
-        error: "decryption_failed",
-        message: err?.message ?? "failed to decrypt test credentials",
-      });
-    }
+    res.status(HttpStatus.NOT_IMPLEMENTED).json({
+      error: "unsupported",
+      message: "Entity test credentials are not supported.",
+    });
   }
 
   // ═══════════════════════════════════════════════════════
@@ -2834,7 +2564,7 @@ export class AgentController {
     if (!entity) {
       throw new NotFoundException({ error: "Entity not found", entityId });
     }
-    const prisma = (this.agentService as any).prisma;
+    const prisma = this.prisma;
     const entityPk = (entity as { id: string }).id;
     const [config, bearerTokenCount] = await Promise.all([
       prisma.entityMcpConfig.findUnique({ where: { entityId: entityPk } }),
@@ -2901,7 +2631,7 @@ export class AgentController {
       throw new NotFoundException({ error: "Entity not found", entityId });
     }
     const entityPk = (entity as { id: string }).id;
-    const prisma = (this.agentService as any).prisma;
+    const prisma = this.prisma;
 
     const update: Record<string, unknown> = {};
     if (typeof body.enabled === "boolean") update.enabled = body.enabled;
@@ -2935,8 +2665,9 @@ export class AgentController {
       where: { entityId: entityPk },
       create: {
         entityId: entityPk,
-        enabled: update.enabled ?? false,
-        identityMode: update.identityMode ?? "bearer",
+        enabled: typeof update.enabled === "boolean" ? update.enabled : false,
+        identityMode:
+          typeof update.identityMode === "string" ? update.identityMode : "bearer",
         identityProviders: update.identityProviders ?? [],
         branding: update.branding ?? {},
         toolAllowlist: (update.toolAllowlist as string[] | undefined) ?? [],
@@ -2953,6 +2684,9 @@ export class AgentController {
         where: { entityId: entityPk, revokedAt: null },
       }),
     ]);
+    if (!fresh) {
+      throw new ServiceUnavailableException("Failed to load canonical entity MCP configuration");
+    }
     return {
       entityPk,
       entityId,
@@ -3087,20 +2821,21 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { rows: [], windowHours: 24, fetchedAt: new Date().toISOString() };
     const limit = Math.min(20, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 5 : 5));
     const since = new Date(Date.now() - 24 * 86_400_000);
 
     // Aggregate memory rows by agentId + kind (last 24h)
-    const rows: Array<{ agentId: string | null; kind: string; confidence: number | null; createdAt: Date; id: string; content: string }> =
-      await prisma.platosMemory.findMany({
+    const rows: Array<{ agentId: string; kind: string; confidence: number | null; createdAt: Date; id: string; content: string }> =
+      await prisma.memory.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
+          agent: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
           createdAt: { gte: since },
-          agentId: { not: null },
         },
         select: { agentId: true, kind: true, confidence: true, createdAt: true, id: true, content: true },
         orderBy: { createdAt: "desc" },
@@ -3134,7 +2869,7 @@ export class AgentController {
 
     // Fetch agent names
     const agentNameRows: Array<{ id: string; name: string }> = agentIds.length
-      ? await prisma.platosAgent.findMany({ where: { id: { in: agentIds } }, select: { id: true, name: true } })
+      ? await prisma.agent.findMany({ where: { id: { in: agentIds } }, select: { id: true, name: true } })
       : [];
     const nameMap = new Map(agentNameRows.map((a) => [a.id, a.name]));
 
@@ -3215,7 +2950,7 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { users: [], nextCursor: null, fetchedAt: new Date().toISOString() };
 
     const limit = Math.min(100, Math.max(1, limitRaw ? parseInt(limitRaw, 10) || 50 : 50));
@@ -3224,30 +2959,34 @@ export class AgentController {
     const cost7dSince = new Date(Date.now() - 7 * 86_400_000);
 
     // 1. Thread-level aggregation by userId
-    const threadRows: Array<{
-      userId: string;
-      agentId: string;
-      id: string;
-      createdAt: Date;
-    }> = await prisma.platosAgentThread.findMany({
+    const canonicalThreadRows = await prisma.thread.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
+        agent: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
         ...(agentIdFilter ? { agentId: agentIdFilter } : {}),
         updatedAt: { gte: since },
       },
-      select: { userId: true, agentId: true, id: true, createdAt: true },
+      select: { endUserId: true, agentId: true, id: true, createdAt: true },
     });
+    const threadRows = canonicalThreadRows.map((thread) => ({
+      userId: thread.endUserId,
+      agentId: thread.agentId,
+      id: thread.id,
+      createdAt: thread.createdAt,
+    }));
 
     // 2. Turn (user-message) counts + lastActive per userId
-    const msgRows: Array<{ threadId: string; createdAt: Date }> = await prisma.platosAgentMessage.findMany({
+    const msgRows: Array<{ threadId: string; createdAt: Date }> = await prisma.turn.findMany({
       where: {
-        role: "user",
         thread: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
+          agent: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
         },
         createdAt: { gte: since },
       },
@@ -3271,52 +3010,85 @@ export class AgentController {
     ]));
 
     // 4. Safety events (7d) per userId
-    const safetyRows: Array<{ userId: string | null }> = await prisma.platosSafetyEvent.findMany({
+    const safetyRows = await prisma.safetyEvent.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
         createdAt: { gte: cost7dSince },
       },
-      select: { userId: true },
+      select: { endUserId: true, metadata: true },
     });
-    const safetyMap = new Map<string, number>();
-    for (const s of safetyRows) {
-      if (s.userId) safetyMap.set(s.userId, (safetyMap.get(s.userId) ?? 0) + 1);
-    }
 
-    // 5a. PlatosEndUser displayName/email (primary alias source)
-    const endUserRows: Array<{ externalUserId: string; displayName: string | null; email: string | null }> =
-      await (prisma as any).platosEndUser.findMany({
-        where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
-          environmentId: scope.environmentId,
+    // 5a. Canonical EndUser display name / verified identity profile.
+    const endUserRows = await prisma.endUser.findMany({
+      where: {
+        organizationId: scope.organizationId,
+        id: { in: [...new Set(threadRows.map((thread) => thread.userId))] },
+      },
+      select: {
+        id: true,
+        displayName: true,
+        identities: {
+          where: { disabledAt: null },
+          select: { issuer: true, channel: true, subject: true, profile: true },
         },
-        select: { externalUserId: true, displayName: true, email: true },
-      }).catch(() => []);
+      },
+    });
     const aliasMap = new Map<string, string>();
+    const externalUserIdMap = new Map<string, string>();
+    const canonicalByExternalUserId = new Map<string, string>();
     for (const eu of endUserRows) {
-      const alias = eu.displayName || eu.email;
-      if (alias) aliasMap.set(eu.externalUserId, alias);
+      const externalIdentity = eu.identities.find(
+        (identity) =>
+          identity.issuer === EXTERNAL_END_USER_IDENTITY.issuer &&
+          identity.channel === EXTERNAL_END_USER_IDENTITY.channel,
+      );
+      if (externalIdentity) {
+        externalUserIdMap.set(eu.id, externalIdentity.subject);
+        canonicalByExternalUserId.set(externalIdentity.subject, eu.id);
+      }
+      const profileValue = eu.identities
+        .map((identity) => identity.profile)
+        .find((value) =>
+          !!value && typeof value === "object" && !Array.isArray(value),
+        );
+      const profile = profileValue as unknown as Record<string, unknown> | undefined;
+      const email = typeof profile?.["email"] === "string" ? profile["email"] : null;
+      const alias = eu.displayName || email;
+      if (alias) aliasMap.set(eu.id, alias);
+    }
+    const safetyMap = new Map<string, number>();
+    for (const safety of safetyRows) {
+      const metadata = safety.metadata && typeof safety.metadata === "object" && !Array.isArray(safety.metadata)
+        ? safety.metadata as Record<string, unknown>
+        : null;
+      const adapter = metadata?.["__platosSafety"];
+      const externalUserId = adapter && typeof adapter === "object" && !Array.isArray(adapter)
+        ? (adapter as Record<string, unknown>)["userId"]
+        : null;
+      const canonicalUserId = safety.endUserId ?? (
+        typeof externalUserId === "string"
+          ? canonicalByExternalUserId.get(externalUserId) ?? null
+          : null
+      );
+      if (canonicalUserId) {
+        safetyMap.set(canonicalUserId, (safetyMap.get(canonicalUserId) ?? 0) + 1);
+      }
     }
 
     // 5b. Fallback: profile aliases from PlatosMemory (kind=profile, metadata.name)
-    const profileRows: Array<{ userId: string; content: string; metadata: any }> = await prisma.platosMemory.findMany({
+    const profileRows = await prisma.memory.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
         kind: "profile",
       },
-      select: { userId: true, content: true, metadata: true },
-    }).catch(() => []);
+      select: { endUserId: true, content: true, metadata: true },
+    });
     for (const p of profileRows) {
-      if (aliasMap.has(p.userId)) continue; // PlatosEndUser takes priority
+      if (aliasMap.has(p.endUserId)) continue; // EndUser takes priority
       const meta = p.metadata as Record<string, unknown> | null;
       if (meta?.profileKey === "name" || p.content?.startsWith("Name:")) {
         const name = String(meta?.value ?? p.content.replace(/^Name:\s*/i, "")).trim();
-        if (name) aliasMap.set(p.userId, name);
+        if (name) aliasMap.set(p.endUserId, name);
       }
     }
 
@@ -3377,7 +3149,8 @@ export class AgentController {
     const users = Array.from(byUser.values()).map((b) => {
       const riskFlagCount = safetyMap.get(b.userId) ?? 0;
       const score = computeScore(b, riskFlagCount, b.turns);
-      const tokens = tokensMap.get(b.userId) ?? {
+      const externalUserId = externalUserIdMap.get(b.userId) ?? null;
+      const tokens = (externalUserId ? tokensMap.get(externalUserId) : undefined) ?? {
         inputTokens: 0,
         outputTokens: 0,
         cacheReadInputTokens: 0,
@@ -3386,12 +3159,13 @@ export class AgentController {
       };
       return {
         userId: b.userId,
+        externalUserId,
         alias: aliasMap.get(b.userId) ?? null,
         totalConversations: b.threadIds.size,
         agentsTouched: b.agentIds.size,
         totalTurns: b.turns,
         lastActiveAt: b.lastActiveAt.toISOString(),
-        cost7dCents: costMap.get(b.userId) ?? 0,
+        cost7dCents: externalUserId ? costMap.get(externalUserId) ?? 0 : 0,
         // PRELAUNCH-A1-10 — token breakdown for the monitoring table.
         inputTokens: tokens.inputTokens,
         outputTokens: tokens.outputTokens,
@@ -3430,40 +3204,56 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { agents: [], fetchedAt: new Date().toISOString() };
     const sinceDays = Math.min(90, Math.max(1, sinceDaysRaw ? parseInt(sinceDaysRaw, 10) || 30 : 30));
     const since = new Date(Date.now() - sinceDays * 86_400_000);
 
     // Threads in scope within window
-    const threads: Array<{ id: string; agentId: string; userId: string; createdAt: Date; updatedAt: Date }> =
-      await prisma.platosAgentThread.findMany({
+    const canonicalThreads = await prisma.thread.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
+          agent: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
           updatedAt: { gte: since },
         },
-        select: { id: true, agentId: true, userId: true, createdAt: true, updatedAt: true },
+        select: { id: true, agentId: true, endUserId: true, createdAt: true, updatedAt: true },
       });
+    const threads = canonicalThreads.map((thread) => ({
+      id: thread.id,
+      agentId: thread.agentId,
+      userId: thread.endUserId,
+      createdAt: thread.createdAt,
+      updatedAt: thread.updatedAt,
+    }));
 
     // Agent names + model
     const agentIds = [...new Set(threads.map((t) => t.agentId))];
-    const agentRows: Array<{ id: string; name: string; model: string | null }> =
-      await prisma.platosAgent.findMany({
-        where: { id: { in: agentIds } },
-        select: { id: true, name: true, model: true },
-      });
+    const agentBindings = await prisma.agentBinding.findMany({
+      where: { environmentId: scope.environmentId, agentId: { in: agentIds } },
+      select: {
+        agent: { select: { id: true, name: true } },
+        activeAgentVersion: { select: { model: true } },
+      },
+    });
+    const agentRows = agentBindings.map((binding) => ({
+      id: binding.agent.id,
+      name: binding.agent.name,
+      model: binding.activeAgentVersion.model,
+    }));
     const agentMeta = new Map(agentRows.map((a: { id: string; name: string; model: string | null }) => [a.id, a]));
 
     // User-turn counts per agentId (proxy for "turns")
-    const msgRows: Array<{ threadId: string }> = await prisma.platosAgentMessage.findMany({
+    const msgRows: Array<{ threadId: string }> = await prisma.turn.findMany({
       where: {
-        role: "user",
         thread: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
+          agent: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
         },
         createdAt: { gte: since },
       },
@@ -3547,7 +3337,7 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     const days = Math.min(365, Math.max(1, daysRaw ? parseInt(daysRaw, 10) || 7 : 7));
     if (!prisma) {
       return { days, agents: [], fetchedAt: new Date().toISOString() };
@@ -3562,42 +3352,53 @@ export class AgentController {
         // appear as rows with zeroed metrics.
         this.agentCrud.list(scope),
         // Windowed threads → conversation count + thread→agent map for messages.
-        prisma.platosAgentThread.findMany({
+        prisma.thread.findMany({
           where: {
-            organizationId: scope.organizationId,
-            projectId: scope.projectId,
             environmentId: scope.environmentId,
+            agent: {
+              projectId: scope.projectId,
+              project: { organizationId: scope.organizationId },
+            },
             updatedAt: { gte: since },
           },
           select: { id: true, agentId: true },
-        }) as Promise<Array<{ id: string; agentId: string }>>,
+        }),
         // All-time last-active per agent (max thread.updatedAt) — one aggregate
         // row per agent, so "Last active" stays truthful for dormant agents.
-        prisma.platosAgentThread.groupBy({
+        prisma.thread.groupBy({
           by: ["agentId"],
           where: {
-            organizationId: scope.organizationId,
-            projectId: scope.projectId,
             environmentId: scope.environmentId,
+            agent: {
+              projectId: scope.projectId,
+              project: { organizationId: scope.organizationId },
+            },
           },
           _max: { updatedAt: true },
-        }) as Promise<Array<{ agentId: string; _max: { updatedAt: Date | null } }>>,
-        // Windowed message counts (all roles) → message volume via thread map.
-        // groupBy aggregates in Postgres: one row per thread instead of one row
-        // per message, so a busy 30d window doesn't materialize hundreds of
-        // thousands of rows in Node memory.
-        prisma.platosAgentMessage.groupBy({
-          by: ["threadId"],
+        }),
+        // Canonical message projection: each Turn contributes its input and at
+        // most one assistant side. Steps are implementation detail within that
+        // assistant response, not additional chat messages.
+        prisma.turn.findMany({
           where: {
             createdAt: { gte: since },
             thread: {
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
               environmentId: scope.environmentId,
+              agent: {
+                projectId: scope.projectId,
+                project: { organizationId: scope.organizationId },
+              },
             },
           },
-          _count: { _all: true },
-        }) as Promise<Array<{ threadId: string; _count: { _all: number } }>>,
+          select: {
+            threadId: true,
+            inputText: true,
+            input: true,
+            outputText: true,
+            output: true,
+            _count: { select: { steps: true } },
+          },
+        }),
         this.costService.getCostByAgent(scopeTuple, { days, limit: 10_000 }),
         this.ratingService.satisfactionByAgent(scopeTuple, { days }),
       ]);
@@ -3612,9 +3413,13 @@ export class AgentController {
 
     // message volume per agent (windowed)
     const messagesPerAgent = new Map<string, number>();
-    for (const g of msgRows) {
-      const aid = threadIdToAgent.get(g.threadId);
-      if (aid) messagesPerAgent.set(aid, (messagesPerAgent.get(aid) ?? 0) + g._count._all);
+    for (const turn of msgRows) {
+      const aid = threadIdToAgent.get(turn.threadId);
+      if (!aid) continue;
+      const projectedMessages =
+        (turn.inputText !== null || turn.input !== null ? 1 : 0) +
+        (turn.outputText !== null || turn.output !== null || turn._count.steps > 0 ? 1 : 0);
+      messagesPerAgent.set(aid, (messagesPerAgent.get(aid) ?? 0) + projectedMessages);
     }
 
     // all-time last active per agent
@@ -3668,11 +3473,43 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { error: "service unavailable", status: 503 };
 
     const cost7dSince = new Date(Date.now() - 7 * 86_400_000);
     const cost30dSince = new Date(Date.now() - 30 * 86_400_000);
+
+    const endUserRow = await prisma.endUser.findFirst({
+      where: {
+        id: targetUserId,
+        organizationId: scope.organizationId,
+        ...currentEnvironmentEndUserPresence(scope.environmentId),
+      },
+      select: {
+        id: true,
+        displayName: true,
+        identities: {
+          where: { disabledAt: null },
+          select: { issuer: true, channel: true, subject: true, profile: true },
+        },
+      },
+    });
+    if (!endUserRow) throw new NotFoundException("End user not found in this Environment");
+    const externalUserId = endUserRow.identities.find(
+      (identity) =>
+        identity.issuer === EXTERNAL_END_USER_IDENTITY.issuer &&
+        identity.channel === EXTERNAL_END_USER_IDENTITY.channel,
+    )?.subject ?? null;
+    const emailIdentity = endUserRow.identities.find((identity) => identity.channel === "email");
+    const profileEmail = endUserRow.identities
+      .map((identity) => identity.profile)
+      .map((value) =>
+        value && typeof value === "object" && !Array.isArray(value)
+          ? (value as unknown as Record<string, unknown>)["email"]
+          : null,
+      )
+      .find((value): value is string => typeof value === "string") ?? null;
+    const endUserEmail = emailIdentity?.subject ?? profileEmail;
 
     // Threads for this user
     const threads: Array<{
@@ -3682,12 +3519,14 @@ export class AgentController {
       createdAt: Date;
       updatedAt: Date;
       status: string;
-    }> = await prisma.platosAgentThread.findMany({
+    }> = await prisma.thread.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
-        userId: targetUserId,
+        endUserId: targetUserId,
+        agent: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
       },
       select: { id: true, agentId: true, title: true, createdAt: true, updatedAt: true, status: true },
       orderBy: { updatedAt: "desc" },
@@ -3696,7 +3535,7 @@ export class AgentController {
 
     // Agent names
     const agentIds = [...new Set(threads.map((t) => t.agentId))];
-    const agentRows: Array<{ id: string; name: string }> = await prisma.platosAgent.findMany({
+    const agentRows: Array<{ id: string; name: string }> = await prisma.agent.findMany({
       where: { id: { in: agentIds } },
       select: { id: true, name: true },
     });
@@ -3723,69 +3562,56 @@ export class AgentController {
 
     // Profile memories
     const profileMemories: Array<{ id: string; kind: string; content: string; metadata: any; createdAt: Date }> =
-      await prisma.platosMemory.findMany({
+      await prisma.memory.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
-          userId: targetUserId,
+          endUserId: targetUserId,
           kind: "profile",
         },
         select: { id: true, kind: true, content: true, metadata: true, createdAt: true },
         orderBy: { createdAt: "desc" },
         take: 50,
-      }).catch(() => []);
+      });
 
     // Risk events (7d)
-    const riskEvents = await this.safetyEventService.list(this.scopeTuple(scope), {
-      userId: targetUserId,
-      limit: 50,
-    });
+    const riskEvents = externalUserId
+      ? await this.safetyEventService.list(this.scopeTuple(scope), {
+          userId: externalUserId,
+          limit: 50,
+        })
+      : { rows: [] };
 
     // Cost
     const cost7dRows = await this.costService.getCostByUser(this.scopeTuple(scope), { days: 7, limit: 500 });
     const cost30dRows = await this.costService.getCostByUser(this.scopeTuple(scope), { days: 30, limit: 500 });
-    const cost7dCents = cost7dRows.find((r) => r.userId === targetUserId)?.costCents ?? 0;
-    const cost30dCents = cost30dRows.find((r) => r.userId === targetUserId)?.costCents ?? 0;
-
-    // PlatosEndUser metadata
-    const endUserRow: { displayName: string | null; email: string | null } | null =
-      await (prisma as any).platosEndUser.findFirst({
-        where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
-          environmentId: scope.environmentId,
-          externalUserId: targetUserId,
-        },
-        select: { displayName: true, email: true },
-      }).catch(() => null);
+    const cost7dCents = externalUserId
+      ? cost7dRows.find((r) => r.userId === externalUserId)?.costCents ?? 0
+      : 0;
+    const cost30dCents = externalUserId
+      ? cost30dRows.find((r) => r.userId === externalUserId)?.costCents ?? 0
+      : 0;
 
     // Ratings summary
     // PlatosMessageRating has direct scope + userId columns — no relation needed.
-    const ratings: Array<{ rating: number }> = await prisma.platosMessageRating.findMany({
+    const ratings: Array<{ rating: number }> = await prisma.messageRating.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
-        userId: targetUserId,
+        endUserId: targetUserId,
       },
       select: { rating: true },
-    }).catch(() => []);
+    });
     const ratingsUps = ratings.filter((r) => r.rating > 0).length;
     const ratingsDowns = ratings.filter((r) => r.rating < 0).length;
 
     // Memory count by kind
-    const memoryCounts: Array<{ kind: string; _count: { id: number } }> =
-      await prisma.platosMemory.groupBy({
+    const memoryCounts = await prisma.memory.groupBy({
         by: ["kind"],
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
-          userId: targetUserId,
+          endUserId: targetUserId,
         },
         _count: { id: true },
-      }).catch(() => []);
+      });
     const memoryBreakdown: Record<string, number> = Object.fromEntries(
       memoryCounts.map((r) => [r.kind, r._count.id]),
     );
@@ -3799,8 +3625,9 @@ export class AgentController {
 
     return {
       userId: targetUserId,
-      displayName: endUserRow?.displayName ?? null,
-      email: endUserRow?.email ?? null,
+      externalUserId,
+      displayName: endUserRow.displayName ?? null,
+      email: endUserEmail,
       conversationsByAgent,
       profileMemories: profileMemories.map((m) => ({
         id: m.id,
@@ -3836,7 +3663,24 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    return this.budgetService.getUserConsumptionSummary(scope, targetUserId);
+    const endUser = await this.prisma.endUser.findFirst({
+      where: {
+        id: targetUserId,
+        organizationId: scope.organizationId,
+        ...currentEnvironmentEndUserPresence(scope.environmentId),
+      },
+      select: {
+        identities: {
+          where: EXTERNAL_END_USER_IDENTITY,
+          select: { subject: true },
+          take: 1,
+        },
+      },
+    });
+    if (!endUser) throw new NotFoundException("End user not found in this Environment");
+    const externalUserId = endUser.identities[0]?.subject;
+    if (!externalUserId) throw new NotFoundException("External user identity not found");
+    return this.budgetService.getUserConsumptionSummary(scope, externalUserId);
   }
 
   /**
@@ -3869,49 +3713,76 @@ export class AgentController {
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { error: "service unavailable" };
+
+    const endUser = await prisma.endUser.findFirst({
+      where: {
+        id: targetUserId,
+        organizationId: scope.organizationId,
+        ...currentEnvironmentEndUserPresence(scope.environmentId),
+      },
+      select: {
+        identities: {
+          where: EXTERNAL_END_USER_IDENTITY,
+          select: { subject: true },
+          take: 1,
+        },
+      },
+    });
+    if (!endUser) throw new NotFoundException("End user not found in this Environment");
+    const externalUserId = endUser.identities[0]?.subject ?? null;
 
     // Collect compact data for the prompt
     const [threads, memories, safetyRows] = await Promise.all([
-      prisma.platosAgentThread.findMany({
+      prisma.thread.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
-          userId: targetUserId,
+          endUserId: targetUserId,
+          agent: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
         },
         select: { id: true, agentId: true, title: true, updatedAt: true },
         orderBy: { updatedAt: "desc" },
         take: 50,
       }),
-      prisma.platosMemory.findMany({
+      prisma.memory.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
-          userId: targetUserId,
+          endUserId: targetUserId,
         },
         select: { kind: true, content: true, createdAt: true },
         orderBy: { createdAt: "desc" },
         take: 30,
       }),
-      prisma.platosSafetyEvent.findMany({
+      prisma.safetyEvent.findMany({
         where: {
-          organizationId: scope.organizationId,
-          projectId: scope.projectId,
           environmentId: scope.environmentId,
-          userId: targetUserId,
+          OR: [
+            { endUserId: targetUserId },
+            ...(externalUserId
+              ? [{
+                  metadata: {
+                    path: ["__platosSafety", "userId"],
+                    equals: externalUserId,
+                  },
+                }]
+              : []),
+          ],
         },
         select: { detector: true, severity: true, detail: true, createdAt: true },
         orderBy: { createdAt: "desc" },
         take: 10,
-      }).catch(() => []),
+      }),
     ]);
 
     // Cost data
     const costRows = await this.costService.getCostByUser(this.scopeTuple(scope), { days: 30, limit: 500 });
-    const cost30d = costRows.find((r) => r.userId === targetUserId)?.costCents ?? 0;
+    const cost30d = externalUserId
+      ? costRows.find((r) => r.userId === externalUserId)?.costCents ?? 0
+      : 0;
 
     // Resolve Anthropic key
     const anthropicKey = await this.agentService.resolvePublicApiKey(this.scopeTuple(scope), "anthropic");
@@ -3923,7 +3794,7 @@ export class AgentController {
 
     // Build compact context
     const agentIds = [...new Set((threads as Array<{ agentId: string }>).map((t) => t.agentId))];
-    const agentRows: Array<{ id: string; name: string }> = await prisma.platosAgent.findMany({
+    const agentRows: Array<{ id: string; name: string }> = await prisma.agent.findMany({
       where: { id: { in: agentIds } },
       select: { id: true, name: true },
     });
@@ -4999,7 +4870,7 @@ Write the summary now:`;
     const scopeTuple = this.scopeTuple(scope);
 
     const [threadCountAll, threadCountDay, cost7d] = await Promise.all([
-      (this.agentService as any).prisma.thread.count({
+      this.prisma.thread.count({
         where: {
           environmentId: scope.environmentId,
           environment: {
@@ -5007,7 +4878,7 @@ Write the summary now:`;
           },
         },
       }),
-      (this.agentService as any).prisma.thread.count({
+      this.prisma.thread.count({
         where: {
           environmentId: scope.environmentId,
           environment: {
@@ -5023,7 +4894,7 @@ Write the summary now:`;
     // traverse the canonical Environment → Project relation to re-check the
     // full tuple instead of relying on a legacy RuntimeEnvironment delegate.
     const activeToolsRows: Array<{ totalCalls: number; lastCalledAt: Date | null }> =
-      await (this.agentService as any).prisma.toolHealth.findMany({
+      await this.prisma.toolHealth.findMany({
         where: {
           environmentId: scope.environmentId,
           environment: {
@@ -5121,7 +4992,7 @@ Write the summary now:`;
    *   1. PlatosAgentMessage (assistant turns)
    *   2. PlatosConnectedEntity (connect/disconnect)
    *   3. PlatosMemory (extraction events, source="extractor")
-   *   4. PlatosAgentVersion (version promotions)
+   *   4. AdminAudit (immutable version-promotion events)
    *   5. PlatosSafetyEvent
    * Each source is fetched independently with take=limit, then merged and
    * sorted descending in-memory. Max 50 items.
@@ -5134,15 +5005,8 @@ Write the summary now:`;
   ) {
     const scope = this.getScope(req);
     requireOperator(scope); // SECURITY (audit H1) — operator-only dashboard
-    const prisma = (this.agentService as any).prisma;
+    const prisma = this.prisma;
     const limit = Math.min(50, Math.max(1, limitStr ? parseInt(limitStr, 10) : 15));
-    const scopeWhere = {
-      organizationId: scope.organizationId,
-      projectId: scope.projectId,
-      environmentId: scope.environmentId,
-      ...(agentId ? { agentId } : {}),
-    };
-
     type ActivityItem = {
       kind: string;
       at: string;
@@ -5158,11 +5022,24 @@ Write the summary now:`;
 
     // 1. Recently active threads (PlatosAgentMessage has no scope columns —
     //    scope lives on the thread; query threads instead).
-    const turns = await prisma.platosAgentThread.findMany({
-      where: { ...scopeWhere },
+    const turns = await prisma.thread.findMany({
+      where: {
+        environmentId: scope.environmentId,
+        ...(agentId ? { agentId } : {}),
+        agent: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
+      },
       orderBy: { updatedAt: "desc" },
       take: limit,
-      select: { id: true, agentId: true, userId: true, updatedAt: true, turnCount: true },
+      select: {
+        id: true,
+        agentId: true,
+        endUserId: true,
+        updatedAt: true,
+        _count: { select: { turns: true } },
+      },
     });
     for (const t of turns) {
       items.push({
@@ -5170,23 +5047,22 @@ Write the summary now:`;
         at: t.updatedAt.toISOString(),
         agentId: t.agentId,
         threadId: t.id,
-        userId: t.userId ?? undefined,
-        summary: `Thread active · ${t.turnCount} turn${t.turnCount !== 1 ? "s" : ""}`,
+        userId: t.endUserId,
+        summary: `Thread active · ${t._count.turns} turn${t._count.turns !== 1 ? "s" : ""}`,
         severity: "info",
-        payload: { turnCount: t.turnCount },
+        payload: { turnCount: t._count.turns },
       });
     }
 
     // 2. Entity connect/disconnect (recent updates)
-    const entities = await prisma.platosConnectedEntity.findMany({
+    const entities = await prisma.entity.findMany({
       where: {
-        organizationId: scope.organizationId,
         projectId: scope.projectId,
-        ...(agentId ? {} : {}),
+        project: { organizationId: scope.organizationId },
       },
       orderBy: { updatedAt: "desc" },
       take: limit,
-      select: { entityId: true, updatedAt: true, lastConnectedAt: true },
+      select: { externalId: true, updatedAt: true, lastConnectedAt: true },
     });
     for (const e of entities) {
       const connected = !!e.lastConnectedAt &&
@@ -5194,20 +5070,22 @@ Write the summary now:`;
       items.push({
         kind: connected ? "entity.connected" : "entity.disconnected",
         at: e.updatedAt.toISOString(),
-        summary: `Entity ${e.entityId} ${connected ? "connected" : "disconnected"}`,
+        summary: `Entity ${e.externalId} ${connected ? "connected" : "disconnected"}`,
         severity: "info",
-        payload: { entityId: e.entityId },
+        payload: { entityId: e.externalId },
       });
     }
 
     // 3. Memory extraction events
-    const memories = await prisma.platosMemory.findMany({
+    const memories = await prisma.memory.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
         source: "extractor",
         ...(agentId ? { agentId } : {}),
+        agent: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
       },
       orderBy: { createdAt: "desc" },
       take: limit,
@@ -5224,49 +5102,58 @@ Write the summary now:`;
       });
     }
 
-    // 4. Agent version promotions.
-    // PlatosAgentVersion has no scope columns of its own — scope through the
-    // `agent` relation (PlatosAgent owns organizationId/projectId/environmentId).
-    const versions = await prisma.platosAgentVersion.findMany({
+    // 4. Agent version promotions. AgentVersion.createdAt records version
+    // creation, not promotion; use the immutable admin event instead.
+    const promotions = await prisma.adminAudit.findMany({
       where: {
-        agent: {
-          organizationId: scope.organizationId,
+        environmentId: scope.environmentId,
+        environment: {
           projectId: scope.projectId,
-          environmentId: scope.environmentId,
+          project: { organizationId: scope.organizationId },
         },
-        ...(agentId ? { agentId } : {}),
+        action: "agent.canary.promote",
+        ...(agentId ? { subjectId: agentId } : {}),
       },
       orderBy: { createdAt: "desc" },
       take: limit,
-      select: { agentId: true, createdAt: true, versionNumber: true },
+      select: { subjectId: true, createdAt: true, before: true, after: true },
     });
-    for (const v of versions) {
+    for (const promotion of promotions) {
+      const after = promotion.after && typeof promotion.after === "object" && !Array.isArray(promotion.after)
+        ? promotion.after as Record<string, unknown>
+        : null;
+      const currentVersionId = typeof after?.["currentVersionId"] === "string"
+        ? after["currentVersionId"]
+        : null;
       items.push({
         kind: "version.promoted",
-        at: v.createdAt.toISOString(),
-        agentId: v.agentId,
-        summary: `Agent version v${v.versionNumber} created`,
+        at: promotion.createdAt.toISOString(),
+        agentId: promotion.subjectId ?? undefined,
+        summary: "Canary version promoted to current",
         severity: "info",
-        payload: { versionNumber: v.versionNumber },
+        payload: { currentVersionId },
       });
     }
 
     // 5. Safety events
-    const safety = await prisma.platosSafetyEvent.findMany({
-      where: { ...scopeWhere },
+    const safety = await prisma.safetyEvent.findMany({
+      where: {
+        environmentId: scope.environmentId,
+        ...(agentId ? { agentId } : {}),
+      },
       orderBy: { createdAt: "desc" },
       take: limit,
-      select: { agentId: true, threadId: true, createdAt: true, kind: true, severity: true, detector: true },
-    }).catch(() => []);
+      select: { agentId: true, threadId: true, createdAt: true, action: true, severity: true, detector: true },
+    });
     for (const s of safety) {
       items.push({
         kind: "safety.event",
         at: s.createdAt.toISOString(),
         agentId: s.agentId ?? undefined,
         threadId: s.threadId ?? undefined,
-        summary: `Safety event · ${s.kind} (${s.severity})`,
+        summary: `Safety event · ${s.action} (${s.severity})`,
         severity: s.severity === "high" ? "error" : s.severity === "medium" ? "warn" : "info",
-        payload: { kind: s.kind, severity: s.severity, detector: s.detector },
+        payload: { kind: s.action, severity: s.severity, detector: s.detector },
       });
     }
 
@@ -5895,13 +5782,11 @@ Write the summary now:`;
   @Get("postman-templates")
   async listPostmanTemplates(@Req() req: Request, @Query("agentId") agentId?: string) {
     const scope = this.getScope(req);
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { templates: [] };
-    const templates = await (prisma as any).platosPostmanTemplate.findMany({
+    const templates = await prisma.postmanTemplate.findMany({
       where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
+        ...environmentScopeWhere(scope),
         ...(agentId ? { agentId } : {}),
       },
       orderBy: [{ isDefault: "desc" }, { updatedAt: "desc" }],
@@ -5916,23 +5801,36 @@ Write the summary now:`;
     @Body() body: { agentId: string; name: string; simulateUserId: string; sessionContext?: unknown; isDefault?: boolean },
   ) {
     const scope = this.getScope(req);
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { error: "unavailable" };
+    const binding = await prisma.agentBinding.findFirst({
+      where: {
+        environmentId: scope.environmentId,
+        agentId: body.agentId,
+        agent: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
+      },
+      select: { id: true },
+    });
+    if (!binding) throw new NotFoundException("Agent not found in scope");
     if (body.isDefault) {
-      await (prisma as any).platosPostmanTemplate.updateMany({
-        where: { organizationId: scope.organizationId, projectId: scope.projectId, environmentId: scope.environmentId, agentId: body.agentId },
+      await prisma.postmanTemplate.updateMany({
+        where: { ...environmentScopeWhere(scope), agentId: body.agentId },
         data: { isDefault: false },
       });
     }
-    const template = await (prisma as any).platosPostmanTemplate.create({
+    const template = await prisma.postmanTemplate.create({
       data: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
         environmentId: scope.environmentId,
         agentId: body.agentId,
         name: body.name,
         simulateUserId: body.simulateUserId,
-        sessionContext: body.sessionContext ?? null,
+        sessionContext:
+          body.sessionContext === undefined || body.sessionContext === null
+            ? Prisma.JsonNull
+            : (body.sessionContext as Prisma.InputJsonValue),
         isDefault: body.isDefault ?? false,
         createdBy: scope.userId,
       },
@@ -5947,24 +5845,31 @@ Write the summary now:`;
     @Body() body: { name?: string; simulateUserId?: string; sessionContext?: unknown; isDefault?: boolean },
   ) {
     const scope = this.getScope(req);
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { error: "unavailable" };
-    const existing = await (prisma as any).platosPostmanTemplate.findFirst({
-      where: { id, organizationId: scope.organizationId, projectId: scope.projectId, environmentId: scope.environmentId },
+    const existing = await prisma.postmanTemplate.findFirst({
+      where: { id, ...environmentScopeWhere(scope) },
     });
     if (!existing) throw new NotFoundException("Template not found");
     if (body.isDefault) {
-      await (prisma as any).platosPostmanTemplate.updateMany({
-        where: { organizationId: scope.organizationId, projectId: scope.projectId, environmentId: scope.environmentId, agentId: existing.agentId },
+      await prisma.postmanTemplate.updateMany({
+        where: { ...environmentScopeWhere(scope), agentId: existing.agentId },
         data: { isDefault: false },
       });
     }
-    const updated = await (prisma as any).platosPostmanTemplate.update({
+    const updated = await prisma.postmanTemplate.update({
       where: { id },
       data: {
         ...(body.name !== undefined ? { name: body.name } : {}),
         ...(body.simulateUserId !== undefined ? { simulateUserId: body.simulateUserId } : {}),
-        ...(body.sessionContext !== undefined ? { sessionContext: body.sessionContext } : {}),
+        ...(body.sessionContext !== undefined
+          ? {
+              sessionContext:
+                body.sessionContext === null
+                  ? Prisma.JsonNull
+                  : (body.sessionContext as Prisma.InputJsonValue),
+            }
+          : {}),
         ...(body.isDefault !== undefined ? { isDefault: body.isDefault } : {}),
       },
     });
@@ -5974,10 +5879,10 @@ Write the summary now:`;
   @Delete("postman-templates/:id")
   async deletePostmanTemplate(@Req() req: Request, @Param("id") id: string) {
     const scope = this.getScope(req);
-    const prisma = (this.costService as any).prisma;
+    const prisma = this.prisma;
     if (!prisma) return { error: "unavailable" };
-    await (prisma as any).platosPostmanTemplate.deleteMany({
-      where: { id, organizationId: scope.organizationId, projectId: scope.projectId, environmentId: scope.environmentId },
+    await prisma.postmanTemplate.deleteMany({
+      where: { id, ...environmentScopeWhere(scope) },
     });
     return { ok: true };
   }

--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -34,7 +34,7 @@ import * as crypto from "crypto";
 import type { RequestScope } from "../auth/scope.guard";
 import { REDIS_TOKEN } from "../shared/redis.provider";
 import type Redis from "ioredis";
-import { PRISMA_TOKEN } from "../shared/database.provider";
+import { PRISMA_TOKEN, environmentScopeWhere } from "../shared/database.provider";
 import { pickExternalId } from "../shared/end-user-id";
 import { ToolRegistryService } from "../tool-gateway/tool-registry.service";
 import { ToolExecutorService } from "../tool-gateway/tool-executor.service";
@@ -3888,38 +3888,41 @@ export class AgentService {
       const deprecation_notice =
         opts.emittedAs === "list_tasks" ? bgoDeprecation("list_tasks", "list_bgos") : undefined;
       try {
-        // PPR-20 — scope filter MUST include runtimeEnvironmentId. Before
-        // this fix an agent in env=dev could enumerate prod tasks by
-        // project alone (Theme B + Runtime reviews flagged as cross-env
-        // leak). `runtimeEnvironmentId` dropped from the select too so the
-        // leak isn't visible in the response even if the where clause ever
-        // regresses.
-        const where: Record<string, unknown> = {
-          projectId: scope.projectId,
-          runtimeEnvironmentId: scope.environmentId,
-        };
-        if (filter) (where as any).slug = { contains: filter };
-        const rows = await this.prisma.backgroundWorkerTask.findMany({
-          where,
+        const rows = await this.prisma.job.findMany({
+          where: {
+            ...environmentScopeWhere(scope),
+            externalId: filter ? { contains: filter } : { not: null },
+          },
           select: {
-            slug: true,
-            filePath: true,
-            triggerSource: true,
+            externalId: true,
+            triggerType: true,
             description: true,
           },
-          distinct: ["slug"],
-          orderBy: { slug: "asc" },
+          orderBy: { externalId: "asc" },
           take: limit ?? 50,
         });
+        const bgos = rows.map((row: {
+          externalId: string;
+          triggerType: string;
+          description: string | null;
+        }) => ({
+          slug: row.externalId,
+          filePath: null,
+          triggerSource: row.triggerType,
+          description: row.description,
+        }));
         // Theme BGO — dual-emit `bgos` + `tasks` (identical array) for one
         // release so callers on either name see the rows.
         return {
-          bgos: rows,
-          tasks: rows,
+          bgos,
+          tasks: bgos,
           ...(deprecation_notice ? { deprecation_notice } : {}),
         };
-      } catch (err: any) {
-        return { status: "failed", error: err?.message || `${opts.emittedAs} failed` };
+      } catch {
+        return {
+          status: "failed",
+          error: "Background operation catalog is unavailable.",
+        };
       }
     };
     // `list_tasks` was previously gated on `metaEnabled("list_tasks")` with
@@ -3927,7 +3930,7 @@ export class AgentService {
     if (bgoMetaEnabled("list_bgos", "list_tasks", false)) {
       tools.list_bgos = {
         description:
-          "List background operations (BGOs) available in the current project/env. Returns `{ bgos: [{ slug, filePath?, triggerSource, description? }] }`. Optional text filter. Backed by the underlying trigger.dev task catalog.",
+          "List canonical background-operation Jobs available in the current project/env. Returns `{ bgos: [{ slug, filePath, triggerSource, description? }] }`. Optional text filter; filePath is null because the canonical Job model has no source-path field.",
         inputSchema: listBgosParameters,
         execute: async (args) => listBgosHandler(args, { emittedAs: "list_bgos" }),
       };
@@ -3951,39 +3954,10 @@ export class AgentService {
         status: z.string().optional().describe("Filter by run status (e.g. 'COMPLETED', 'FAILED')"),
         limit: z.number().int().min(1).max(200).optional().describe("Max rows (default 25)"),
       }),
-      execute: async ({ taskId, status, limit }) => {
-        try {
-          const where: Record<string, unknown> = {
-            projectId: scope.projectId,
-            runtimeEnvironmentId: scope.environmentId,
-          };
-          if (taskId) (where as any).taskIdentifier = taskId;
-          if (status) (where as any).status = status;
-          const rows = await this.prisma.taskRun.findMany({
-            where,
-            select: {
-              friendlyId: true,
-              taskIdentifier: true,
-              status: true,
-              createdAt: true,
-              completedAt: true,
-            },
-            orderBy: { createdAt: "desc" },
-            take: limit ?? 25,
-          });
-          return {
-            runs: rows.map((r: any) => ({
-              id: r.friendlyId,
-              taskIdentifier: r.taskIdentifier,
-              status: r.status,
-              startedAt: r.createdAt,
-              completedAt: r.completedAt,
-            })),
-          };
-        } catch (err: any) {
-          return { status: "failed", error: err?.message || "list_runs failed" };
-        }
-      },
+      execute: async () => ({
+        error: "unavailable",
+        message: "Task run history is not available through the canonical control database.",
+      }),
     };
 
     // schedule_bgo (Theme BGO — formerly `trigger_with_delay`) — schedule a

--- a/apps/agent/src/agent-runtime/job-runtime-cutover.test.ts
+++ b/apps/agent/src/agent-runtime/job-runtime-cutover.test.ts
@@ -50,3 +50,115 @@ describe("run_platos_task clean Job lookup", () => {
     });
   });
 });
+
+describe("background-operation catalog clean Job lookup", () => {
+  const scope: RequestScope = {
+    organizationId: "org-a",
+    projectId: "project-a",
+    environmentId: "env-a",
+    userId: "user-a",
+    agentId: "agent-a",
+  };
+
+  it("lists scoped canonical Jobs through both BGO names", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        externalId: "send-report",
+        triggerType: "agent-spawn",
+        description: "Send a report",
+      },
+    ]);
+    const service = new AgentService(
+      {} as any,
+      { job: { findMany } } as any,
+      { get: vi.fn() } as any,
+      { get: vi.fn(() => null) } as any,
+    );
+    const tools = (service as any).buildMetaTools(scope, {
+      metaTools: { list_bgos: true },
+    });
+
+    const result = await tools.list_bgos.execute({ filter: "report", limit: 10 });
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        environmentId: "env-a",
+        environment: {
+          projectId: "project-a",
+          project: { organizationId: "org-a" },
+        },
+        externalId: { contains: "report" },
+      },
+      select: {
+        externalId: true,
+        triggerType: true,
+        description: true,
+      },
+      orderBy: { externalId: "asc" },
+      take: 10,
+    });
+    expect(result).toEqual({
+      bgos: [
+        {
+          slug: "send-report",
+          filePath: null,
+          triggerSource: "agent-spawn",
+          description: "Send a report",
+        },
+      ],
+      tasks: [
+        {
+          slug: "send-report",
+          filePath: null,
+          triggerSource: "agent-spawn",
+          description: "Send a report",
+        },
+      ],
+    });
+
+    const deprecated = await tools.list_tasks.execute({});
+    expect(deprecated).toMatchObject({ bgos: result.bgos, tasks: result.tasks });
+    expect(deprecated.deprecation_notice).toContain("list_tasks");
+  });
+
+  it("redacts catalog persistence failures", async () => {
+    const service = new AgentService(
+      {} as any,
+      {
+        job: {
+          findMany: vi.fn().mockRejectedValue(new Error("postgres://sentinel-secret")),
+        },
+      } as any,
+      { get: vi.fn() } as any,
+      { get: vi.fn(() => null) } as any,
+    );
+    const tools = (service as any).buildMetaTools(scope, {
+      metaTools: { list_bgos: true },
+    });
+
+    const result = await tools.list_bgos.execute({});
+
+    expect(result).toEqual({
+      status: "failed",
+      error: "Background operation catalog is unavailable.",
+    });
+    expect(JSON.stringify(result)).not.toContain("sentinel-secret");
+  });
+
+  it("fails explicitly when canonical run history is unavailable", async () => {
+    const service = new AgentService(
+      {} as any,
+      {} as any,
+      { get: vi.fn() } as any,
+      { get: vi.fn(() => null) } as any,
+    );
+    const tools = (service as any).buildMetaTools(scope, {
+      metaTools: { list_runs: true },
+    });
+
+    await expect(tools.list_runs.execute({ limit: 25 })).resolves.toEqual({
+      error: "unavailable",
+      message: "Task run history is not available through the canonical control database.",
+    });
+  });
+});

--- a/apps/agent/src/clean-prisma-delegates.test.ts
+++ b/apps/agent/src/clean-prisma-delegates.test.ts
@@ -1,0 +1,376 @@
+import { createHash } from "node:crypto";
+import { readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { Prisma, PrismaClient } from "@platos/tenancy-database";
+import ts from "typescript";
+import { afterAll, describe, expect, it } from "vitest";
+
+const sourceRoot = __dirname;
+const generatedClient = new PrismaClient();
+
+function productionTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return productionTypeScriptFiles(path);
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) return [];
+    if (/\.(?:test|spec)\.ts$/.test(entry.name) || entry.name.endsWith(".d.ts")) return [];
+    return [path];
+  });
+}
+
+function lowerFirst(value: string): string {
+  return `${value[0]?.toLowerCase() ?? ""}${value.slice(1)}`;
+}
+
+const generatedDelegates = new Set(
+  Prisma.dmmf.datamodel.models.map((model) => lowerFirst(model.name)),
+);
+const generatedOperationsByDelegate = new Map<string, Set<string>>(
+  [...generatedDelegates].map((delegate) => {
+    const value = (generatedClient as unknown as Record<string, Record<string, unknown>>)[delegate];
+    return [
+      delegate,
+      new Set(Object.keys(value).filter((key) => typeof value[key] === "function" && !key.startsWith("$"))),
+    ];
+  }),
+);
+const generatedOperations = new Set(
+  [...generatedOperationsByDelegate.values()].flatMap((operations) => [...operations]),
+);
+
+type DelegateCall = {
+  delegate: string;
+  operation: string;
+  file: string;
+  line: number;
+};
+
+type Analysis = {
+  calls: DelegateCall[];
+  unresolvedDynamicAccesses: string[];
+};
+
+function staticMemberName(expression: ts.Expression): string | null {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  if (ts.isElementAccessExpression(expression)) {
+    const argument = expression.argumentExpression;
+    return argument && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))
+      ? argument.text
+      : null;
+  }
+  return null;
+}
+
+function memberBase(expression: ts.Expression): ts.Expression | null {
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return expression.expression;
+  }
+  return null;
+}
+
+function symbolAt(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | undefined {
+  return checker.getSymbolAtLocation(node) ?? undefined;
+}
+
+function declarationsFor(checker: ts.TypeChecker, identifier: ts.Identifier): readonly ts.Declaration[] {
+  return symbolAt(checker, identifier)?.declarations ?? [];
+}
+
+function hasInjectedPrismaToken(parameter: ts.ParameterDeclaration): boolean {
+  const decorators = ts.canHaveDecorators(parameter) ? ts.getDecorators(parameter) : undefined;
+  return decorators?.some((decorator) => decorator.getText().includes("Inject(PRISMA_TOKEN)")) ?? false;
+}
+
+function createAnalyzer(program: ts.Program, files: readonly ts.SourceFile[]) {
+  const checker = program.getTypeChecker();
+  const clientSymbols = new Set<ts.Symbol>();
+
+  const markTypedClient = (node: ts.Node, name: ts.Node) => {
+    const rendered = checker.typeToString(checker.getTypeAtLocation(node));
+    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) {
+      const symbol = symbolAt(checker, name);
+      if (symbol) clientSymbols.add(symbol);
+    }
+  };
+
+  for (const file of files) {
+    const visit = (node: ts.Node): void => {
+      if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+        markTypedClient(node, node.name);
+        if (hasInjectedPrismaToken(node)) {
+          const symbol = symbolAt(checker, node.name);
+          if (symbol) clientSymbols.add(symbol);
+        }
+      } else if (
+        (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node))
+        && ts.isIdentifier(node.name)
+      ) {
+        markTypedClient(node, node.name);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+  }
+
+  const isClientExpression = (expression: ts.Expression, seen = new Set<ts.Symbol>()): boolean => {
+    const rendered = checker.typeToString(checker.getTypeAtLocation(expression));
+    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) return true;
+
+    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
+      return isClientExpression(expression.expression, seen);
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return false;
+      if (clientSymbols.has(symbol)) return true;
+      seen.add(symbol);
+      return (symbol.declarations ?? []).some((declaration) => {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          return isClientExpression(declaration.initializer, seen);
+        }
+        if (ts.isParameter(declaration) && hasInjectedPrismaToken(declaration)) return true;
+        return false;
+      });
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const nameNode = ts.isPropertyAccessExpression(expression)
+        ? expression.name
+        : expression.argumentExpression;
+      const symbol = nameNode ? symbolAt(checker, nameNode) : undefined;
+      if (symbol && clientSymbols.has(symbol)) return true;
+    }
+    return false;
+  };
+
+  // Resolve constructor assignments (`this.prisma = prisma`) and transaction
+  // callback parameters. Repeat because either side may itself be an alias.
+  for (let pass = 0; pass < 3; pass++) {
+    for (const file of files) {
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isBinaryExpression(node)
+          && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          && isClientExpression(node.right)
+        ) {
+          const target = ts.isPropertyAccessExpression(node.left)
+            ? node.left.name
+            : ts.isIdentifier(node.left)
+              ? node.left
+              : null;
+          const symbol = target ? symbolAt(checker, target) : undefined;
+          if (symbol) clientSymbols.add(symbol);
+        }
+        if (ts.isCallExpression(node) && staticMemberName(node.expression) === "$transaction") {
+          const base = memberBase(node.expression);
+          const callback = node.arguments[0];
+          if (
+            base
+            && isClientExpression(base)
+            && callback
+            && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
+          ) {
+            const parameter = callback.parameters[0];
+            if (parameter && ts.isIdentifier(parameter.name)) {
+              const symbol = symbolAt(checker, parameter.name);
+              if (symbol) clientSymbols.add(symbol);
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(file);
+    }
+  }
+
+  const delegateFromType = (expression: ts.Expression): string | null => {
+    const expressionType = checker.getTypeAtLocation(expression);
+    const types = expressionType.isUnion() ? expressionType.types : [expressionType];
+    for (const type of types) {
+      const name = (type.aliasSymbol ?? type.getSymbol())?.getName() ?? "";
+      const match = /^\$?(.+)Delegate$/.exec(name);
+      if (match?.[1]) return lowerFirst(match[1]);
+    }
+    return null;
+  };
+
+  const delegateFor = (expression: ts.Expression, seen = new Set<ts.Symbol>()): string | null => {
+    const typed = delegateFromType(expression);
+    if (typed) return typed;
+    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
+      return delegateFor(expression.expression, seen);
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const base = memberBase(expression);
+      const name = staticMemberName(expression);
+      if (base && isClientExpression(base)) return name ?? "<dynamic>";
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return null;
+      seen.add(symbol);
+      for (const declaration of symbol.declarations ?? []) {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          const delegated = delegateFor(declaration.initializer, seen);
+          if (delegated) return delegated;
+        }
+        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
+          const variable = declaration.parent.parent;
+          if (ts.isVariableDeclaration(variable) && variable.initializer && isClientExpression(variable.initializer)) {
+            return declaration.propertyName && ts.isIdentifier(declaration.propertyName)
+              ? declaration.propertyName.text
+              : ts.isIdentifier(declaration.name)
+                ? declaration.name.text
+                : null;
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const callable = (
+    expression: ts.Expression,
+    seen = new Set<ts.Symbol>(),
+  ): { delegate: string; operation: string } | null => {
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const operation = staticMemberName(expression);
+      const base = memberBase(expression);
+      if (operation && generatedOperations.has(operation) && base) {
+        const delegate = delegateFor(base);
+        return delegate ? { delegate, operation } : null;
+      }
+      return null;
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return null;
+      seen.add(symbol);
+      for (const declaration of declarationsFor(checker, expression)) {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          const resolved = callable(declaration.initializer, seen);
+          if (resolved) return resolved;
+        }
+        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
+          const operation = declaration.propertyName && ts.isIdentifier(declaration.propertyName)
+            ? declaration.propertyName.text
+            : ts.isIdentifier(declaration.name)
+              ? declaration.name.text
+              : null;
+          const variable = declaration.parent.parent;
+          if (
+            operation
+            && generatedOperations.has(operation)
+            && ts.isVariableDeclaration(variable)
+            && variable.initializer
+          ) {
+            const delegate = delegateFor(variable.initializer);
+            if (delegate) return { delegate, operation };
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  return (): Analysis => {
+    const calls: DelegateCall[] = [];
+    const unresolvedDynamicAccesses: string[] = [];
+    for (const file of files) {
+      const visit = (node: ts.Node): void => {
+        if (ts.isCallExpression(node)) {
+          const resolvedCall = callable(node.expression);
+          if (resolvedCall) {
+            const position = file.getLineAndCharacterOfPosition(node.getStart(file));
+            const location = `${relative(sourceRoot, file.fileName)}:${position.line + 1}`;
+            if (resolvedCall.delegate === "<dynamic>") {
+              unresolvedDynamicAccesses.push(location);
+            } else {
+              calls.push({
+                ...resolvedCall,
+                file: relative(sourceRoot, file.fileName),
+                line: position.line + 1,
+              });
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(file);
+    }
+    return { calls, unresolvedDynamicAccesses };
+  };
+}
+
+function productionProgram(files: string[]): ts.Program {
+  const configPath = ts.findConfigFile(resolve(sourceRoot, ".."), ts.sys.fileExists, "tsconfig.json");
+  if (!configPath) throw new Error("apps/agent tsconfig.json not found");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, resolve(configPath, ".."));
+  return ts.createProgram({ rootNames: files, options: parsed.options });
+}
+
+afterAll(async () => {
+  await generatedClient.$disconnect();
+});
+
+describe("clean tenancy Prisma boundary", () => {
+  it("uses the type checker to inventory every production delegate operation", () => {
+    const paths = productionTypeScriptFiles(sourceRoot);
+    const program = productionProgram(paths);
+    const files = paths.map((path) => program.getSourceFile(path)).filter((file): file is ts.SourceFile => !!file);
+    const analysis = createAnalyzer(program, files)();
+    const violations = analysis.calls.filter(({ delegate, operation }) =>
+      !generatedDelegates.has(delegate)
+      || !generatedOperationsByDelegate.get(delegate)?.has(operation),
+    );
+    const inventory = [...new Set(
+      analysis.calls.map(({ delegate, operation }) => `${delegate}.${operation}`),
+    )].sort();
+    const inventoryDigest = createHash("sha256").update(inventory.join("\n")).digest("hex");
+
+    expect(files.length).toBeGreaterThan(100);
+    expect(analysis.unresolvedDynamicAccesses).toEqual([]);
+    expect(violations).toEqual([]);
+    // Independently pin both call-site count and unique operation inventory so
+    // the audit cannot pass because its discovery silently stopped working.
+    expect(analysis.calls.length).toBe(716);
+    expect(inventory).toHaveLength(287);
+    expect(inventoryDigest).toBe(
+      "3a10e71f7561430a71be7539d13991016e5d8a6412fc0cb0382493763cab264d",
+    );
+  }, 20_000);
+
+  it("follows delegate aliases, object destructuring, method aliases, and bracket access", () => {
+    const fileName = "/virtual/clean-prisma-inventory-fixture.ts";
+    const source = `
+      interface JobDelegate { findMany(): void; count(): void }
+      interface PrismaClient { job: JobDelegate; $transaction(): void }
+      declare const prisma: PrismaClient;
+      const direct = prisma["job"];
+      const { job: destructured } = prisma;
+      const aliased = destructured;
+      aliased["findMany"]();
+      const { count: countJobs } = direct;
+      countJobs();
+    `;
+    const options: ts.CompilerOptions = { strict: true, target: ts.ScriptTarget.ES2022 };
+    const baseHost = ts.createCompilerHost(options);
+    const sourceFile = ts.createSourceFile(fileName, source, options.target!, true);
+    const host: ts.CompilerHost = {
+      ...baseHost,
+      fileExists: (path) => path === fileName || baseHost.fileExists(path),
+      readFile: (path) => path === fileName ? source : baseHost.readFile(path),
+      getSourceFile: (path, languageVersion, onError, shouldCreateNewSourceFile) =>
+        path === fileName
+          ? sourceFile
+          : baseHost.getSourceFile(path, languageVersion, onError, shouldCreateNewSourceFile),
+    };
+    const program = ts.createProgram([fileName], options, host);
+    const analysis = createAnalyzer(program, [sourceFile])();
+
+    expect(analysis.calls.map(({ delegate, operation }) => `${delegate}.${operation}`).sort()).toEqual([
+      "job.count",
+      "job.findMany",
+    ]);
+  });
+});

--- a/apps/agent/src/control-plane/operation-manifest.generated.json
+++ b/apps/agent/src/control-plane/operation-manifest.generated.json
@@ -103,7 +103,7 @@
       },
       {
         "name": "agents.clone_from",
-        "description": "Composite — snapshot an existing agent's config and create a fresh copy in the SAME scope with a new name + slug. Copies promptBlocks, dynamicBlocks, tool + meta-tool config, memory/extraction policy, output schema, and contextMapping. Does NOT copy threads, versions, or canary pointers — the clone starts clean.",
+        "description": "Composite — snapshot an existing agent's config and create a fresh copy in the SAME scope with a new name + slug. Copies promptBlocks, dynamicBlocks, tool + meta-tool config, memory/extraction policy, and output schema. contextMapping is not part of the canonical agent graph and is not copied. Does NOT copy threads, versions, or canary pointers — the clone starts clean.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -220,7 +220,7 @@
       },
       {
         "name": "agents.deploy_with_skills",
-        "description": "Composite — create a new agent + enable a list of scope-resident skills on it + (optionally) set its contextMapping. Returns the fully-configured agent. Destructive — defaults to require_approval at platform tier.",
+        "description": "Composite — create a new agent + enable a list of scope-resident skills on it + return the fully-configured agent. contextMapping is rejected because it has no canonical persistence field. Destructive — defaults to require_approval at platform tier.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -373,7 +373,7 @@
       },
       {
         "name": "alert_channels.create",
-        "description": "Register a new alert channel scoped to the caller's project. Required: `type` (EMAIL|SLACK|WEBHOOK), `name`, `alertTypes` (≥1 of TASK_RUN / DEPLOYMENT_FAILURE / DEPLOYMENT_SUCCESS / ERROR_GROUP), and `channel` (type-specific config). EMAIL: `{ email }`. WEBHOOK: `{ url, secret? }` — secret is encrypted with the webapp-shared ENCRYPTION_KEY before persistence; if omitted a 32-byte random secret is generated. SLACK: `{ channelId, channelName, integrationId? }` (operator must have already linked the Slack workspace via the dashboard — this tool does NOT initiate OAuth). Optional `environmentTypes` default to [STAGING, PRODUCTION]; `deduplicationKey` enables idempotent retries. Audit-logged (channel type + name + masked URL host — never the webhook URL path or any secret).",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -400,25 +400,13 @@
               "type": "array",
               "minItems": 1,
               "items": {
-                "type": "string",
-                "enum": [
-                  "TASK_RUN",
-                  "DEPLOYMENT_FAILURE",
-                  "DEPLOYMENT_SUCCESS",
-                  "ERROR_GROUP"
-                ]
+                "type": "string"
               }
             },
             "environmentTypes": {
               "type": "array",
               "items": {
-                "type": "string",
-                "enum": [
-                  "DEVELOPMENT",
-                  "STAGING",
-                  "PRODUCTION",
-                  "PREVIEW"
-                ]
+                "type": "string"
               }
             },
             "deduplicationKey": {
@@ -441,7 +429,7 @@
       },
       {
         "name": "alert_channels.delete",
-        "description": "Remove an alert channel by id. Cascades through `ProjectAlert` + `ProjectAlertStorage` rows attached to this channel (foreign keys are ON DELETE CASCADE). Returns `{ error: 'not_found' }` for unknown / cross-project ids. Audit-logged.",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -464,7 +452,7 @@
       },
       {
         "name": "alert_channels.get_integration",
-        "description": "Inspect the OAuth integration linked to a channel (SLACK + future Discord etc). Returns `{ provider, externalOrgId, integrationId, lastUpdatedAt, hasToken }` — NEVER returns the OAuth access token. EMAIL + WEBHOOK channels return `{ linked: false }` (they don't carry an OAuth integration). Returns `{ error: 'not_found' }` for unknown / cross-project ids.",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -487,7 +475,7 @@
       },
       {
         "name": "alert_channels.list",
-        "description": "List `ProjectAlertChannel` rows for the caller's project. Channels are project-scoped (one channel routes alerts across every environment type listed in `environmentTypes`). Optional `type` narrows by EMAIL / SLACK / WEBHOOK; `enabled` filters by active status. Webhook secrets + Slack tokens are stripped — WEBHOOK rows surface only `url` + `hasSecret`.",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -520,7 +508,7 @@
       },
       {
         "name": "alert_channels.test",
-        "description": "Send a synthetic test notification to a channel. Currently supports WEBHOOK channels — the agent decrypts the channel's secret + signs a `{ type: 'test', message }` payload with HMAC-SHA-256 + POSTs to the configured URL. EMAIL + SLACK tests delegate to the webapp delivery service (returns `{ supported: false }` until the webapp ships a test endpoint). Returns `{ ok, status, latencyMs, urlHost }`. NEVER echoes the webhook URL or secret in the response.",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -547,7 +535,7 @@
       },
       {
         "name": "alert_channels.update",
-        "description": "Patch an existing alert channel by id. Mutable fields: `name`, `alertTypes`, `environmentTypes`, `enabled`, and the type-specific `channel` payload (matches the create-time shape). The channel `type` itself is immutable — delete + recreate to switch (e.g. EMAIL → WEBHOOK). Secrets follow the same encryption path as create. Returns `{ error: 'not_found' }` for unknown / cross-project ids. Audit-logged.",
+        "description": "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -565,25 +553,13 @@
             "alertTypes": {
               "type": "array",
               "items": {
-                "type": "string",
-                "enum": [
-                  "TASK_RUN",
-                  "DEPLOYMENT_FAILURE",
-                  "DEPLOYMENT_SUCCESS",
-                  "ERROR_GROUP"
-                ]
+                "type": "string"
               }
             },
             "environmentTypes": {
               "type": "array",
               "items": {
-                "type": "string",
-                "enum": [
-                  "DEVELOPMENT",
-                  "STAGING",
-                  "PRODUCTION",
-                  "PREVIEW"
-                ]
+                "type": "string"
               }
             },
             "enabled": {
@@ -2103,7 +2079,7 @@
       },
       {
         "name": "end_users.bind_external_id",
-        "description": "Adopt an EXTERNAL id (e.g. the Walle DB user id = Composio `user_id`) onto the PlatosEndUser behind a VERIFIED (channel, handle) claim, so per-user Composio tools resolve `{{endUserId}}` to that external id. Keyed by the claim, NOT the cuid — callers (e.g. Walle finish-setup) supply only `(channel, handle, externalId)`.\n\nFor Slack, `handle` is `<team>:<slackUserId>` where `<team> = teamId ?? enterpriseId` (an org/Grid install has teamId null ⇒ keyed by enterpriseId) — the SAME team-qualified handle the channel runtime mints. `channel` is lowercased + must match /^[a-z0-9_-]{1,32}$/; `externalId` is trimmed, 1..256 chars, no control chars.\n\nBehaviour: if a (channel, handle) identity exists, adopt its owner; else find-or-create a person by externalUserId=`<channel>:<handle>` and create the identity row with verified:true FORCED (so a later inbound message anchors on it) — regardless of the `verified` input flag. Then set linkedExternalId with idempotent OVERWRITE: an identical re-call is a no-op (created:false); a re-bind of the same claim to a NEW externalId re-links (moves the Composio identity). If a DIFFERENT person in scope already holds that externalId the call is refused with `{ error: 'external_id_conflict', existingPlatosEndUserId }`. Scope-pinned; audited (records old→new on a re-link).",
+        "description": "Verify that an authenticated runtime external id belongs to the person behind a verified channel claim. This tool never creates or promotes identity trust.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2137,7 +2113,7 @@
       },
       {
         "name": "end_users.get",
-        "description": "Fetch a single PlatosEndUser in the token's scope by EXACTLY ONE of `externalUserId` (the opaque id forwarded by the entity backend) or `platosEndUserId` (the canonical cuid). Returns the person's profile (id, externalUserId, displayName, email, threadCount, lastActiveAt, metadata) plus every linked identity (channel, handle, verified, sourceEntityId, createdAt). Scope-pinned — cross-scope ids return `{ error: 'not_found' }`.",
+        "description": "Fetch one organization-owned EndUser by exactly one of externalUserId or platosEndUserId, including canonical identities and scope-local thread activity.",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -2160,7 +2136,7 @@
       },
       {
         "name": "end_users.link_identity",
-        "description": "Manually attach a channel-native identity to a PlatosEndUser. The person must already exist in the token's scope. `channel` is lowercased + must match /^[a-z0-9_-]{1,32}$/ (e.g. email, phone, slack, teams, whatsapp); `handle` is the channel-native id (email addr, E.164 phone, Slack user id) — trimmed, 1..256 chars, no control chars. Manual links carry NO trust anchor (sourceEntityId = null). If the (channel, handle) already points at a DIFFERENT person the call returns `{ error: 'identity_conflict' }` naming the existing linkage and does NOT re-point (link-not-merge). Re-linking the SAME person updates the verified flag + metadata.",
+        "description": "Attach a canonical EndUserIdentity to an organization-owned EndUser. Existing identities are never re-pointed to another person.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2197,7 +2173,7 @@
       },
       {
         "name": "end_users.unlink_identity",
-        "description": "Detach a channel-native identity by its (channel, handle) within the token's scope. `channel` is lowercased before lookup; `handle` is trimmed. Scope-pinned — an identity in another scope is invisible and returns `{ ok: false, error: 'not_found' }`. Returns the row that was unlinked (channel, handle, verified, sourceEntityId, platosEndUserId) so the caller can re-link if needed. Never merges or re-points other rows.",
+        "description": "Detach one channel identity in the token's organization without re-pointing any other identity.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2323,7 +2299,7 @@
       },
       {
         "name": "entities.get_linked_agents",
-        "description": "List the agents allowed to use this entity's tools. Empty array = unrestricted (every agent in scope sees the tools); non-empty = only the listed PlatosAgent.id values.",
+        "description": "Legacy compatibility endpoint. Entity-level agent allow-lists are unsupported by the canonical control schema.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2371,7 +2347,7 @@
       },
       {
         "name": "entities.get_test_credentials",
-        "description": "Fetch the entity's stored test-credential headers — DECRYPTED in memory, returned in plaintext. Caller already has scope access; encryption is purely an at-rest defence. Audit-logged.",
+        "description": "Legacy compatibility endpoint. Entity test credentials are unsupported by the canonical control schema.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2591,7 +2567,7 @@
       },
       {
         "name": "entities.set_linked_agents",
-        "description": "Replace the per-entity agent allow-list. Every supplied agentId must belong to (org, project, env) — forged ids return an error. Empty array clears the restriction (= every agent in scope sees the tools). Mirrors PATCH /entities/:id linkedAgentIds.",
+        "description": "Legacy compatibility endpoint. Entity-level agent allow-lists are unsupported by the canonical control schema.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2675,7 +2651,7 @@
       },
       {
         "name": "entities.set_test_credentials",
-        "description": "Store encrypted test-credential headers used when 'Test' is clicked from the dashboard. Validates RFC 7230 names + 4096-char value cap + 32-header total. Pass `null` to clear. Audit-logged.",
+        "description": "Legacy compatibility endpoint. Entity test credentials are unsupported by the canonical control schema.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2885,7 +2861,7 @@
       },
       {
         "name": "environments.delete_secret",
-        "description": "Remove a secret from the caller's (project, environment) scope. Owner-gated. Idempotent — already-missing secrets return `{ deleted: false }` rather than throwing. Audit logs the NAME only.",
+        "description": "Environment credential management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -2924,7 +2900,7 @@
       },
       {
         "name": "environments.list_secrets",
-        "description": "List secret NAMES (and version + timestamps) for the caller's (project, environment) scope. Caller must be an org member. **NEVER returns secret values** — use the dashboard or deploy-pipeline injection to read them.",
+        "description": "Environment credential management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "properties": {},
@@ -2940,7 +2916,7 @@
       },
       {
         "name": "environments.set_secret",
-        "description": "Write a secret to the caller's (project, environment) scope. Owner-gated (ADMIN). Encrypted at rest with the webapp-shared `ENCRYPTION_KEY` (AES-256-GCM). Audit logs record the NAME only — never the value or any prefix. Validates name format (`^[A-Z][A-Z0-9_]{0,63}$`) + 8KiB value cap.",
+        "description": "Environment credential management is unavailable pending the canonical WIN-124 persistence cutover.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -4926,7 +4902,7 @@
       },
       {
         "name": "platos_tasks.create",
-        "description": "Create a new operator-authored task. Required: `taskId` (1-64 lowercase alphanumeric + hyphens, unique within scope), `displayName`, `handler` (raw JavaScript source — must `export function run(payload, ctx)`). Optional: `triggerType` (manual|schedule|webhook|agent-spawn, default 'manual'), `scheduleCron`, `scheduleTimezone`, `allowedAgentIds`, `payloadSchema`, `timeout` (seconds, default 300), `maxRetries` (default 3). The handler is syntax-checked before save; rows with syntax errors are stored with `isActive=false` + a `syntaxError` field surfaced in the response. Audit-logged (`taskId`, `displayName`, `handlerLength` only — never the handler source itself).",
+        "description": "Create a canonical Environment-owned job after syntax validation.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5006,7 +4982,7 @@
       },
       {
         "name": "platos_tasks.delete",
-        "description": "Delete a task by id. Removes the row + cascades nothing (TaskRun rows are not joined to PlatosTask — they remain in the trigger engine's history). Returns `{ error: 'not_found' }` for unknown / cross-scope ids. Audit-logged.",
+        "description": "Delete one canonical job in the current Environment.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5031,7 +5007,7 @@
       },
       {
         "name": "platos_tasks.get",
-        "description": "Fetch a single `PlatosTask` by id. Includes the raw `handler` source. Returns `{ error: 'not_found' }` for unknown / cross-scope ids — never echoes the row. Server-side `compiledHandler` cache is stripped before returning.",
+        "description": "Fetch one canonical job in scope, including its handler source.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5056,7 +5032,7 @@
       },
       {
         "name": "platos_tasks.get_run",
-        "description": "Fetch a single `TaskRun` (by friendly id `run_*` or full cuid). Restricted to runs whose `taskIdentifier='platos-custom-task'` and whose `runtimeEnvironmentId` + `projectId` match the caller's scope. Returns the parsed payload + status + timings. Returns `{ error: 'not_found' }` for cross-scope or non-platos-task runs.",
+        "description": "Run details are unavailable through the canonical control database.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5079,7 +5055,7 @@
       },
       {
         "name": "platos_tasks.get_runs",
-        "description": "List recent `TaskRun` rows for a `PlatosTask`. Filters `taskIdentifier='platos-custom-task'` + the agent's environment, then matches each run's `payload.taskRowId` against the supplied task `id`. Returns runs ordered most-recent first. Optional `status` narrows the underlying enum (PENDING, EXECUTING, COMPLETED_SUCCESSFULLY, FAILED, etc.). Default limit 50, max 200.",
+        "description": "Run history is unavailable through the canonical control database.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5110,7 +5086,7 @@
       },
       {
         "name": "platos_tasks.list",
-        "description": "List operator-authored custom tasks (`PlatosTask`) in the current scope. Returns metadata only — `handler` source is omitted to keep the response small + avoid leaking embedded secrets in bulk reads. Use `platos_tasks.get` to fetch a specific task with handler code.",
+        "description": "List canonical jobs in the current Environment. Handler source is omitted.",
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -5146,7 +5122,7 @@
       },
       {
         "name": "platos_tasks.run",
-        "description": "Manually dispatch a task via trigger.dev. Refuses if `isActive` is false. Requires `TRIGGER_SECRET_KEY` set in the agent environment (returns `{ queued: false, message: ... }` if missing). Optional `payload` is JSON-stringified into the execution context. Returns `{ queued: true, runId, taskId }` on success. Audit-logged (taskId + payload-key list — payload values are NOT echoed in the audit row to avoid leaking PII).",
+        "description": "Dispatch an active canonical job through Trigger.dev.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5174,7 +5150,7 @@
       },
       {
         "name": "platos_tasks.set_enabled",
-        "description": "Toggle the `isActive` flag on a task. Disabling a task makes it non-dispatchable via `platos_tasks.run` and `run_platos_task` meta-tool. Re-enabling will run a fresh syntax check on the stored handler — if it fails, the call rejects with `{ error: 'syntax_error' }` and `isActive` stays false. Audit-logged.",
+        "description": "Enable or disable a canonical job by changing its WorkStatus.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5201,7 +5177,7 @@
       },
       {
         "name": "platos_tasks.update",
-        "description": "Patch a task by id. Any field omitted is left untouched. If `handler` is supplied AND differs from the stored value, it is syntax-checked, `handlerVersion` is bumped, and `isActive` flips based on the syntax check (a clean handler reactivates a previously-broken task). Audit-logged (changed fields + new `handlerLength` if rewritten — never the handler source).",
+        "description": "Update canonical job fields. Handler changes are syntax checked.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5292,7 +5268,7 @@
       },
       {
         "name": "platos_tasks.validate_handler",
-        "description": "Compile-check a JavaScript handler source without executing it. Uses `new Function(payload, ctx, source)` to surface parse errors. Returns `{ valid: true }` on a clean parse, `{ valid: false, error: '...' }` otherwise. No DB writes, no audit — pure utility for the dashboard editor + agent IDE flows.\n\n**SYNTAX: CommonJS only.** The runtime executor (platos-custom-task) wraps the handler in a function expression, so use either:\n  • a bare expression body that returns a value, or\n  • `module.exports = async (payload, ctx) => { … }`\nESM syntax (`export default`, top-level `import`, top-level `await` outside an async fn) WILL fail to compile here and at runtime — this is intentional, the executor uses CommonJS-style `new Function` rather than dynamic `import()`. If you need npm modules, use `require(\"name\")` from inside the handler body.",
+        "description": "Syntax-check CommonJS handler source without executing it.",
         "inputSchema": {
           "type": "object",
           "required": [
@@ -5790,7 +5766,7 @@
       },
       {
         "name": "runs.list_all",
-        "description": "List trigger.dev TaskRuns in the caller's scope. Filters by optional `taskIdentifier`, `status` (PENDING / EXECUTING / COMPLETED_SUCCESSFULLY / COMPLETED_WITH_ERRORS / FAILED / CANCELED / etc.), and `since` (ISO timestamp). Newest-first. Returns metadata only — payload + traceContext are NEVER echoed.",
+        "description": "Task run history is unavailable until a canonical run-history model is added to the control database.",
         "inputSchema": {
           "type": "object",
           "properties": {

--- a/apps/agent/src/mcp-platform/control-plane-contract.test.ts
+++ b/apps/agent/src/mcp-platform/control-plane-contract.test.ts
@@ -82,7 +82,7 @@ const REPRESENTATIVE_REAL_TOOLS: Record<string, string> = {
   audit: "audit.safety_events.query",
   budgets: "budgets.delete",
   channel_apps: "channel_apps.bind_installation",
-  channels: "channels.create",
+  channels: "channels.list",
   clusters: "clusters.add_agent",
   end_users: "end_users.bind_external_id",
   entities: "entities.regenerate_secret",
@@ -121,13 +121,15 @@ const AUTHORITY = {
 };
 
 // These representative handlers do not pass the complete Environment tuple to
-// one dependency call: macros are token-local in-memory state, while the mcp
-// inventory adapter uses an existing project-scoped AuthService contract, and
-// projects.list_all is intentionally membership-scoped across the caller's
-// organizations. They are covered by router scope pinning/schema rejection
-// here, not claimed as full downstream database-tuple coverage.
+// one dependency call: canonical EndUser rows are Organization-owned, macros
+// are token-local in-memory state, the mcp inventory adapter uses an existing
+// project-scoped AuthService contract, and projects.list_all is intentionally
+// membership-scoped across the caller's organizations. They are covered by
+// router scope pinning/schema rejection here, not claimed as full downstream
+// database-tuple coverage.
 const ROUTER_PINNED_NAMESPACES = new Set([
   "alert_channels",
+  "end_users",
   "macros",
   "mcp",
   "oauth",
@@ -159,6 +161,26 @@ function strictScopedDependencies() {
       if (record.environmentId !== AUTHORITY.environmentId)
         violations.push(`environmentId=${String(record.environmentId)}`);
       canonicalTuples.push(record);
+    }
+    const environment = record["environment"];
+    if (
+      "environmentId" in record &&
+      environment &&
+      typeof environment === "object" &&
+      !Array.isArray(environment)
+    ) {
+      const environmentWhere = environment as Record<string, unknown>;
+      const project = environmentWhere["project"];
+      if (project && typeof project === "object" && !Array.isArray(project)) {
+        const projectWhere = project as Record<string, unknown>;
+        if (record.environmentId !== AUTHORITY.environmentId)
+          violations.push(`environmentId=${String(record.environmentId)}`);
+        if (environmentWhere["projectId"] !== AUTHORITY.projectId)
+          violations.push(`projectId=${String(environmentWhere["projectId"])}`);
+        if (projectWhere["organizationId"] !== AUTHORITY.organizationId)
+          violations.push(`organizationId=${String(projectWhere["organizationId"])}`);
+        canonicalTuples.push(record);
+      }
     }
     for (const key of ["organizationId", "projectId", "environmentId"] as const) {
       const forged = { organizationId: "org-b", projectId: "project-b", environmentId: "env-b" };

--- a/apps/agent/src/mcp-platform/mcp-platform.controller.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform.controller.ts
@@ -62,6 +62,7 @@ import { MessageCryptoService } from "../monitoring/message-crypto.service";
 // (resolved lazily via ModuleRef; a direct import in the constructor would
 // require importing ChannelsModule → DI cycle with AgentRuntimeModule).
 import { ChannelRuntimeService } from "../channels/channel-runtime.service";
+import { ChannelPersistenceService } from "../channels/channel-persistence.service";
 // MCPF-W6 — monitoring + settings/admin tool dependencies.
 import { TraceService } from "../monitoring/trace.service";
 import { ProviderHealthService } from "../auth/provider-health.service";
@@ -218,6 +219,7 @@ export class McpPlatformController {
         orgs: this.orgs,
         envs: this.envs,
         clusters: this.clusters,
+        channelPersistence: this.moduleRef.get(ChannelPersistenceService, { strict: false }),
         // Connect channels.* — evict the runtime's cached Chat instance after
         // update/delete/rotate so credential + routing changes take effect
         // immediately (not after the 10-min TTL). Best-effort: the runtime is

--- a/apps/agent/src/mcp-platform/mcp-router.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-router.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { McpRouter, RPC_ERRORS } from "./mcp-router";
+import type { VerifiedToken } from "./token.service";
+
+const token: VerifiedToken = {
+  id: "token-1",
+  scope: {
+    organizationId: "org-1",
+    projectId: "project-1",
+    environmentId: "env-1",
+  },
+  permissions: ["harmless.*"],
+  mintedByUserId: "user-1",
+  expiresAt: null,
+  tier: "scope",
+};
+
+function router() {
+  return new McpRouter(
+    {
+      buildScope: (verified) => ({
+        ...verified.scope,
+        userId: verified.mintedByUserId,
+      }),
+    },
+    {
+      resolve: vi.fn().mockResolvedValue({
+        state: "auto_allow",
+        tier: 1,
+        reason: "platform policy",
+      }),
+    } as any
+  );
+}
+
+describe("McpRouter tools/call", () => {
+  it("executes a harmless registered tool", async () => {
+    const instance = router();
+    const execute = vi.fn().mockResolvedValue({ ok: true });
+    instance.register({
+      name: "harmless.ping",
+      description: "A harmless test tool",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      execute,
+    });
+
+    const response = await instance.handle(
+      {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "harmless.ping", arguments: {} },
+      },
+      token
+    );
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toEqual({
+      content: [{ type: "text", text: JSON.stringify({ ok: true }) }],
+    });
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
+  it("returns a stable generic internal error without logging exception details", async () => {
+    const instance = router();
+    const secret = "Prisma P2022 ciphertext=sentinel-ciphertext";
+    instance.register({
+      name: "harmless.failure",
+      description: "A failing test tool",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+      async execute() {
+        throw new Error(secret);
+      },
+    });
+    const error = vi.fn();
+    (instance as any).logger = { error };
+
+    const response = await instance.handle(
+      {
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "harmless.failure", arguments: {} },
+      },
+      token
+    );
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      id: 2,
+      error: { code: RPC_ERRORS.INTERNAL_ERROR, message: "internal error" },
+    });
+    expect(JSON.stringify(response)).not.toContain(secret);
+    expect(error).toHaveBeenCalledWith("Platform MCP request failed");
+    expect(JSON.stringify(error.mock.calls)).not.toContain(secret);
+  });
+});

--- a/apps/agent/src/mcp-platform/mcp-router.ts
+++ b/apps/agent/src/mcp-platform/mcp-router.ts
@@ -11,6 +11,7 @@
  * wraps it in a `data: <json>\n\n` frame.
  */
 
+import { Logger } from "@nestjs/common";
 import type { RequestScope } from "../auth/scope.guard";
 import type { VerifiedToken } from "./token.service";
 import { PlatosMCPTokenService } from "./token.service";
@@ -162,6 +163,7 @@ export interface McpApprovalGate {
 }
 
 export class McpRouter {
+  private readonly logger = new Logger(McpRouter.name);
   private handlers = new Map<string, McpToolHandler>();
   private recorder: McpMacroRecorder | null = null;
   private approvalGate: McpApprovalGate | null = null;
@@ -636,13 +638,14 @@ export class McpRouter {
             },
           };
       }
-    } catch (err: any) {
+    } catch {
+      this.logger.error("Platform MCP request failed");
       return {
         jsonrpc: "2.0",
         id,
         error: {
           code: RPC_ERRORS.INTERNAL_ERROR,
-          message: err?.message || "internal error",
+          message: "internal error",
         },
       };
     }

--- a/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import { MCPPermissionGatewayService } from "./permission-gateway.service";
+
+const scope = {
+  organizationId: "org-1",
+  projectId: "project-1",
+  environmentId: "env-1",
+};
+
+function harness(
+  options: {
+    orgPolicies?: Array<{ pattern: string; effect: "ALLOW" | "DENY" }>;
+    binding?: unknown;
+  } = {}
+) {
+  const prisma = {
+    organizationMcpPolicy: {
+      findMany: vi.fn().mockResolvedValue(options.orgPolicies ?? []),
+    },
+    agentBinding: {
+      findFirst: vi.fn().mockResolvedValue(options.binding ?? null),
+    },
+  };
+  return {
+    service: new MCPPermissionGatewayService(prisma as any),
+    prisma,
+  };
+}
+
+describe("MCPPermissionGatewayService canonical policies", () => {
+  it("scopes organization policies only by authenticated organization ancestry", async () => {
+    const { service, prisma } = harness({
+      orgPolicies: [{ pattern: "reports.*", effect: "ALLOW" }],
+    });
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: null,
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(prisma.organizationMcpPolicy.findMany).toHaveBeenCalledWith({
+      where: { organizationId: "org-1" },
+      select: { pattern: true, effect: true },
+    });
+    expect(resolved.state).toBe("auto_allow");
+  });
+
+  it("maps organization DENY to block", async () => {
+    const { service } = harness({
+      orgPolicies: [{ pattern: "reports.*", effect: "DENY" }],
+    });
+
+    await expect(
+      service.resolve({
+        scope,
+        agentId: null,
+        userId: "user-1",
+        toolName: "reports.get",
+      })
+    ).resolves.toEqual({ state: "block", tier: 2, reason: "org-policy block" });
+  });
+
+  it("maps organization ALLOW to auto_allow", async () => {
+    const { service } = harness({
+      orgPolicies: [{ pattern: "reports.*", effect: "ALLOW" }],
+    });
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: null,
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(resolved.state).toBe("auto_allow");
+  });
+
+  it("fails closed when the scoped AgentBinding is missing", async () => {
+    const { service } = harness();
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: "agent-1",
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(resolved).toEqual({ state: "block", tier: 3, reason: "agent-policy block" });
+  });
+
+  it("loads the active AgentVersion through the fully scoped AgentBinding", async () => {
+    const { service, prisma } = harness({
+      binding: {
+        activeAgentVersion: {
+          toolDefaultPolicy: "ALL",
+          toolPolicies: [],
+        },
+      },
+    });
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: "agent-1",
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(prisma.agentBinding.findFirst).toHaveBeenCalledWith({
+      where: {
+        agentId: "agent-1",
+        environmentId: "env-1",
+        environment: {
+          projectId: "project-1",
+          project: { organizationId: "org-1" },
+        },
+        agent: { projectId: "project-1" },
+      },
+      select: {
+        activeAgentVersion: {
+          select: {
+            toolDefaultPolicy: true,
+            toolPolicies: {
+              where: { tool: { name: "reports.get" } },
+              orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
+              take: 1,
+              select: { effect: true },
+            },
+          },
+        },
+      },
+    });
+    expect(resolved.state).toBe("auto_allow");
+  });
+
+  it.each([
+    ["DENY", "block"],
+    ["ALLOW", "auto_allow"],
+  ] as const)("applies explicit AgentToolPolicy %s as %s", async (effect, expected) => {
+    const { service } = harness({
+      binding: {
+        activeAgentVersion: {
+          toolDefaultPolicy: effect === "DENY" ? "ALL" : "NONE",
+          toolPolicies: [{ effect }],
+        },
+      },
+    });
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: "agent-1",
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(resolved.state).toBe(expected);
+  });
+
+  it.each([
+    ["NONE", "block"],
+    ["ALL", "auto_allow"],
+  ] as const)("maps AgentVersion default %s to %s", async (toolDefaultPolicy, expected) => {
+    const { service } = harness({
+      binding: {
+        activeAgentVersion: {
+          toolDefaultPolicy,
+          toolPolicies: [],
+        },
+      },
+    });
+
+    const resolved = await service.resolve({
+      scope,
+      agentId: "agent-1",
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+
+    expect(resolved.state).toBe(expected);
+  });
+});

--- a/apps/agent/src/mcp-platform/permission-gateway.service.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.ts
@@ -1,5 +1,8 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import { PRISMA_TOKEN } from "../shared/database.provider";
+import {
+  PRISMA_TOKEN,
+  type ControlDatabaseClient,
+} from "../shared/database.provider";
 import type { RequestScope } from "../auth/scope.guard";
 
 /**
@@ -335,6 +338,16 @@ function normalizePolicy(raw: unknown): McpPermissionState | null {
   return null;
 }
 
+function fromPolicyEffect(effect: "ALLOW" | "DENY"): McpPermissionState {
+  return effect === "DENY" ? "block" : "auto_allow";
+}
+
+function toPolicyEffect(policy: McpPermissionState): "ALLOW" | "DENY" {
+  if (policy === "block") return "DENY";
+  if (policy === "auto_allow") return "ALLOW";
+  throw new Error("organization MCP policies support only auto_allow or block");
+}
+
 export interface ResolvePermissionInput {
   scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
   agentId: string | null;
@@ -360,7 +373,7 @@ export interface ResolvedPermission {
 export class MCPPermissionGatewayService {
   private readonly logger = new Logger(MCPPermissionGatewayService.name);
 
-  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: any) {}
+  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
 
   /** Tier-1 platform baseline. Matches pattern list to get the minimum. */
   private readPlatformMinimum(toolName: string): McpPermissionState {
@@ -375,18 +388,14 @@ export class MCPPermissionGatewayService {
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     toolName: string,
   ): Promise<McpPermissionState | null> {
-    const rows = await this.prisma.platosOrgMcpPolicy.findMany({
-      where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
-      },
-      select: { pattern: true, policy: true },
+    const rows = await this.prisma.organizationMcpPolicy.findMany({
+      where: { organizationId: scope.organizationId },
+      select: { pattern: true, effect: true },
     });
     let winner: McpPermissionState | null = null;
     for (const row of rows) {
       if (matchesPattern(row.pattern, toolName)) {
-        const normalized = normalizePolicy(row.policy);
+        const normalized = fromPolicyEffect(row.effect);
         if (normalized && (!winner || stateOrder(normalized) > stateOrder(winner))) {
           winner = normalized;
         }
@@ -395,30 +404,43 @@ export class MCPPermissionGatewayService {
     return winner;
   }
 
-  /** Tier-3 per-agent override — JSON column lookup. */
+  /** Tier-3 per-agent override from the active version's typed tool policy. */
   private async readAgentOverride(
+    scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     agentId: string,
     toolName: string,
   ): Promise<McpPermissionState | null> {
-    const agent = await this.prisma.platosAgent.findUnique({
-      where: { id: agentId },
-      select: { mcpPermissions: true },
+    const binding = await this.prisma.agentBinding.findFirst({
+      where: {
+        agentId,
+        environmentId: scope.environmentId,
+        environment: {
+          projectId: scope.projectId,
+          project: { organizationId: scope.organizationId },
+        },
+        agent: { projectId: scope.projectId },
+      },
+      select: {
+        activeAgentVersion: {
+          select: {
+            toolDefaultPolicy: true,
+            toolPolicies: {
+              where: { tool: { name: toolName } },
+              orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
+              take: 1,
+              select: { effect: true },
+            },
+          },
+        },
+      },
     });
-    const perms = agent?.mcpPermissions as Record<string, unknown> | null;
-    if (!perms || typeof perms !== "object") return null;
-    // Exact match first; fall back to prefix glob.
-    if (toolName in perms) {
-      return normalizePolicy(perms[toolName]);
+    if (!binding) {
+      this.logger.warn("MCP permission denied: scoped AgentBinding was not found");
+      return "block";
     }
-    let winner: McpPermissionState | null = null;
-    for (const [pattern, policy] of Object.entries(perms)) {
-      if (pattern === toolName || !matchesPattern(pattern, toolName)) continue;
-      const normalized = normalizePolicy(policy);
-      if (normalized && (!winner || stateOrder(normalized) > stateOrder(winner))) {
-        winner = normalized;
-      }
-    }
-    return winner;
+    const explicit = binding.activeAgentVersion.toolPolicies[0];
+    if (explicit) return fromPolicyEffect(explicit.effect);
+    return binding.activeAgentVersion.toolDefaultPolicy === "ALL" ? "auto_allow" : "block";
   }
 
   /** Tier-4 session override — passed in by the caller; no DB touch. */
@@ -442,7 +464,7 @@ export class MCPPermissionGatewayService {
     if (t2 === "block") return { state: "block", tier: 2, reason: "org-policy block" };
 
     const t3 = input.agentId
-      ? await this.readAgentOverride(input.agentId, input.toolName)
+      ? await this.readAgentOverride(input.scope, input.agentId, input.toolName)
       : null;
     if (t3 === "block") return { state: "block", tier: 3, reason: "agent-policy block" };
 
@@ -504,14 +526,11 @@ export class MCPPermissionGatewayService {
   async listOrgPolicies(
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
   ) {
-    return this.prisma.platosOrgMcpPolicy.findMany({
-      where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
-      },
+    const rows = await this.prisma.organizationMcpPolicy.findMany({
+      where: { organizationId: scope.organizationId },
       orderBy: [{ pattern: "asc" }],
     });
+    return rows.map(({ effect, ...row }) => ({ ...row, policy: fromPolicyEffect(effect) }));
   }
 
   async upsertOrgPolicy(
@@ -522,51 +541,41 @@ export class MCPPermissionGatewayService {
     if (!pattern || pattern.length < 1 || pattern.length > 200) {
       throw new Error("pattern must be 1–200 chars");
     }
-    if (normalizePolicy(policy) === null) {
-      throw new Error(`policy must be auto_allow | require_approval | block`);
-    }
+    const effect = toPolicyEffect(policy);
     // Upsert via find + update/create since the unique key is composite.
-    const existing = await this.prisma.platosOrgMcpPolicy.findFirst({
-      where: {
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
-        pattern,
-      },
+    const existing = await this.prisma.organizationMcpPolicy.findFirst({
+      where: { organizationId: scope.organizationId, pattern },
       select: { id: true },
     });
     if (existing) {
-      return this.prisma.platosOrgMcpPolicy.update({
+      const updated = await this.prisma.organizationMcpPolicy.update({
         where: { id: existing.id },
-        data: { policy },
+        data: { effect },
       });
+      const { effect: savedEffect, ...row } = updated;
+      return { ...row, policy: fromPolicyEffect(savedEffect) };
     }
-    return this.prisma.platosOrgMcpPolicy.create({
+    const created = await this.prisma.organizationMcpPolicy.create({
       data: {
         organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
         pattern,
-        policy,
+        effect,
       },
     });
+    const { effect: savedEffect, ...row } = created;
+    return { ...row, policy: fromPolicyEffect(savedEffect) };
   }
 
   async deleteOrgPolicy(
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     id: string,
   ) {
-    const existing = await this.prisma.platosOrgMcpPolicy.findFirst({
-      where: {
-        id,
-        organizationId: scope.organizationId,
-        projectId: scope.projectId,
-        environmentId: scope.environmentId,
-      },
+    const existing = await this.prisma.organizationMcpPolicy.findFirst({
+      where: { id, organizationId: scope.organizationId },
       select: { id: true },
     });
     if (!existing) return false;
-    await this.prisma.platosOrgMcpPolicy.delete({ where: { id } });
+    await this.prisma.organizationMcpPolicy.delete({ where: { id } });
     return true;
   }
 

--- a/apps/agent/src/mcp-platform/tools/admin.ts
+++ b/apps/agent/src/mcp-platform/tools/admin.ts
@@ -27,6 +27,7 @@ import type { ToolAuditService } from "../../monitoring/tool-audit.service";
 import type { CostService } from "../../monitoring/cost.service";
 import type { MemoryService } from "../../memory/memory.service";
 import type { KnowledgeGraphService } from "../../memory/knowledge-graph.service";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
 
@@ -37,11 +38,11 @@ interface ScopeRow {
   projectSlug: string;
   environmentId: string;
   environmentSlug: string;
-  environmentType: string;
+  environmentType: string | null;
 }
 
 export interface AdminToolsDeps {
-  prisma: any;
+  prisma: ControlDatabaseClient;
   toolAudit: ToolAuditService;
   cost: CostService;
   memory: MemoryService;
@@ -54,19 +55,25 @@ export interface AdminToolsDeps {
  * provided org ids.
  */
 async function loadOrgScopes(
-  prisma: any,
+  prisma: ControlDatabaseClient,
   organizationId: string,
 ): Promise<ScopeRow[]> {
-  const envs = await prisma.runtimeEnvironment.findMany({
-    where: { organizationId, archivedAt: null },
+  const envs = await prisma.environment.findMany({
+    where: {
+      archivedAt: null,
+      project: { organizationId, archivedAt: null },
+    },
     select: {
       id: true,
       slug: true,
-      type: true,
-      organizationId: true,
-      organization: { select: { slug: true } },
       projectId: true,
-      project: { select: { slug: true, deletedAt: true } },
+      project: {
+        select: {
+          slug: true,
+          organizationId: true,
+          organization: { select: { slug: true } },
+        },
+      },
     },
     orderBy: [{ projectId: "asc" }, { slug: "asc" }],
   });
@@ -74,22 +81,21 @@ async function loadOrgScopes(
   for (const e of envs as Array<{
     id: string;
     slug: string;
-    type: string;
-    organizationId: string;
-    organization: { slug: string } | null;
     projectId: string;
-    project: { slug: string; deletedAt: Date | null } | null;
+    project: {
+      slug: string;
+      organizationId: string;
+      organization: { slug: string };
+    };
   }>) {
-    // Skip soft-deleted projects — they're effectively dead scopes.
-    if (!e.project || e.project.deletedAt) continue;
     out.push({
-      organizationId: e.organizationId,
-      organizationSlug: e.organization?.slug ?? "",
+      organizationId: e.project.organizationId,
+      organizationSlug: e.project.organization.slug,
       projectId: e.projectId,
       projectSlug: e.project.slug,
       environmentId: e.id,
       environmentSlug: e.slug,
-      environmentType: e.type,
+      environmentType: null,
     });
   }
   return out;
@@ -292,34 +298,38 @@ export function buildAdminToolHandlers(deps: AdminToolsDeps): McpToolHandler[] {
         const limitPerScope = (params["limitPerScope"] as number) ?? 100;
         const scopes = await loadOrgScopes(prisma, scope.organizationId);
 
-        const rows = await prisma.platosAgent.findMany({
+        const rows = await prisma.agentBinding.findMany({
           where: {
-            organizationId: scope.organizationId,
-            ...(includeInactive ? {} : { isActive: true }),
+            environment: { project: { organizationId: scope.organizationId } },
+            ...(includeInactive ? {} : { agent: { isActive: true } }),
           },
           select: {
-            id: true,
-            projectId: true,
             environmentId: true,
-            name: true,
-            slug: true,
-            model: true,
-            isActive: true,
+            agent: {
+              select: {
+                id: true,
+                projectId: true,
+                name: true,
+                slug: true,
+                isActive: true,
+              },
+            },
+            activeAgentVersion: { select: { model: true } },
           },
           orderBy: { createdAt: "desc" },
         });
 
         const byKey = new Map<string, Array<any>>();
         for (const a of rows as Array<any>) {
-          const key = `${a.projectId}::${a.environmentId}`;
+          const key = `${a.agent.projectId}::${a.environmentId}`;
           const list = byKey.get(key) ?? [];
           if (list.length < limitPerScope) {
             list.push({
-              id: a.id,
-              name: a.name,
-              slug: a.slug,
-              model: a.model,
-              isActive: a.isActive,
+              id: a.agent.id,
+              name: a.agent.name,
+              slug: a.agent.slug,
+              model: a.activeAgentVersion.model,
+              isActive: a.agent.isActive,
             });
           }
           byKey.set(key, list);
@@ -361,13 +371,12 @@ export function buildAdminToolHandlers(deps: AdminToolsDeps): McpToolHandler[] {
       },
       async execute(_params, scope) {
         const scopes = await loadOrgScopes(prisma, scope.organizationId);
-        const entities = await prisma.platosConnectedEntity.findMany({
-          where: { organizationId: scope.organizationId },
+        const entities = await prisma.entity.findMany({
+          where: { project: { organizationId: scope.organizationId } },
           select: {
             id: true,
-            organizationId: true,
             projectId: true,
-            entityId: true,
+            externalId: true,
             displayName: true,
             connectionStatus: true,
             lastConnectedAt: true,
@@ -381,7 +390,7 @@ export function buildAdminToolHandlers(deps: AdminToolsDeps): McpToolHandler[] {
           const list = byProject.get(e.projectId) ?? [];
           list.push({
             id: e.id,
-            entityId: e.entityId,
+            entityId: e.externalId,
             displayName: e.displayName,
             connectionStatus: e.connectionStatus,
             lastConnectedAt: e.lastConnectedAt,

--- a/apps/agent/src/mcp-platform/tools/alert_channels.ts
+++ b/apps/agent/src/mcp-platform/tools/alert_channels.ts
@@ -1,219 +1,30 @@
 /**
- * Theme MCPF-W4 — Alert channel management MCP tools (6 tools).
- *
- * Wraps `ProjectAlertChannel` — the trigger.dev failure-notification surface
- * (EMAIL, SLACK, WEBHOOK). Channels are PROJECT-scoped (no environmentId);
- * each channel routes alerts for any matching `environmentTypes` (DEVELOPMENT,
- * STAGING, PRODUCTION) within its project.
- *
- * Tools:
- *   • `alert_channels.list`             — list channels for the scope's project
- *   • `alert_channels.create`           — register an EMAIL/SLACK/WEBHOOK channel (gated)
- *   • `alert_channels.update`           — patch channel config (gated)
- *   • `alert_channels.delete`           — remove a channel (gated)
- *   • `alert_channels.test`             — send a synthetic test (WEBHOOK supported here;
- *                                         SLACK + EMAIL deferred to webapp delivery service)
- *   • `alert_channels.get_integration`  — inspect linked OAuth integration metadata
- *                                         (NEVER returns the access token)
- *
- * Tier-1 require_approval (set in `permission-gateway.service.ts`
- * PLATFORM_TIER_MINIMUMS):
- *   - alert_channels.create
- *   - alert_channels.update
- *   - alert_channels.delete
- *
- * Audit logging: mutations record channel `type` + `name` + masked URL host
- * only. Webhook URLs, Slack channelIds, and access tokens are NEVER echoed
- * into audit rows.
+ * Alert-channel persistence belongs to the paused WIN-124 cutover. Keep the
+ * registered MCP surface stable, but fail before reading or writing legacy
+ * ProjectAlertChannel / OrganizationIntegration rows or handling secrets.
  */
 
-import { createCipheriv, createHmac, randomBytes } from "node:crypto";
-import { env } from "../../shared/env";
-import {
-  validatePublicUrl,
-  describeUrlValidationError,
-} from "../../shared/url-validator";
-import type { McpToolHandler } from "../mcp-router";
-import type { RequestScope } from "../../auth/scope.guard";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
+import type { McpToolHandler } from "../mcp-router";
 
-type ChannelType = "EMAIL" | "SLACK" | "WEBHOOK";
-const CHANNEL_TYPES = new Set<ChannelType>(["EMAIL", "SLACK", "WEBHOOK"]);
-
-const ALERT_TYPES = new Set([
-  "TASK_RUN",
-  "TASK_RUN_ATTEMPT",
-  "DEPLOYMENT_FAILURE",
-  "DEPLOYMENT_SUCCESS",
-  "ERROR_GROUP",
-]);
-
-const ENV_TYPES = new Set(["DEVELOPMENT", "STAGING", "PRODUCTION", "PREVIEW"]);
-
-type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
-
-function tuple(scope: RequestScope): ScopeTuple {
+function alertChannelsUnavailable() {
   return {
-    organizationId: scope.organizationId,
-    projectId: scope.projectId,
-    environmentId: scope.environmentId,
-  };
+    error: "unavailable",
+    message:
+      "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
+  } as const;
 }
 
-/**
- * Mask a URL to host:port only — never echo the path or query string into
- * audit rows. `https://hooks.slack.com/services/T01/B01/secret` → `hooks.slack.com`.
- */
-function maskUrlHost(url: string | undefined | null): string | null {
-  if (!url || typeof url !== "string") return null;
-  try {
-    const u = new URL(url);
-    return u.host;
-  } catch {
-    return "invalid_url";
-  }
-}
-
-/**
- * Friendly id generator — mirrors `generateFriendlyId("alert_channel")` in
- * the webapp without dragging that dependency into the agent. Format
- * matches existing rows (`alert_channel_<22 chars>`).
- */
-function generateFriendlyId(prefix: string): string {
-  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-  let suffix = "";
-  const buf = randomBytes(22);
-  for (let i = 0; i < 22; i++) {
-    const byte = buf[i];
-    if (typeof byte === "number") {
-      suffix += chars[byte % chars.length];
-    }
-  }
-  return `${prefix}_${suffix}`;
-}
-
-interface EncryptedSecret {
-  nonce: string;
-  ciphertext: string;
-  tag: string;
-}
-
-/**
- * Encrypt a webhook secret using the WEBAPP-SHARED `ENCRYPTION_KEY` (32-byte
- * UTF-8 OR 64-hex-char). Output format matches webapp `encryptSecret` so
- * the deliverAlert webhook path can decrypt later.
- */
-function encryptWebhookSecret(plaintext: string): EncryptedSecret | null {
-  const raw = env.ENCRYPTION_KEY;
-  if (!raw) return null;
-  let key: Buffer;
-  if (raw.length === 64 && /^[0-9a-f]{64}$/i.test(raw)) {
-    key = Buffer.from(raw, "hex");
-  } else if (Buffer.from(raw, "utf8").length === 32) {
-    key = Buffer.from(raw, "utf8");
-  } else {
-    return null;
-  }
-  const nonce = randomBytes(12);
-  const cipher = createCipheriv("aes-256-gcm", key, nonce);
-  let encrypted = cipher.update(plaintext, "utf8", "hex");
-  encrypted += cipher.final("hex");
-  const tag = cipher.getAuthTag().toString("hex");
-  return {
-    nonce: nonce.toString("hex"),
-    ciphertext: encrypted,
-    tag,
-  };
-}
-
-/**
- * Public-facing channel shape — the underlying `properties` JSON contains
- * encrypted secrets we never want to leak through MCP. Convert to a safe
- * subset before returning.
- */
-function publicChannel(row: Record<string, any>): Record<string, unknown> {
-  const props = (row["properties"] as Record<string, any> | null) ?? {};
-  let safeProps: Record<string, unknown>;
-  switch (row["type"]) {
-    case "EMAIL":
-      safeProps = { email: props["email"] ?? null };
-      break;
-    case "SLACK":
-      safeProps = {
-        channelId: props["channelId"] ?? null,
-        channelName: props["channelName"] ?? null,
-        integrationId: props["integrationId"] ?? null,
-      };
-      break;
-    case "WEBHOOK":
-      safeProps = {
-        url: props["url"] ?? null,
-        // `secret` is { nonce, ciphertext, tag } — surface presence only,
-        // never the encrypted payload itself.
-        hasSecret: !!props["secret"],
-        version: props["version"] ?? null,
-      };
-      break;
-    default:
-      safeProps = {};
-  }
-  return {
-    id: row["id"],
-    friendlyId: row["friendlyId"],
-    type: row["type"],
-    name: row["name"],
-    enabled: row["enabled"],
-    alertTypes: row["alertTypes"] ?? [],
-    environmentTypes: row["environmentTypes"] ?? [],
-    properties: safeProps,
-    integrationId: row["integrationId"] ?? null,
-    deduplicationKey: row["deduplicationKey"] ?? null,
-    userProvidedDeduplicationKey: row["userProvidedDeduplicationKey"] ?? false,
-    createdAt: row["createdAt"] instanceof Date ? row["createdAt"].toISOString() : row["createdAt"],
-    updatedAt: row["updatedAt"] instanceof Date ? row["updatedAt"].toISOString() : row["updatedAt"],
-  };
-}
-
-export function buildAlertChannelToolHandlers(deps: {
+export function buildAlertChannelToolHandlers(_deps: {
   toolAudit: ToolAuditService;
   prisma: any;
 }): McpToolHandler[] {
-  const { toolAudit, prisma } = deps;
-
-  function auditMutation(
-    scope: RequestScope,
-    toolName: string,
-    args: Record<string, unknown>,
-    result: unknown,
-    status: "success" | "failed",
-    startedAt: number,
-    error?: string,
-  ): void {
-    toolAudit
-      .record({
-        scope: tuple(scope),
-        toolName,
-        userId: scope.userId ?? null,
-        args,
-        result,
-        ...(error !== undefined ? { error } : {}),
-        status,
-        latencyMs: Date.now() - startedAt,
-        source: "mcp_platform",
-      })
-      .catch(() => undefined);
-  }
-
   return [
     {
       name: "alert_channels.list",
       description:
-        "List `ProjectAlertChannel` rows for the caller's project. " +
-        "Channels are project-scoped (one channel routes alerts across " +
-        "every environment type listed in `environmentTypes`). Optional " +
-        "`type` narrows by EMAIL / SLACK / WEBHOOK; `enabled` filters by " +
-        "active status. Webhook secrets + Slack tokens are stripped — " +
-        "WEBHOOK rows surface only `url` + `hasSecret`.",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         properties: {
@@ -223,449 +34,74 @@ export function buildAlertChannelToolHandlers(deps: {
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const reqScope = scope as RequestScope;
-        const where: Record<string, unknown> = { projectId: reqScope.projectId };
-        if (typeof params["type"] === "string") where["type"] = String(params["type"]);
-        if (typeof params["enabled"] === "boolean") where["enabled"] = params["enabled"];
-        const limit = (params["limit"] as number | undefined) ?? 100;
-        const rows = await prisma.projectAlertChannel.findMany({
-          where,
-          orderBy: { createdAt: "desc" },
-          take: limit,
-        });
-        return {
-          channels: (rows as Array<Record<string, any>>).map((r) => publicChannel(r)),
-        };
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
-
     {
       name: "alert_channels.create",
       description:
-        "Register a new alert channel scoped to the caller's project. " +
-        "Required: `type` (EMAIL|SLACK|WEBHOOK), `name`, `alertTypes` (≥1 " +
-        "of TASK_RUN / DEPLOYMENT_FAILURE / DEPLOYMENT_SUCCESS / " +
-        "ERROR_GROUP), and `channel` (type-specific config). EMAIL: " +
-        "`{ email }`. WEBHOOK: `{ url, secret? }` — secret is encrypted " +
-        "with the webapp-shared ENCRYPTION_KEY before persistence; if " +
-        "omitted a 32-byte random secret is generated. SLACK: " +
-        "`{ channelId, channelName, integrationId? }` (operator must " +
-        "have already linked the Slack workspace via the dashboard — this " +
-        "tool does NOT initiate OAuth). Optional `environmentTypes` " +
-        "default to [STAGING, PRODUCTION]; `deduplicationKey` enables " +
-        "idempotent retries. Audit-logged (channel type + name + masked " +
-        "URL host — never the webhook URL path or any secret).",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["type", "name", "alertTypes", "channel"],
         properties: {
           type: { type: "string", enum: ["EMAIL", "SLACK", "WEBHOOK"] },
           name: { type: "string", minLength: 1, maxLength: 200 },
-          alertTypes: {
-            type: "array",
-            minItems: 1,
-            items: {
-              type: "string",
-              enum: ["TASK_RUN", "DEPLOYMENT_FAILURE", "DEPLOYMENT_SUCCESS", "ERROR_GROUP"],
-            },
-          },
-          environmentTypes: {
-            type: "array",
-            items: { type: "string", enum: ["DEVELOPMENT", "STAGING", "PRODUCTION", "PREVIEW"] },
-          },
+          alertTypes: { type: "array", minItems: 1, items: { type: "string" } },
+          environmentTypes: { type: "array", items: { type: "string" } },
           deduplicationKey: { type: "string", maxLength: 200 },
           channel: { type: "object" },
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const type = String(params["type"]) as ChannelType;
-        const name = String(params["name"]).trim();
-        const alertTypes = (params["alertTypes"] as string[]).filter((t) => ALERT_TYPES.has(t));
-        const environmentTypes = ((params["environmentTypes"] as string[] | undefined) ?? [
-          "STAGING",
-          "PRODUCTION",
-        ]).filter((t) => ENV_TYPES.has(t));
-        const deduplicationKey = params["deduplicationKey"] as string | undefined;
-        const channel = (params["channel"] as Record<string, any>) ?? {};
-
-        const auditArgs: Record<string, unknown> = {
-          type,
-          name,
-          alertTypeCount: alertTypes.length,
-          environmentTypeCount: environmentTypes.length,
-        };
-
-        if (!CHANNEL_TYPES.has(type)) {
-          const err = "type must be EMAIL | SLACK | WEBHOOK";
-          auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, err);
-          return { error: "invalid_type", message: err };
-        }
-        if (!name) {
-          auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "name_required");
-          return { error: "invalid_name", message: "name is required" };
-        }
-        if (alertTypes.length === 0) {
-          auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "no_alert_types");
-          return { error: "invalid_alert_types", message: "alertTypes must include at least one valid type" };
-        }
-
-        let properties: Record<string, unknown>;
-        let integrationId: string | null = null;
-        if (type === "EMAIL") {
-          if (typeof channel["email"] !== "string" || !channel["email"].includes("@")) {
-            auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "invalid_email");
-            return { error: "invalid_email", message: "channel.email is required for EMAIL channels" };
-          }
-          properties = { email: String(channel["email"]).trim() };
-        } else if (type === "WEBHOOK") {
-          const url = channel["url"];
-          if (typeof url !== "string" || !/^https?:\/\//i.test(url)) {
-            auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "invalid_url");
-            return { error: "invalid_url", message: "channel.url must be an absolute http(s) URL" };
-          }
-          // SSRF defence — reject URLs that resolve to private/loopback/IMDS
-          // ranges or use blocked infra ports. Same guard every other agent
-          // fetch path uses (events, budgets, skill-importer, tool-executor).
-          // This is a register-time check; `alert_channels.test` re-validates
-          // immediately before the actual fetch (DNS-rebinding defence).
-          const urlCheck = await validatePublicUrl(url);
-          if (!urlCheck.ok) {
-            (auditArgs as Record<string, unknown>)["urlHost"] = maskUrlHost(url);
-            auditMutation(
-              reqScope,
-              "alert_channels.create",
-              auditArgs,
-              null,
-              "failed",
-              startedAt,
-              `url_blocked:${urlCheck.error.kind}`,
-            );
-            return {
-              error: "url_blocked",
-              message: `channel.url rejected: ${describeUrlValidationError(urlCheck.error)}`,
-            };
-          }
-          // Secret: operator-supplied OR auto-generated (matches webapp behaviour).
-          const plaintext = typeof channel["secret"] === "string" && channel["secret"].length > 0
-            ? String(channel["secret"])
-            : randomBytes(32).toString("hex");
-          const encrypted = encryptWebhookSecret(plaintext);
-          if (!encrypted) {
-            auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "encryption_unavailable");
-            return {
-              error: "encryption_unavailable",
-              message:
-                "ENCRYPTION_KEY is not configured on this agent. Set it (matching the webapp value) to register webhook channels with secrets.",
-            };
-          }
-          properties = { url, secret: encrypted, version: "v2" };
-          (auditArgs as Record<string, unknown>)["urlHost"] = maskUrlHost(url);
-        } else {
-          // SLACK
-          if (typeof channel["channelId"] !== "string" || typeof channel["channelName"] !== "string") {
-            auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "invalid_slack_payload");
-            return { error: "invalid_slack_payload", message: "SLACK channels require channelId + channelName" };
-          }
-          properties = {
-            channelId: String(channel["channelId"]).trim(),
-            channelName: String(channel["channelName"]).trim(),
-            integrationId: channel["integrationId"] ?? null,
-          };
-          if (typeof channel["integrationId"] === "string") {
-            // Validate the integration belongs to the caller's org.
-            const integ = await prisma.organizationIntegration.findFirst({
-              where: { id: String(channel["integrationId"]), organizationId: reqScope.organizationId },
-              select: { id: true },
-            });
-            if (!integ) {
-              auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, "integration_not_found");
-              return {
-                error: "integration_not_found",
-                message: "channel.integrationId does not match any integration in this organization",
-              };
-            }
-            integrationId = integ.id;
-          }
-        }
-
-        // Dedup: same key on this project upserts (matches CreateAlertChannelService).
-        if (deduplicationKey) {
-          const existing = await prisma.projectAlertChannel.findFirst({
-            where: { projectId: reqScope.projectId, deduplicationKey },
-            select: { id: true },
-          });
-          if (existing) {
-            const updated = await prisma.projectAlertChannel.update({
-              where: { id: existing.id },
-              data: {
-                name,
-                type,
-                properties,
-                alertTypes,
-                environmentTypes,
-                enabled: true,
-                ...(integrationId ? { integrationId } : {}),
-              },
-            });
-            const result = publicChannel(updated as Record<string, any>);
-            auditMutation(
-              reqScope,
-              "alert_channels.create",
-              auditArgs,
-              { id: updated.id, upserted: true },
-              "success",
-              startedAt,
-            );
-            return { ...result, upserted: true };
-          }
-        }
-
-        try {
-          const created = await prisma.projectAlertChannel.create({
-            data: {
-              friendlyId: generateFriendlyId("alert_channel"),
-              projectId: reqScope.projectId,
-              name,
-              type,
-              properties,
-              alertTypes,
-              environmentTypes,
-              enabled: true,
-              ...(integrationId ? { integrationId } : {}),
-              ...(deduplicationKey
-                ? { deduplicationKey, userProvidedDeduplicationKey: true }
-                : {}),
-            },
-          });
-          const result = publicChannel(created as Record<string, any>);
-          auditMutation(reqScope, "alert_channels.create", auditArgs, { id: created.id }, "success", startedAt);
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "alert_channels.create", auditArgs, null, "failed", startedAt, message);
-          if (/unique/i.test(message) || err?.code === "P2002") {
-            return { error: "already_exists", message: "A channel with this deduplicationKey already exists in the project." };
-          }
-          return { error: "create_failed", message };
-        }
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
-
     {
       name: "alert_channels.update",
       description:
-        "Patch an existing alert channel by id. Mutable fields: `name`, " +
-        "`alertTypes`, `environmentTypes`, `enabled`, and the type-specific " +
-        "`channel` payload (matches the create-time shape). The channel " +
-        "`type` itself is immutable — delete + recreate to switch (e.g. " +
-        "EMAIL → WEBHOOK). Secrets follow the same encryption path as " +
-        "create. Returns `{ error: 'not_found' }` for unknown / cross-project " +
-        "ids. Audit-logged.",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["id"],
         properties: {
           id: { type: "string" },
           name: { type: "string", minLength: 1, maxLength: 200 },
-          alertTypes: {
-            type: "array",
-            items: {
-              type: "string",
-              enum: ["TASK_RUN", "DEPLOYMENT_FAILURE", "DEPLOYMENT_SUCCESS", "ERROR_GROUP"],
-            },
-          },
-          environmentTypes: {
-            type: "array",
-            items: { type: "string", enum: ["DEVELOPMENT", "STAGING", "PRODUCTION", "PREVIEW"] },
-          },
+          alertTypes: { type: "array", items: { type: "string" } },
+          environmentTypes: { type: "array", items: { type: "string" } },
           enabled: { type: "boolean" },
           channel: { type: "object" },
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const id = String(params["id"]);
-        const auditArgs: Record<string, unknown> = { id };
-
-        const existing = await prisma.projectAlertChannel.findFirst({
-          where: { id, projectId: reqScope.projectId },
-          select: { id: true, type: true, name: true, properties: true, integrationId: true },
-        });
-        if (!existing) {
-          auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "not_found");
-          return { error: "not_found", id };
-        }
-
-        const data: Record<string, unknown> = {};
-        if (typeof params["name"] === "string") {
-          data["name"] = String(params["name"]).trim();
-          (auditArgs as Record<string, unknown>)["name"] = data["name"];
-        }
-        if (Array.isArray(params["alertTypes"])) {
-          const filtered = (params["alertTypes"] as string[]).filter((t) => ALERT_TYPES.has(t));
-          if (filtered.length === 0) {
-            auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "no_alert_types");
-            return { error: "invalid_alert_types", message: "alertTypes must include at least one valid type" };
-          }
-          data["alertTypes"] = filtered;
-        }
-        if (Array.isArray(params["environmentTypes"])) {
-          data["environmentTypes"] = (params["environmentTypes"] as string[]).filter((t) =>
-            ENV_TYPES.has(t),
-          );
-        }
-        if (typeof params["enabled"] === "boolean") data["enabled"] = params["enabled"];
-
-        const channel = params["channel"] as Record<string, any> | undefined;
-        if (channel) {
-          const t = existing.type as ChannelType;
-          (auditArgs as Record<string, unknown>)["channelType"] = t;
-          if (t === "EMAIL" && typeof channel["email"] === "string") {
-            if (!channel["email"].includes("@")) {
-              auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "invalid_email");
-              return { error: "invalid_email", message: "channel.email must contain '@'" };
-            }
-            data["properties"] = { ...(existing.properties as object), email: String(channel["email"]).trim() };
-          } else if (t === "WEBHOOK") {
-            const merged: Record<string, unknown> = { ...(existing.properties as object) };
-            if (typeof channel["url"] === "string") {
-              if (!/^https?:\/\//i.test(channel["url"])) {
-                auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "invalid_url");
-                return { error: "invalid_url", message: "channel.url must be an absolute http(s) URL" };
-              }
-              // SSRF defence — same guard as `alert_channels.create`. Reject
-              // private/loopback/IMDS ranges + blocked infra ports.
-              const urlCheck = await validatePublicUrl(channel["url"]);
-              if (!urlCheck.ok) {
-                (auditArgs as Record<string, unknown>)["urlHost"] = maskUrlHost(channel["url"]);
-                auditMutation(
-                  reqScope,
-                  "alert_channels.update",
-                  auditArgs,
-                  null,
-                  "failed",
-                  startedAt,
-                  `url_blocked:${urlCheck.error.kind}`,
-                );
-                return {
-                  error: "url_blocked",
-                  message: `channel.url rejected: ${describeUrlValidationError(urlCheck.error)}`,
-                };
-              }
-              merged["url"] = channel["url"];
-              (auditArgs as Record<string, unknown>)["urlHost"] = maskUrlHost(channel["url"]);
-            }
-            if (typeof channel["secret"] === "string" && channel["secret"].length > 0) {
-              const encrypted = encryptWebhookSecret(String(channel["secret"]));
-              if (!encrypted) {
-                auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "encryption_unavailable");
-                return { error: "encryption_unavailable", message: "ENCRYPTION_KEY missing on agent" };
-              }
-              merged["secret"] = encrypted;
-              merged["version"] = "v2";
-            }
-            data["properties"] = merged;
-          } else if (t === "SLACK") {
-            const merged: Record<string, unknown> = { ...(existing.properties as object) };
-            if (typeof channel["channelId"] === "string") merged["channelId"] = String(channel["channelId"]).trim();
-            if (typeof channel["channelName"] === "string") merged["channelName"] = String(channel["channelName"]).trim();
-            if (typeof channel["integrationId"] === "string") {
-              const integ = await prisma.organizationIntegration.findFirst({
-                where: { id: String(channel["integrationId"]), organizationId: reqScope.organizationId },
-                select: { id: true },
-              });
-              if (!integ) {
-                auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "integration_not_found");
-                return { error: "integration_not_found", message: "channel.integrationId does not match any org integration" };
-              }
-              merged["integrationId"] = integ.id;
-              data["integrationId"] = integ.id;
-            }
-            data["properties"] = merged;
-          }
-        }
-
-        if (Object.keys(data).length === 0) {
-          auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, "no_op");
-          return { error: "no_changes", message: "supply at least one field to update" };
-        }
-
-        try {
-          const updated = await prisma.projectAlertChannel.update({ where: { id }, data });
-          const result = publicChannel(updated as Record<string, any>);
-          auditMutation(reqScope, "alert_channels.update", auditArgs, { id: updated.id }, "success", startedAt);
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "alert_channels.update", auditArgs, null, "failed", startedAt, message);
-          return { error: "update_failed", message };
-        }
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
-
     {
       name: "alert_channels.delete",
       description:
-        "Remove an alert channel by id. Cascades through " +
-        "`ProjectAlert` + `ProjectAlertStorage` rows attached to this " +
-        "channel (foreign keys are ON DELETE CASCADE). Returns " +
-        "`{ error: 'not_found' }` for unknown / cross-project ids. " +
-        "Audit-logged.",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["id"],
         properties: { id: { type: "string" } },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const id = String(params["id"]);
-        const existing = await prisma.projectAlertChannel.findFirst({
-          where: { id, projectId: reqScope.projectId },
-          select: { id: true, type: true, name: true },
-        });
-        if (!existing) {
-          auditMutation(reqScope, "alert_channels.delete", { id }, null, "failed", startedAt, "not_found");
-          return { error: "not_found", id };
-        }
-        try {
-          await prisma.projectAlertChannel.delete({ where: { id } });
-          const result = { deleted: true, id, type: existing.type, name: existing.name };
-          auditMutation(
-            reqScope,
-            "alert_channels.delete",
-            { id, type: existing.type, name: existing.name },
-            result,
-            "success",
-            startedAt,
-          );
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "alert_channels.delete", { id }, null, "failed", startedAt, message);
-          return { error: "delete_failed", message };
-        }
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
-
     {
       name: "alert_channels.test",
       description:
-        "Send a synthetic test notification to a channel. Currently " +
-        "supports WEBHOOK channels — the agent decrypts the channel's " +
-        "secret + signs a `{ type: 'test', message }` payload with " +
-        "HMAC-SHA-256 + POSTs to the configured URL. EMAIL + SLACK tests " +
-        "delegate to the webapp delivery service (returns " +
-        "`{ supported: false }` until the webapp ships a test endpoint). " +
-        "Returns `{ ok, status, latencyMs, urlHost }`. NEVER echoes the " +
-        "webhook URL or secret in the response.",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -675,214 +111,23 @@ export function buildAlertChannelToolHandlers(deps: {
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const reqScope = scope as RequestScope;
-        const id = String(params["id"]);
-        const message = (params["message"] as string | undefined) ?? "Test notification from Platos MCP";
-
-        const channel = await prisma.projectAlertChannel.findFirst({
-          where: { id, projectId: reqScope.projectId },
-          select: { id: true, type: true, properties: true, name: true, enabled: true },
-        });
-        if (!channel) return { error: "not_found", id };
-        if (!channel.enabled) {
-          return { ok: false, supported: true, error: "channel_disabled", message: "Channel is disabled" };
-        }
-
-        if (channel.type === "EMAIL") {
-          return {
-            supported: false,
-            type: "EMAIL",
-            message:
-              "EMAIL test delivery is owned by the webapp's deliverAlert service. " +
-              "Use the dashboard 'Send test email' button or trigger a real alert.",
-          };
-        }
-        if (channel.type === "SLACK") {
-          return {
-            supported: false,
-            type: "SLACK",
-            message:
-              "SLACK test delivery requires the webapp's OAuth integration repository " +
-              "(token resolution lives in apps/webapp). Trigger a real alert or use the dashboard.",
-          };
-        }
-
-        // WEBHOOK path — agent can encrypt + decrypt + POST directly.
-        const props = (channel.properties as Record<string, any>) ?? {};
-        const url = props["url"] as string | undefined;
-        const secret = props["secret"] as EncryptedSecret | undefined;
-        const urlHost = maskUrlHost(url ?? null);
-        if (!url || !secret) {
-          return { ok: false, error: "missing_webhook_config", urlHost };
-        }
-        // SSRF defence-in-depth — re-validate immediately before fetch even
-        // though create/update already validated. Catches DNS rebinding (a
-        // public hostname that re-resolves to 169.254.169.254 after admin
-        // approval but before the test runs) and rows that may have been
-        // written by older code paths predating the create-time check.
-        const urlCheck = await validatePublicUrl(url);
-        if (!urlCheck.ok) {
-          return {
-            ok: false,
-            error: "url_blocked",
-            urlHost,
-            message: `webhook URL rejected: ${describeUrlValidationError(urlCheck.error)}`,
-          };
-        }
-        // Decrypt the secret using the same ENCRYPTION_KEY the webapp wrote it with.
-        const raw = env.ENCRYPTION_KEY;
-        if (!raw) {
-          return {
-            ok: false,
-            error: "encryption_unavailable",
-            urlHost,
-            message: "ENCRYPTION_KEY not set on agent — cannot decrypt webhook secret",
-          };
-        }
-        let key: Buffer;
-        if (raw.length === 64 && /^[0-9a-f]{64}$/i.test(raw)) {
-          key = Buffer.from(raw, "hex");
-        } else if (Buffer.from(raw, "utf8").length === 32) {
-          key = Buffer.from(raw, "utf8");
-        } else {
-          return { ok: false, error: "encryption_unavailable", urlHost };
-        }
-
-        let plaintextSecret: string;
-        try {
-          const { createDecipheriv } = await import("node:crypto");
-          const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(secret.nonce, "hex"));
-          decipher.setAuthTag(Buffer.from(secret.tag, "hex"));
-          let plain = decipher.update(secret.ciphertext, "hex", "utf8");
-          plain += decipher.final("utf8");
-          plaintextSecret = plain;
-        } catch (err: any) {
-          return {
-            ok: false,
-            error: "decrypt_failed",
-            urlHost,
-            message: "Failed to decrypt webhook secret — likely an ENCRYPTION_KEY mismatch with the webapp",
-          };
-        }
-
-        const payload = {
-          type: "test",
-          message,
-          channelId: channel.id,
-          channelName: channel.name,
-          sentAt: new Date().toISOString(),
-        };
-        const rawBody = JSON.stringify(payload);
-        const signature = createHmac("sha256", plaintextSecret).update(rawBody).digest("hex");
-
-        const start = Date.now();
-        try {
-          const resp = await fetch(url, {
-            method: "POST",
-            headers: {
-              "content-type": "application/json",
-              // Same header name the webapp deliverAlert path emits, so
-              // operator-side webhooks already validating the signature
-              // will accept this test.
-              "x-trigger-signature-hmacsha256": signature,
-              "x-platos-test": "1",
-            },
-            body: rawBody,
-            signal: AbortSignal.timeout(5000),
-          });
-          const latencyMs = Date.now() - start;
-          return {
-            ok: resp.ok,
-            status: resp.status,
-            statusText: resp.statusText,
-            latencyMs,
-            urlHost,
-            type: "WEBHOOK",
-          };
-        } catch (err: any) {
-          return {
-            ok: false,
-            error: "fetch_failed",
-            message: err?.message ?? String(err),
-            latencyMs: Date.now() - start,
-            urlHost,
-            type: "WEBHOOK",
-          };
-        }
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
-
     {
       name: "alert_channels.get_integration",
       description:
-        "Inspect the OAuth integration linked to a channel (SLACK + " +
-        "future Discord etc). Returns `{ provider, externalOrgId, " +
-        "integrationId, lastUpdatedAt, hasToken }` — NEVER returns the " +
-        "OAuth access token. EMAIL + WEBHOOK channels return " +
-        "`{ linked: false }` (they don't carry an OAuth integration). " +
-        "Returns `{ error: 'not_found' }` for unknown / cross-project ids.",
+        "Alert channel management is unavailable pending the canonical " +
+        "WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["id"],
         properties: { id: { type: "string" } },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const reqScope = scope as RequestScope;
-        const id = String(params["id"]);
-        const channel = await prisma.projectAlertChannel.findFirst({
-          where: { id, projectId: reqScope.projectId },
-          select: {
-            id: true,
-            type: true,
-            integrationId: true,
-            integration: {
-              select: {
-                id: true,
-                friendlyId: true,
-                service: true,
-                externalOrganizationId: true,
-                organizationId: true,
-                tokenReferenceId: true,
-                createdAt: true,
-                updatedAt: true,
-                deletedAt: true,
-              },
-            },
-          },
-        });
-        if (!channel) return { error: "not_found", id };
-        if (!channel.integration) {
-          return { linked: false, channelId: channel.id, channelType: channel.type };
-        }
-        const integ = channel.integration as Record<string, any>;
-        // Defence-in-depth: confirm the integration belongs to the caller's
-        // organization. This SHOULD always be true (channels live in the
-        // project's org) but we double-check rather than trust the join.
-        if (integ["organizationId"] !== reqScope.organizationId) {
-          return { error: "not_found", id };
-        }
-        return {
-          linked: true,
-          channelId: channel.id,
-          channelType: channel.type,
-          integration: {
-            id: integ["id"],
-            friendlyId: integ["friendlyId"],
-            provider: integ["service"],
-            externalOrganizationId: integ["externalOrganizationId"],
-            // Token presence flag; never the token itself.
-            hasToken: !!integ["tokenReferenceId"],
-            createdAt: integ["createdAt"] instanceof Date ? integ["createdAt"].toISOString() : integ["createdAt"],
-            updatedAt: integ["updatedAt"] instanceof Date ? integ["updatedAt"].toISOString() : integ["updatedAt"],
-            deletedAt: integ["deletedAt"]
-              ? integ["deletedAt"] instanceof Date
-                ? integ["deletedAt"].toISOString()
-                : integ["deletedAt"]
-              : null,
-          },
-        };
+      async execute() {
+        return alertChannelsUnavailable();
       },
     },
   ];

--- a/apps/agent/src/mcp-platform/tools/channel-apps-import.test.ts
+++ b/apps/agent/src/mcp-platform/tools/channel-apps-import.test.ts
@@ -1,70 +1,7 @@
-/**
- * Connect v3 (operator install tier) — channel_apps.* install-import MCP tools.
- *
- * The tool surface (import_installation / revoke_installation /
- * installations_status) mirrors the REST controller byte-for-byte per the file's
- * own contract; these focused tests pin the tool-specific wiring: scope is taken
- * from the verified token (never args), the bot token is encrypted with the same
- * envelope, import is idempotent + scope-guarded, and the status tool reflects a
- * soft-revoke. Mirrors the REST test's harness.
- */
-import { describe, it, expect, beforeEach } from "vitest";
-import { buildChannelAppToolHandlers } from "./channel-apps";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { McpToolHandler } from "../mcp-router";
+import { buildChannelAppToolHandlers } from "./channel-apps";
 
-const matches = (row: any, where: Record<string, unknown>): boolean =>
-  Object.entries(where).every(([k, v]) => row[k] === v);
-
-function makePrisma(apps: any[]) {
-  const installs: any[] = [];
-  const agents: any[] = [];
-  let seq = 0;
-  return {
-    apps,
-    installs,
-    agents,
-    platosChannelApp: {
-      findFirst: async ({ where }: any) => apps.find((a) => matches(a, where)) ?? null,
-    },
-    platosAgent: {
-      findFirst: async ({ where }: any) => agents.find((a) => matches(a, where)) ?? null,
-    },
-    platosChannelInstallation: {
-      findFirst: async ({ where }: any) => installs.find((r) => matches(r, where)) ?? null,
-      findMany: async ({ where }: any) => installs.filter((r) => matches(r, where)),
-      create: async ({ data }: any) => {
-        const row = {
-          id: `inst_${++seq}`,
-          teamId: null,
-          enterpriseId: null,
-          isEnterpriseInstall: false,
-          teamName: null,
-          botUserId: null,
-          grantedScopes: [],
-          installedByUserId: null,
-          agentId: null,
-          agentRouting: null,
-          status: "active",
-          revokedAt: null,
-          lastEventAt: null,
-          ...data,
-        };
-        installs.push(row);
-        return row;
-      },
-      update: async ({ where, data }: any) => {
-        const row = installs.find((r) => r.id === where.id);
-        Object.assign(row, data);
-        return row;
-      },
-    },
-  };
-}
-
-const messageCrypto = {
-  encryptJsonField: (v: unknown) => ({ __enc: true, v }),
-  decryptJsonField: (e: any) => e?.v,
-} as any;
 const toolAudit = { record: async () => undefined } as any;
 
 const SCOPE = {
@@ -76,100 +13,224 @@ const SCOPE = {
 };
 const TOKEN = {} as any;
 
-function tools(prisma: any): Record<string, McpToolHandler> {
-  const handlers = buildChannelAppToolHandlers({ prisma, messageCrypto, toolAudit });
-  return Object.fromEntries(handlers.map((h) => [h.name, h]));
+type Installation = {
+  id: string;
+  appId: string;
+  teamId: string | null;
+  enterpriseId: string | null;
+  isEnterpriseInstall: boolean;
+  teamName: string | null;
+  botToken: string;
+  refreshToken: string | null;
+  tokenExpiresAt: Date | null;
+  botUserId: string | null;
+  grantedScopes: string[];
+  installedByUserId: string | null;
+  agentId: string | null;
+  agentRouting: unknown;
+  status: string;
+  revokedAt: Date | null;
+  lastEventAt: Date | null;
+};
+
+function app() {
+  return {
+    id: "app1",
+    organizationId: "org1",
+    projectId: "proj1",
+    environmentId: "env1",
+    provider: "slack",
+    defaultAgentId: null,
+  };
 }
 
-const app = () => ({
-  id: "app1",
-  organizationId: "org1",
-  projectId: "proj1",
-  environmentId: "env1",
-  provider: "slack",
-  defaultAgentId: null,
-});
+function harness() {
+  const apps = [app()];
+  const installs: Installation[] = [];
+  let sequence = 0;
+  const loadScopedApp = async (scope: typeof SCOPE, appId: string) =>
+    apps.find(
+      (candidate) =>
+        candidate.id === appId &&
+        candidate.organizationId === scope.organizationId &&
+        candidate.projectId === scope.projectId &&
+        candidate.environmentId === scope.environmentId,
+    ) ?? null;
+  const loadApp = async (appId: string) => apps.find((candidate) => candidate.id === appId) ?? null;
+  const loadInstallation = async (installationId: string, appId?: string) =>
+    installs.find(
+      (installation) =>
+        installation.id === installationId && (!appId || installation.appId === appId),
+    ) ?? null;
+
+  const channelPersistence = {
+    loadScopedApp,
+    loadApp,
+    loadInstallation,
+    listInstallations: async (scope: typeof SCOPE, appId: string) =>
+      (await loadScopedApp(scope, appId))
+        ? installs.filter((installation) => installation.appId === appId)
+        : null,
+    upsertInstallationGrant: async (
+      appRow: ReturnType<typeof app>,
+      coordinates: {
+        teamId: string | null;
+        enterpriseId: string | null;
+        isEnterpriseInstall: boolean;
+      },
+      grant: {
+        botToken: string;
+        refreshToken?: string | null;
+        tokenExpiresAt?: Date | null;
+        botUserId?: string | null;
+        grantedScopes: string[];
+        displayName?: string | null;
+        installedByUserId?: string | null;
+        defaultAgentId?: string | null;
+        agentRouting?: unknown;
+      },
+    ) => {
+      let installation = installs.find(
+        (candidate) =>
+          candidate.appId === appRow.id &&
+          candidate.teamId === coordinates.teamId &&
+          candidate.enterpriseId === coordinates.enterpriseId,
+      );
+      if (!installation) {
+        installation = {
+          id: `inst_${++sequence}`,
+          appId: appRow.id,
+          teamId: coordinates.teamId,
+          enterpriseId: coordinates.enterpriseId,
+          isEnterpriseInstall: coordinates.isEnterpriseInstall,
+          teamName: grant.displayName ?? null,
+          botToken: grant.botToken,
+          refreshToken: grant.refreshToken ?? null,
+          tokenExpiresAt: grant.tokenExpiresAt ?? null,
+          botUserId: grant.botUserId ?? null,
+          grantedScopes: grant.grantedScopes,
+          installedByUserId: grant.installedByUserId ?? null,
+          agentId: grant.defaultAgentId ?? null,
+          agentRouting: grant.agentRouting ?? null,
+          status: "active",
+          revokedAt: null,
+          lastEventAt: null,
+        };
+        installs.push(installation);
+      } else {
+        Object.assign(installation, {
+          isEnterpriseInstall: coordinates.isEnterpriseInstall,
+          teamName: grant.displayName ?? null,
+          botToken: grant.botToken,
+          refreshToken: grant.refreshToken ?? null,
+          tokenExpiresAt: grant.tokenExpiresAt ?? null,
+          botUserId: grant.botUserId ?? null,
+          grantedScopes: grant.grantedScopes,
+          installedByUserId: grant.installedByUserId ?? null,
+          status: "active",
+          revokedAt: null,
+          ...(grant.defaultAgentId !== undefined ? { agentId: grant.defaultAgentId } : {}),
+          ...(grant.agentRouting !== undefined ? { agentRouting: grant.agentRouting } : {}),
+        });
+      }
+      return installation;
+    },
+    revokeInstallation: async (scope: typeof SCOPE, appId: string, installationId: string) => {
+      if (!(await loadScopedApp(scope, appId))) return null;
+      const installation = await loadInstallation(installationId, appId);
+      if (!installation) return null;
+      installation.status = "revoked";
+      installation.revokedAt = new Date();
+      return installation;
+    },
+  };
+  const prisma = { agentBinding: { findFirst: async () => null } } as any;
+  const handlers = buildChannelAppToolHandlers({
+    prisma,
+    channelPersistence: channelPersistence as any,
+    toolAudit,
+  });
+  return {
+    installs,
+    tools: Object.fromEntries(handlers.map((handler) => [handler.name, handler])) as Record<
+      string,
+      McpToolHandler
+    >,
+  };
+}
 
 describe("channel_apps.import_installation (MCP)", () => {
-  let prisma: any;
-  let t: Record<string, McpToolHandler>;
+  let h: ReturnType<typeof harness>;
 
   beforeEach(() => {
-    prisma = makePrisma([app()]);
-    t = tools(prisma);
+    h = harness();
   });
 
-  it("exposes the three new tools", () => {
-    expect(t["channel_apps.import_installation"]).toBeTruthy();
-    expect(t["channel_apps.revoke_installation"]).toBeTruthy();
-    expect(t["channel_apps.installations_status"]).toBeTruthy();
+  it("exposes the three installation tools", () => {
+    expect(h.tools["channel_apps.import_installation"]).toBeTruthy();
+    expect(h.tools["channel_apps.revoke_installation"]).toBeTruthy();
+    expect(h.tools["channel_apps.installations_status"]).toBeTruthy();
   });
 
-  it("imports + encrypts the bot token, scope taken from the token", async () => {
-    const res: any = await t["channel_apps.import_installation"].execute(
+  it("imports the bot token through the canonical persistence boundary", async () => {
+    const result: any = await h.tools["channel_apps.import_installation"].execute(
       { appId: "app1", teamId: "T1", botToken: "xoxb-secret" },
       SCOPE,
       TOKEN,
     );
-    expect(res.hasBotToken).toBe(true);
-    expect(res.botToken).toBeUndefined();
-    expect(messageCrypto.decryptJsonField(JSON.parse(prisma.installs[0].botToken))).toBe(
-      "xoxb-secret",
-    );
+    expect(result.hasBotToken).toBe(true);
+    expect(result.botToken).toBeUndefined();
+    expect(h.installs[0].botToken).toBe("xoxb-secret");
   });
 
-  it("is idempotent on (appId, teamId, enterpriseId) and clears stale rotation state", async () => {
-    await t["channel_apps.import_installation"].execute(
+  it("is idempotent and clears stale rotating-grant state", async () => {
+    await h.tools["channel_apps.import_installation"].execute(
       { appId: "app1", teamId: "T1", botToken: "xoxb-1" },
       SCOPE,
       TOKEN,
     );
-    // Simulate rotation state left behind by a previous rotating OAuth install;
-    // a static-token re-import must clear it (getFreshBotToken keys the
-    // rotation decision off tokenExpiresAt).
-    prisma.installs[0].refreshToken = "old-refresh-envelope";
-    prisma.installs[0].tokenExpiresAt = new Date(Date.now() - 1000);
-    await t["channel_apps.import_installation"].execute(
+    h.installs[0].refreshToken = "old-refresh";
+    h.installs[0].tokenExpiresAt = new Date(Date.now() - 1000);
+    await h.tools["channel_apps.import_installation"].execute(
       { appId: "app1", teamId: "T1", botToken: "xoxb-2" },
       SCOPE,
       TOKEN,
     );
-    expect(prisma.installs.length).toBe(1);
-    expect(messageCrypto.decryptJsonField(JSON.parse(prisma.installs[0].botToken))).toBe("xoxb-2");
-    expect(prisma.installs[0].refreshToken).toBeNull();
-    expect(prisma.installs[0].tokenExpiresAt).toBeNull();
+    expect(h.installs).toHaveLength(1);
+    expect(h.installs[0]).toMatchObject({
+      botToken: "xoxb-2",
+      refreshToken: null,
+      tokenExpiresAt: null,
+    });
   });
 
   it("rejects a cross-scope appId", async () => {
-    const res: any = await t["channel_apps.import_installation"].execute(
+    const result: any = await h.tools["channel_apps.import_installation"].execute(
       { appId: "app1", teamId: "T1", botToken: "xoxb" },
       { ...SCOPE, organizationId: "orgX" },
       TOKEN,
     );
-    expect(res.error).toBe("not_found");
-    expect(prisma.installs.length).toBe(0);
+    expect(result.error).toBe("not_found");
+    expect(h.installs).toHaveLength(0);
   });
 
-  it("status tool reflects a soft-revoke and never leaks the token", async () => {
-    const imp: any = await t["channel_apps.import_installation"].execute(
+  it("reflects a soft revoke without leaking the token", async () => {
+    const imported: any = await h.tools["channel_apps.import_installation"].execute(
       { appId: "app1", teamId: "T1", teamName: "Acme", botToken: "xoxb" },
       SCOPE,
       TOKEN,
     );
-    let status: any = await t["channel_apps.installations_status"].execute(
+    await h.tools["channel_apps.revoke_installation"].execute(
+      { appId: "app1", installationId: imported.id },
+      SCOPE,
+      TOKEN,
+    );
+    const status: any = await h.tools["channel_apps.installations_status"].execute(
       { appId: "app1" },
       SCOPE,
       TOKEN,
     );
-    expect(status.installations[0]).toMatchObject({ teamId: "T1", status: "active" });
+    expect(status.installations[0]).toMatchObject({ teamId: "T1", status: "revoked" });
     expect(status.installations[0].botToken).toBeUndefined();
-
-    await t["channel_apps.revoke_installation"].execute(
-      { appId: "app1", installationId: imp.id },
-      SCOPE,
-      TOKEN,
-    );
-    status = await t["channel_apps.installations_status"].execute({ appId: "app1" }, SCOPE, TOKEN);
-    expect(status.installations[0].status).toBe("revoked");
   });
 });

--- a/apps/agent/src/mcp-platform/tools/channel-apps.ts
+++ b/apps/agent/src/mcp-platform/tools/channel-apps.ts
@@ -31,9 +31,10 @@
 
 import type { McpToolHandler } from "../mcp-router";
 import type { RequestScope } from "../../auth/scope.guard";
-import type { MessageCryptoService } from "../../monitoring/message-crypto.service";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
 import { validateAgentRouting } from "../../agent-runtime/channel-routing";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
+import type { ChannelPersistenceService } from "../../channels/channel-persistence.service";
 
 const APP_PROVIDERS = new Set(["slack"]);
 const DISTRIBUTIONS = new Set(["private", "public"]);
@@ -47,6 +48,18 @@ function scopeTuple(scope: RequestScope) {
     projectId: scope.projectId,
     environmentId: scope.environmentId,
   };
+}
+
+function agentBindingWhere(scope: RequestScope, agentId: string) {
+  return {
+    agentId,
+    environmentId: scope.environmentId,
+    environment: {
+      projectId: scope.projectId,
+      project: { organizationId: scope.organizationId },
+    },
+    agent: { projectId: scope.projectId },
+  } as const;
 }
 
 /**
@@ -70,9 +83,11 @@ function installUrl(appId: string): string | null {
 
 /** Project an app row — strip the two secret columns, surface set-booleans. */
 function projectApp(row: any) {
-  const { clientSecret, signingSecret, ...rest } = row;
+  const { clientSecret, signingSecret, credential, environment, ...rest } = row;
   void clientSecret;
   void signingSecret;
+  void credential;
+  void environment;
   return {
     ...rest,
     hasClientSecret: clientSecret != null,
@@ -82,9 +97,11 @@ function projectApp(row: any) {
 
 /** Project an installation row — strip the secret columns, surface set-booleans. */
 function projectInstallation(row: any) {
-  const { botToken, refreshToken, ...rest } = row;
+  const { botToken, refreshToken, credential, app, ...rest } = row;
   void botToken;
   void refreshToken;
+  void credential;
+  void app;
   return {
     ...rest,
     hasBotToken: botToken != null,
@@ -111,8 +128,8 @@ function normalizeScopes(raw: unknown): string[] | undefined {
 }
 
 export function buildChannelAppToolHandlers(deps: {
-  prisma: any;
-  messageCrypto: MessageCryptoService;
+  prisma: ControlDatabaseClient;
+  channelPersistence: ChannelPersistenceService;
   toolAudit: ToolAuditService;
   /**
    * Evict the channels RUNTIME's cached decrypted bot token(s) for an app
@@ -123,7 +140,7 @@ export function buildChannelAppToolHandlers(deps: {
    */
   invalidateApp?: (appId: string) => void;
 }): McpToolHandler[] {
-  const { prisma, messageCrypto, toolAudit } = deps;
+  const { prisma, channelPersistence, toolAudit } = deps;
 
   /** Best-effort runtime-cache eviction — never fails the mutation. */
   function evictApp(appId: string): void {
@@ -160,16 +177,11 @@ export function buildChannelAppToolHandlers(deps: {
 
   /** Forged-id guard — the agent must belong to this exact scope. */
   async function agentInScope(scope: RequestScope, agentId: string): Promise<boolean> {
-    const agent = await prisma.platosAgent.findFirst({
-      where: { id: agentId, ...scopeTuple(scope) },
+    const agent = await prisma.agentBinding.findFirst({
+      where: agentBindingWhere(scope, agentId),
       select: { id: true },
     });
     return !!agent;
-  }
-
-  /** Encrypt a single secret string into the stored envelope. */
-  function encryptSecret(plain: string): string {
-    return JSON.stringify(messageCrypto.encryptJsonField(plain));
   }
 
   /**
@@ -214,16 +226,33 @@ export function buildChannelAppToolHandlers(deps: {
     enterpriseId: string | null,
     data: Record<string, unknown>,
   ): Promise<any> {
-    const existing = await prisma.platosChannelInstallation.findFirst({
-      where: { appId, teamId, enterpriseId },
-      select: { id: true },
-    });
-    if (existing) {
-      return prisma.platosChannelInstallation.update({ where: { id: existing.id }, data });
-    }
-    return prisma.platosChannelInstallation.create({
-      data: { appId, teamId, enterpriseId, ...data },
-    });
+    const app = await channelPersistence.loadApp(appId);
+    if (!app) throw new Error("channel app not found");
+    return channelPersistence.upsertInstallationGrant(
+      app,
+      {
+        teamId,
+        enterpriseId,
+        isEnterpriseInstall: data["isEnterpriseInstall"] === true,
+      },
+      {
+        botToken: String(data["botToken"] ?? ""),
+        refreshToken: null,
+        botUserId: typeof data["botUserId"] === "string" ? data["botUserId"] : null,
+        grantedScopes: Array.isArray(data["grantedScopes"])
+          ? data["grantedScopes"].filter((value): value is string => typeof value === "string")
+          : [],
+        displayName: typeof data["teamName"] === "string" ? data["teamName"] : null,
+        installedByUserId:
+          typeof data["installedByUserId"] === "string" ? data["installedByUserId"] : null,
+        ...(Object.prototype.hasOwnProperty.call(data, "agentId")
+          ? { defaultAgentId: (data["agentId"] as string | null) ?? null }
+          : {}),
+        ...(Object.prototype.hasOwnProperty.call(data, "agentRouting")
+          ? { agentRouting: data["agentRouting"] }
+          : {}),
+      },
+    );
   }
 
   return [
@@ -395,21 +424,18 @@ export function buildChannelAppToolHandlers(deps: {
         }
 
         try {
-          const row = await prisma.platosChannelApp.create({
-            data: {
-              ...scopeTuple(scope),
-              provider,
-              clientId,
-              clientSecret: encryptSecret(clientSecret),
-              signingSecret: encryptSecret(signingSecret),
-              distribution,
-              ...(displayName !== undefined ? { displayName } : {}),
-              ...(scopes !== undefined ? { scopes } : {}),
-              ...(aiAppsSurface !== undefined ? { aiAppsSurface } : {}),
-              ...(linking !== undefined ? { linking } : {}),
-              ...(defaultAgentId ? { defaultAgentId } : {}),
-              ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
-            },
+          const row = await channelPersistence.createApp(scopeTuple(scope), {
+            provider,
+            clientId,
+            clientSecret,
+            signingSecret,
+            distribution,
+            ...(displayName !== undefined ? { displayName } : {}),
+            ...(scopes !== undefined ? { scopes } : {}),
+            ...(aiAppsSurface !== undefined ? { aiAppsSurface } : {}),
+            ...(linking !== undefined ? { linking } : {}),
+            ...(defaultAgentId ? { defaultAgentId } : {}),
+            ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
           });
           const result = { ...projectApp(row), installUrl: installUrl(row.id) };
           auditMutation(
@@ -445,10 +471,9 @@ export function buildChannelAppToolHandlers(deps: {
       async execute(params, scope) {
         const provider =
           typeof params["provider"] === "string" ? params["provider"].trim().toLowerCase() : undefined;
-        const rows = await prisma.platosChannelApp.findMany({
-          where: { ...scopeTuple(scope), ...(provider ? { provider } : {}) },
-          orderBy: { createdAt: "desc" },
-        });
+        const rows = (await channelPersistence.listApps(scopeTuple(scope))).filter(
+          (row) => !provider || row.provider === provider,
+        );
         return {
           apps: (rows as any[]).map((r) => ({ ...projectApp(r), installUrl: installUrl(r.id) })),
         };
@@ -469,9 +494,7 @@ export function buildChannelAppToolHandlers(deps: {
       async execute(params, scope) {
         const id = String(params["id"] ?? "").trim();
         if (!id) return { error: "invalid_params", message: "id required" };
-        const row = await prisma.platosChannelApp.findFirst({
-          where: { id, ...scopeTuple(scope) },
-        });
+        const row = await channelPersistence.loadScopedApp(scopeTuple(scope), id);
         if (!row) return { error: "not_found", id };
         return { ...projectApp(row), installUrl: installUrl(row.id) };
       },
@@ -576,10 +599,7 @@ export function buildChannelAppToolHandlers(deps: {
           return { error: "invalid_params", message: err };
         }
 
-        const existing = await prisma.platosChannelApp.findFirst({
-          where: { id, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const existing = await channelPersistence.loadScopedApp(scopeTuple(scope), id);
         if (!existing) {
           auditMutation(scope, "channel_apps.update", auditArgs, null, "failed", startedAt, "not_found");
           return { error: "not_found", id };
@@ -600,10 +620,10 @@ export function buildChannelAppToolHandlers(deps: {
           data.clientId = clientId;
         }
         if (hasClientSecret) {
-          data.clientSecret = encryptSecret((params["clientSecret"] as string).trim());
+          data.clientSecret = (params["clientSecret"] as string).trim();
         }
         if (hasSigningSecret) {
-          data.signingSecret = encryptSecret((params["signingSecret"] as string).trim());
+          data.signingSecret = (params["signingSecret"] as string).trim();
         }
         if (Object.prototype.hasOwnProperty.call(params, "scopes")) {
           const scopes = normalizeScopes(params["scopes"]);
@@ -654,7 +674,7 @@ export function buildChannelAppToolHandlers(deps: {
         if (Object.prototype.hasOwnProperty.call(params, "agentRouting")) {
           const ar = params["agentRouting"];
           if (ar === null) {
-            data.agentRouting = null;
+            data.agentRouting = [];
           } else {
             const routing = await validateAgentRouting(prisma, scope, ar);
             if (!routing.ok) {
@@ -674,9 +694,7 @@ export function buildChannelAppToolHandlers(deps: {
         }
 
         if (Object.keys(data).length === 0) {
-          const row = await prisma.platosChannelApp.findFirst({
-            where: { id, ...scopeTuple(scope) },
-          });
+          const row = await channelPersistence.loadScopedApp(scopeTuple(scope), id);
           if (!row) {
             auditMutation(scope, "channel_apps.update", auditArgs, null, "failed", startedAt, "not_found");
             return { error: "not_found", id };
@@ -686,7 +704,24 @@ export function buildChannelAppToolHandlers(deps: {
         }
 
         try {
-          const updated = await prisma.platosChannelApp.update({ where: { id }, data });
+          const credentialKeys = new Set([
+            "clientSecret",
+            "signingSecret",
+            "aiAppsSurface",
+            "linking",
+          ]);
+          const publicData: Record<string, unknown> = {};
+          const credentialData: Record<string, unknown> = {};
+          for (const [key, value] of Object.entries(data)) {
+            (credentialKeys.has(key) ? credentialData : publicData)[key] = value;
+          }
+          const updated = await channelPersistence.updateApp(
+            scopeTuple(scope),
+            id,
+            publicData,
+            credentialData,
+          );
+          if (!updated) return { error: "not_found", id };
           evictApp(id);
           auditMutation(scope, "channel_apps.update", auditArgs, { id }, "success", startedAt);
           return { ...projectApp(updated), installUrl: installUrl(updated.id) };
@@ -714,16 +749,13 @@ export function buildChannelAppToolHandlers(deps: {
         const startedAt = Date.now();
         const id = String(params["id"] ?? "").trim();
         if (!id) return { error: "invalid_params", message: "id required" };
-        const existing = await prisma.platosChannelApp.findFirst({
-          where: { id, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const existing = await channelPersistence.loadScopedApp(scopeTuple(scope), id);
         if (!existing) {
           auditMutation(scope, "channel_apps.delete", { id }, null, "failed", startedAt, "not_found");
           return { ok: false, error: "not_found", id };
         }
         try {
-          await prisma.platosChannelApp.delete({ where: { id } });
+          await channelPersistence.deleteApp(scopeTuple(scope), id);
           evictApp(id);
           const result = { ok: true, id };
           auditMutation(scope, "channel_apps.delete", { id }, result, "success", startedAt);
@@ -752,15 +784,9 @@ export function buildChannelAppToolHandlers(deps: {
       async execute(params, scope) {
         const appId = String(params["appId"] ?? "").trim();
         if (!appId) return { error: "invalid_params", message: "appId required" };
-        const app = await prisma.platosChannelApp.findFirst({
-          where: { id: appId, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const app = await channelPersistence.loadScopedApp(scopeTuple(scope), appId);
         if (!app) return { error: "not_found", appId };
-        const rows = await prisma.platosChannelInstallation.findMany({
-          where: { appId },
-          orderBy: { createdAt: "desc" },
-        });
+        const rows = await channelPersistence.listInstallations(scopeTuple(scope), appId);
         return { installations: (rows as any[]).map((r) => projectInstallation(r)) };
       },
     },
@@ -830,18 +856,12 @@ export function buildChannelAppToolHandlers(deps: {
           return { error: "no_op", message: err };
         }
 
-        const app = await prisma.platosChannelApp.findFirst({
-          where: { id: appId, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const app = await channelPersistence.loadScopedApp(scopeTuple(scope), appId);
         if (!app) {
           auditMutation(scope, "channel_apps.bind_installation", auditArgs, null, "failed", startedAt, "not_found");
           return { error: "not_found", appId };
         }
-        const installation = await prisma.platosChannelInstallation.findFirst({
-          where: { id: installationId, appId },
-          select: { id: true },
-        });
+        const installation = await channelPersistence.loadInstallation(installationId, appId);
         if (!installation) {
           auditMutation(
             scope,
@@ -859,7 +879,7 @@ export function buildChannelAppToolHandlers(deps: {
         if (hasAgentId) {
           const raw = params["agentId"];
           if (raw === null || raw === "") {
-            data.agentId = null;
+            data.defaultAgentId = null;
           } else if (typeof raw === "string") {
             const agentId = raw.trim();
             if (!(await agentInScope(scope, agentId))) {
@@ -874,13 +894,13 @@ export function buildChannelAppToolHandlers(deps: {
               );
               return { error: "unknown_agent_id", agentId };
             }
-            data.agentId = agentId;
+            data.defaultAgentId = agentId;
           }
         }
         if (hasAgentRouting) {
           const ar = params["agentRouting"];
           if (ar === null) {
-            data.agentRouting = null;
+            data.agentRouting = [];
           } else {
             const routing = await validateAgentRouting(prisma, scope, ar);
             if (!routing.ok) {
@@ -900,10 +920,13 @@ export function buildChannelAppToolHandlers(deps: {
         }
 
         try {
-          const updated = await prisma.platosChannelInstallation.update({
-            where: { id: installationId },
+          const updated = await channelPersistence.updateInstallationBinding(
+            scopeTuple(scope),
+            appId,
+            installationId,
             data,
-          });
+          );
+          if (!updated) return { error: "installation_not_found", installationId };
           auditMutation(
             scope,
             "channel_apps.bind_installation",
@@ -1025,10 +1048,7 @@ export function buildChannelAppToolHandlers(deps: {
           return { error: "invalid_params", message: err };
         }
 
-        const app = await prisma.platosChannelApp.findFirst({
-          where: { id: appId, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const app = await channelPersistence.loadScopedApp(scopeTuple(scope), appId);
         if (!app) {
           auditMutation(scope, "channel_apps.import_installation", auditArgs, null, "failed", startedAt, "not_found");
           return { error: "not_found", appId };
@@ -1098,7 +1118,7 @@ export function buildChannelAppToolHandlers(deps: {
         // keys "this install rotates" off tokenExpiresAt, and a stale expiry
         // would refresh the OLD grant over the freshly imported key.
         const data: Record<string, unknown> = {
-          botToken: encryptSecret(botToken),
+          botToken,
           refreshToken: null,
           tokenExpiresAt: null,
           isEnterpriseInstall,
@@ -1163,18 +1183,12 @@ export function buildChannelAppToolHandlers(deps: {
           auditMutation(scope, "channel_apps.revoke_installation", auditArgs, null, "failed", startedAt, err);
           return { error: "invalid_params", message: err };
         }
-        const app = await prisma.platosChannelApp.findFirst({
-          where: { id: appId, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const app = await channelPersistence.loadScopedApp(scopeTuple(scope), appId);
         if (!app) {
           auditMutation(scope, "channel_apps.revoke_installation", auditArgs, null, "failed", startedAt, "not_found");
           return { error: "not_found", appId };
         }
-        const installation = await prisma.platosChannelInstallation.findFirst({
-          where: { id: installationId, appId },
-          select: { id: true },
-        });
+        const installation = await channelPersistence.loadInstallation(installationId, appId);
         if (!installation) {
           auditMutation(
             scope,
@@ -1188,10 +1202,12 @@ export function buildChannelAppToolHandlers(deps: {
           return { error: "installation_not_found", installationId };
         }
         try {
-          const updated = await prisma.platosChannelInstallation.update({
-            where: { id: installationId },
-            data: { status: "revoked", revokedAt: new Date() },
-          });
+          const updated = await channelPersistence.revokeInstallation(
+            scopeTuple(scope),
+            appId,
+            installationId,
+          );
+          if (!updated) return { error: "installation_not_found", installationId };
           evictApp(appId);
           auditMutation(
             scope,
@@ -1230,15 +1246,9 @@ export function buildChannelAppToolHandlers(deps: {
       async execute(params, scope) {
         const appId = String(params["appId"] ?? "").trim();
         if (!appId) return { error: "invalid_params", message: "appId required" };
-        const app = await prisma.platosChannelApp.findFirst({
-          where: { id: appId, ...scopeTuple(scope) },
-          select: { id: true, defaultAgentId: true },
-        });
+        const app = await channelPersistence.loadScopedApp(scopeTuple(scope), appId);
         if (!app) return { error: "not_found", appId };
-        const rows = await prisma.platosChannelInstallation.findMany({
-          where: { appId },
-          orderBy: { createdAt: "desc" },
-        });
+        const rows = await channelPersistence.listInstallations(scopeTuple(scope), appId);
         return {
           installations: (rows as any[]).map((r) => projectInstallationStatus(r, app)),
         };

--- a/apps/agent/src/mcp-platform/tools/channels.ts
+++ b/apps/agent/src/mcp-platform/tools/channels.ts
@@ -28,9 +28,10 @@ import * as crypto from "node:crypto";
 
 import type { McpToolHandler } from "../mcp-router";
 import type { RequestScope } from "../../auth/scope.guard";
-import type { MessageCryptoService } from "../../monitoring/message-crypto.service";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
 import { validateAgentRouting } from "../../agent-runtime/channel-routing";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
+import type { ChannelPersistenceService } from "../../channels/channel-persistence.service";
 
 const CHANNEL_PROVIDERS = new Set(["slack", "telegram", "whatsapp", "discord"]);
 
@@ -44,6 +45,18 @@ function scopeTuple(scope: RequestScope) {
     projectId: scope.projectId,
     environmentId: scope.environmentId,
   };
+}
+
+function agentBindingWhere(scope: RequestScope, agentId: string) {
+  return {
+    agentId,
+    environmentId: scope.environmentId,
+    environment: {
+      projectId: scope.projectId,
+      project: { organizationId: scope.organizationId },
+    },
+    agent: { projectId: scope.projectId },
+  } as const;
 }
 
 /** The full one-time webhook path (embeds the secret) — create + rotate only. */
@@ -81,8 +94,10 @@ function webhookPathRedacted(connectionId: string): string {
  * know whether credentials are set without ever seeing them.
  */
 function projectRow(row: any) {
-  const { credentials, webhookSecret, ...rest } = row;
+  const { credentials, webhookSecret, credential, environment, ...rest } = row;
   void webhookSecret;
+  void credential;
+  void environment;
   return { ...rest, hasCredentials: credentials != null };
 }
 
@@ -162,8 +177,8 @@ function buildSlackAppManifest(appName: string, requestUrl: string) {
 }
 
 export function buildChannelToolHandlers(deps: {
-  prisma: any;
-  messageCrypto: MessageCryptoService;
+  prisma: ControlDatabaseClient;
+  channelPersistence: ChannelPersistenceService;
   toolAudit: ToolAuditService;
   /**
    * Evict the channels RUNTIME's cached Chat instance for a connection after
@@ -175,7 +190,7 @@ export function buildChannelToolHandlers(deps: {
    */
   invalidateRuntime?: (connectionId: string) => void;
 }): McpToolHandler[] {
-  const { prisma, messageCrypto, toolAudit } = deps;
+  const { prisma, channelPersistence, toolAudit } = deps;
 
   /** Best-effort runtime-cache eviction — never fails the mutation. */
   function evictRuntime(connectionId: string): void {
@@ -221,17 +236,11 @@ export function buildChannelToolHandlers(deps: {
    * validation in `entities.set_linked_agents` (org + project + env filter).
    */
   async function agentInScope(scope: RequestScope, agentId: string): Promise<boolean> {
-    const agent = await prisma.platosAgent.findFirst({
-      where: { id: agentId, ...scopeTuple(scope) },
+    const agent = await prisma.agentBinding.findFirst({
+      where: agentBindingWhere(scope, agentId),
       select: { id: true },
     });
     return !!agent;
-  }
-
-  /** Encrypt a credentials object into the stored envelope, or null to clear. */
-  function encryptCredentials(raw: unknown): string | null {
-    if (!isPlainObject(raw)) return null;
-    return JSON.stringify(messageCrypto.encryptJsonField(raw));
   }
 
   return [
@@ -301,7 +310,7 @@ export function buildChannelToolHandlers(deps: {
         const displayName =
           typeof params["displayName"] === "string" ? params["displayName"].trim() : undefined;
         const configJson = isPlainObject(params["config"]) ? params["config"] : undefined;
-        const encryptedCreds = encryptCredentials(params["credentials"]);
+        const hasCredentialInput = isPlainObject(params["credentials"]);
         const routingProvided =
           params["agentRouting"] !== undefined && params["agentRouting"] !== null;
 
@@ -311,7 +320,7 @@ export function buildChannelToolHandlers(deps: {
           provider,
           agentId,
           displayName,
-          hasCredentials: encryptedCreds !== null,
+          hasCredentials: hasCredentialInput,
           hasConfig: configJson !== undefined,
           hasAgentRouting: routingProvided,
         };
@@ -361,17 +370,14 @@ export function buildChannelToolHandlers(deps: {
 
         const webhookSecret = crypto.randomBytes(32).toString("hex");
         try {
-          const row = await prisma.platosChannelConnection.create({
-            data: {
-              ...scopeTuple(scope),
-              provider,
-              agentId,
-              ...(displayName !== undefined ? { displayName } : {}),
-              ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
-              ...(encryptedCreds !== null ? { credentials: encryptedCreds } : {}),
-              ...(configJson !== undefined ? { config: configJson } : {}),
-              webhookSecret,
-            },
+          const row = await channelPersistence.createConnection(scopeTuple(scope), {
+            provider,
+            defaultAgentId: agentId,
+            ...(displayName !== undefined ? { displayName } : {}),
+            ...(agentRoutingData !== undefined ? { agentRouting: agentRoutingData } : {}),
+            credentials: isPlainObject(params["credentials"]) ? params["credentials"] : null,
+            config: configJson ?? null,
+            webhookSecret,
           });
           const result = {
             ...projectRow(row),
@@ -468,9 +474,9 @@ export function buildChannelToolHandlers(deps: {
         }
 
         // In-scope guard (forged ids rejected) + name fallback for the manifest.
-        const agent = await prisma.platosAgent.findFirst({
-          where: { id: agentId, ...scopeTuple(scope) },
-          select: { id: true, name: true },
+        const agent = await prisma.agentBinding.findFirst({
+          where: agentBindingWhere(scope, agentId),
+          select: { agent: { select: { id: true, name: true } } },
         });
         if (!agent) {
           auditMutation(
@@ -506,21 +512,18 @@ export function buildChannelToolHandlers(deps: {
         }
 
         const appName =
-          (displayName || (agent as any).name || "Platos Agent").trim() || "Platos Agent";
+          (displayName || agent.agent.name || "Platos Agent").trim() || "Platos Agent";
 
         // (1) CREATE the connection row FIRST so its inbound URL (id + secret)
         // exists — the chicken-and-egg the manifest request_url depends on.
         const webhookSecret = crypto.randomBytes(32).toString("hex");
         let row: any;
         try {
-          row = await prisma.platosChannelConnection.create({
-            data: {
-              ...scopeTuple(scope),
-              provider,
-              agentId,
-              ...(displayName ? { displayName } : {}),
-              webhookSecret,
-            },
+          row = await channelPersistence.createConnection(scopeTuple(scope), {
+            provider,
+            defaultAgentId: agentId,
+            ...(displayName ? { displayName } : {}),
+            webhookSecret,
           });
         } catch (err: any) {
           const message = err?.message ?? String(err);
@@ -531,7 +534,7 @@ export function buildChannelToolHandlers(deps: {
         /** Best-effort rollback — a credential-less row verifies/posts nothing. */
         const rollback = async () => {
           try {
-            await prisma.platosChannelConnection.delete({ where: { id: row.id } });
+            await channelPersistence.deleteConnection(scopeTuple(scope), row.id);
           } catch {
             // Already gone / raced — nothing to undo.
           }
@@ -597,11 +600,6 @@ export function buildChannelToolHandlers(deps: {
         const oauthAuthorizeUrl =
           typeof json.oauth_authorize_url === "string" ? json.oauth_authorize_url : null;
 
-        const encryptedCreds = encryptCredentials({
-          ...(clientId ? { clientId } : {}),
-          ...(clientSecret ? { clientSecret } : {}),
-          ...(signingSecret ? { signingSecret } : {}),
-        });
         const config: Record<string, unknown> = {
           ...(appId ? { slackAppId: appId } : {}),
           // clientId is PUBLIC (rides the authorize URL) — surface it in config
@@ -611,13 +609,20 @@ export function buildChannelToolHandlers(deps: {
 
         let updated: any;
         try {
-          updated = await prisma.platosChannelConnection.update({
-            where: { id: row.id },
-            data: {
-              ...(encryptedCreds !== null ? { credentials: encryptedCreds } : {}),
+          updated = await channelPersistence.updateConnection(
+            scopeTuple(scope),
+            row.id,
+            {},
+            {
+              credentials: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                ...(signingSecret ? { signingSecret } : {}),
+              },
               config,
             },
-          });
+          );
+          if (!updated) throw new Error("channel connection unavailable after write");
         } catch {
           // The app WAS created at Slack but the secret store failed. Do NOT
           // roll back (that orphans a live Slack app pointing here) — return the
@@ -678,14 +683,9 @@ export function buildChannelToolHandlers(deps: {
           typeof params["provider"] === "string" ? params["provider"].trim().toLowerCase() : undefined;
         const agentId =
           typeof params["agentId"] === "string" ? params["agentId"].trim() : undefined;
-        const rows = await prisma.platosChannelConnection.findMany({
-          where: {
-            ...scopeTuple(scope),
-            ...(provider ? { provider } : {}),
-            ...(agentId ? { agentId } : {}),
-          },
-          orderBy: { createdAt: "desc" },
-        });
+        const rows = (await channelPersistence.listConnections(scopeTuple(scope))).filter(
+          (row) => (!provider || row.provider === provider) && (!agentId || row.agentId === agentId),
+        );
         return {
           channels: (rows as any[]).map((r) => ({
             ...projectRow(r),
@@ -711,9 +711,7 @@ export function buildChannelToolHandlers(deps: {
       async execute(params, scope) {
         const id = String(params["id"] ?? "").trim();
         if (!id) return { error: "invalid_params", message: "id required" };
-        const row = await prisma.platosChannelConnection.findFirst({
-          where: { id, ...scopeTuple(scope) },
-        });
+        const row = await channelPersistence.loadScopedConnection(scopeTuple(scope), id);
         if (!row) return { error: "not_found", id };
         return { ...projectRow(row), webhookPath: webhookPathRedacted(row.id) };
       },
@@ -794,10 +792,7 @@ export function buildChannelToolHandlers(deps: {
           return { error: "invalid_params", message: err };
         }
 
-        const existing = await prisma.platosChannelConnection.findFirst({
-          where: { id, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const existing = await channelPersistence.loadScopedConnection(scopeTuple(scope), id);
         if (!existing) {
           auditMutation(scope, "channels.update", auditArgs, null, "failed", startedAt, "not_found");
           return { error: "not_found", id };
@@ -828,12 +823,12 @@ export function buildChannelToolHandlers(deps: {
             );
             return { error: "unknown_agent_id", agentId };
           }
-          data.agentId = agentId;
+          data.defaultAgentId = agentId;
         }
         if (agentRoutingKeyPresent) {
           const ar = params["agentRouting"];
           if (ar === null) {
-            data.agentRouting = null; // explicit clear → default agent only
+            data.agentRouting = []; // explicit clear → default agent only
           } else {
             // array → validate + normalize (rule agentIds checked in-scope,
             // same guard as the default agentId); anything else → error.
@@ -854,18 +849,26 @@ export function buildChannelToolHandlers(deps: {
           }
         }
         if (Object.prototype.hasOwnProperty.call(params, "config")) {
-          data.config = isPlainObject(params["config"]) ? params["config"] : null;
+          // Stored inside the channel Credential envelope.
         }
         if (hasCredentials) {
           // object → re-encrypt; null (or anything non-object) → clear.
-          data.credentials = encryptCredentials(params["credentials"]);
+          // Stored inside the channel Credential envelope.
         }
 
-        if (Object.keys(data).length === 0) {
+        const credentialData: Record<string, unknown> = {};
+        if (Object.prototype.hasOwnProperty.call(params, "config")) {
+          credentialData.config = isPlainObject(params["config"]) ? params["config"] : null;
+        }
+        if (hasCredentials) {
+          credentialData.credentials = isPlainObject(params["credentials"])
+            ? params["credentials"]
+            : null;
+        }
+
+        if (Object.keys(data).length === 0 && Object.keys(credentialData).length === 0) {
           // No-op patch — return existing without bumping updatedAt.
-          const row = await prisma.platosChannelConnection.findFirst({
-            where: { id, ...scopeTuple(scope) },
-          });
+          const row = await channelPersistence.loadScopedConnection(scopeTuple(scope), id);
           if (!row) {
             // Raced a concurrent delete between the existence check and this
             // refetch — report not_found instead of throwing on the destructure.
@@ -877,10 +880,13 @@ export function buildChannelToolHandlers(deps: {
         }
 
         try {
-          const updated = await prisma.platosChannelConnection.update({
-            where: { id },
+          const updated = await channelPersistence.updateConnection(
+            scopeTuple(scope),
+            id,
             data,
-          });
+            credentialData,
+          );
+          if (!updated) return { error: "not_found", id };
           evictRuntime(id);
           auditMutation(scope, "channels.update", auditArgs, { id }, "success", startedAt);
           return { ...projectRow(updated), webhookPath: webhookPathRedacted(updated.id) };
@@ -908,16 +914,13 @@ export function buildChannelToolHandlers(deps: {
         const startedAt = Date.now();
         const id = String(params["id"] ?? "").trim();
         if (!id) return { error: "invalid_params", message: "id required" };
-        const existing = await prisma.platosChannelConnection.findFirst({
-          where: { id, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const existing = await channelPersistence.loadScopedConnection(scopeTuple(scope), id);
         if (!existing) {
           auditMutation(scope, "channels.delete", { id }, null, "failed", startedAt, "not_found");
           return { ok: false, error: "not_found", id };
         }
         try {
-          await prisma.platosChannelConnection.delete({ where: { id } });
+          await channelPersistence.deleteConnection(scopeTuple(scope), id);
           evictRuntime(id);
           const result = { ok: true, id };
           auditMutation(scope, "channels.delete", { id }, result, "success", startedAt);
@@ -949,10 +952,7 @@ export function buildChannelToolHandlers(deps: {
         const startedAt = Date.now();
         const id = String(params["id"] ?? "").trim();
         if (!id) return { error: "invalid_params", message: "id required" };
-        const existing = await prisma.platosChannelConnection.findFirst({
-          where: { id, ...scopeTuple(scope) },
-          select: { id: true },
-        });
+        const existing = await channelPersistence.loadScopedConnection(scopeTuple(scope), id);
         if (!existing) {
           auditMutation(
             scope,
@@ -967,10 +967,13 @@ export function buildChannelToolHandlers(deps: {
         }
         const webhookSecret = crypto.randomBytes(32).toString("hex");
         try {
-          const updated = await prisma.platosChannelConnection.update({
-            where: { id },
-            data: { webhookSecret },
-          });
+          const updated = await channelPersistence.updateConnection(
+            scopeTuple(scope),
+            id,
+            {},
+            { webhookSecret },
+          );
+          if (!updated) return { error: "not_found", id };
           evictRuntime(id);
           const result = {
             ...projectRow(updated),

--- a/apps/agent/src/mcp-platform/tools/end-users.test.ts
+++ b/apps/agent/src/mcp-platform/tools/end-users.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RequestScope } from "../../auth/scope.guard";
+import { buildEndUserToolHandlers } from "./end-users";
+
+const scope: RequestScope = {
+  organizationId: "org-a",
+  projectId: "project-a",
+  environmentId: "env-a",
+  userId: "operator-a",
+  principal: "operator",
+};
+
+const presence = {
+  OR: [
+    { threads: { some: { environmentId: "env-a" } } },
+    { memories: { some: { environmentId: "env-a" } } },
+    { messageAttachments: { some: { environmentId: "env-a" } } },
+    { toolCallAudits: { some: { environmentId: "env-a" } } },
+    { safetyEvents: { some: { environmentId: "env-a" } } },
+  ],
+};
+
+function tool(name: string, prisma: any) {
+  const handlers = buildEndUserToolHandlers({
+    prisma,
+    toolAudit: { record: vi.fn().mockResolvedValue(undefined) } as any,
+  });
+  return handlers.find((candidate) => candidate.name === name)!;
+}
+
+describe("end_users Environment authority", () => {
+  it("requires current-Environment presence for reads by canonical id", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const handler = tool("end_users.get", { endUser: { findFirst } });
+
+    await expect(
+      handler.execute({ platosEndUserId: "end-user-a" }, scope, {} as any),
+    ).resolves.toEqual({ error: "not_found", platosEndUserId: "end-user-a" });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        id: "end-user-a",
+        organizationId: "org-a",
+        ...presence,
+      },
+    });
+  });
+
+  it("does not manufacture a verified manual identity", async () => {
+    const findFirst = vi.fn();
+    const handler = tool("end_users.link_identity", {
+      endUser: { findFirst },
+    });
+
+    await expect(
+      handler.execute(
+        {
+          platosEndUserId: "end-user-a",
+          channel: "email",
+          handle: "person@example.com",
+          verified: true,
+        },
+        scope,
+        {} as any,
+      ),
+    ).resolves.toEqual({
+      error: "trusted_claim_required",
+      message: "Manual MCP identities cannot manufacture a verified claim.",
+    });
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("requires a verified runtime claim already present in the Environment", async () => {
+    const claimFindFirst = vi.fn().mockResolvedValue(null);
+    const handler = tool("end_users.bind_external_id", {
+      endUserIdentity: { findFirst: claimFindFirst },
+    });
+
+    await expect(
+      handler.execute(
+        { channel: "email", handle: "person@example.com", externalId: "customer-a" },
+        scope,
+        {} as any,
+      ),
+    ).resolves.toEqual({
+      error: "trusted_claim_required",
+      message: "A verified runtime identity in the current Environment is required.",
+    });
+    expect(claimFindFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-a",
+        issuer: "channel:email",
+        channel: "email",
+        subject: "person@example.com",
+        disabledAt: null,
+        verifiedAt: { not: null },
+        endUser: {
+          organizationId: "org-a",
+          ...presence,
+        },
+      },
+    });
+  });
+
+  it("only confirms an external tuple previously verified by runtime persistence", async () => {
+    const claim = {
+      id: "identity-email",
+      endUserId: "end-user-a",
+      verifiedAt: new Date(),
+    };
+    const findFirst = vi.fn().mockResolvedValue(claim);
+    const findUnique = vi.fn().mockResolvedValue({
+      id: "identity-external",
+      endUserId: "end-user-a",
+      verifiedAt: new Date(),
+    });
+    const create = vi.fn();
+    const update = vi.fn();
+    const handler = tool("end_users.bind_external_id", {
+      endUserIdentity: { findFirst, findUnique, create, update },
+    });
+
+    await expect(
+      handler.execute(
+        { channel: "email", handle: "person@example.com", externalId: "customer-a" },
+        scope,
+        {} as any,
+      ),
+    ).resolves.toEqual({
+      ok: true,
+      platosEndUserId: "end-user-a",
+      externalId: "customer-a",
+      created: false,
+    });
+    expect(findUnique).toHaveBeenCalledWith({
+      where: {
+        organizationId_issuer_channel_subject: {
+          organizationId: "org-a",
+          issuer: "platos:external",
+          channel: "external",
+          subject: "customer-a",
+        },
+      },
+    });
+    expect(create).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("unlinks only a manual identity belonging to an Environment-present person", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const handler = tool("end_users.unlink_identity", {
+      endUserIdentity: { findFirst },
+    });
+
+    await handler.execute(
+      { channel: "email", handle: "person@example.com" },
+      scope,
+      {} as any,
+    );
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org-a",
+        issuer: "platos:mcp-manual",
+        channel: "email",
+        subject: "person@example.com",
+        disabledAt: null,
+        endUser: {
+          organizationId: "org-a",
+          ...presence,
+        },
+      },
+    });
+   });
+ });

--- a/apps/agent/src/mcp-platform/tools/end-users.ts
+++ b/apps/agent/src/mcp-platform/tools/end-users.ts
@@ -1,42 +1,14 @@
-/**
- * Theme EUI — end-user identity management platform MCP tools.
- *
- * The runtime resolves an end-user to a canonical `PlatosEndUser` row and
- * attaches channel-native identities (email addr, E.164 phone, Slack user
- * id, …) as `PlatosEndUserIdentity` rows using a link-not-merge model:
- * a verified identity anchors the person, every claimed identity is linked
- * to that person, and a handle already pointing at a DIFFERENT person is
- * never re-pointed. These tools give MCP clients the read + manual-edit
- * surface over that graph.
- *
- *   - end_users.get              → fetch a PlatosEndUser + its identities[]
- *   - end_users.link_identity    → manually attach a (channel, handle) identity
- *   - end_users.bind_external_id → adopt an EXTERNAL id (Composio user_id) onto
- *                                  the person behind a verified (channel, handle)
- *                                  claim; sets linkedExternalId (idempotent
- *                                  overwrite). See IDENTITY-CORE §A.3.
- *   - end_users.unlink_identity  → detach a (channel, handle) identity
- *
- * Scope is ALWAYS taken from the verified MCP token, never from the
- * LLM-supplied args — every query is filtered by the token's
- * (organizationId, projectId, environmentId) tuple. Manual links carry no
- * trust anchor (`sourceEntityId = null`); only the runtime resolver stamps
- * a sourceEntityId from the connected entity that asserted the identity.
- */
-
 import type { McpToolHandler } from "../mcp-router";
 import type { RequestScope } from "../../auth/scope.guard";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 
-// ── Identity sanitization — mirrors the mint-time rules in the shared
-//    contract (auth.service SessionPayload.userIdentities). Keep in sync:
-//    channel lowercased/trimmed matching /^[a-z0-9_-]{1,32}$/; handle
-//    trimmed, length 1..256, no control chars. ────────────────────────
 const CHANNEL_RE = /^[a-z0-9_-]{1,32}$/;
-// C0 control chars + DEL — a handle carrying these could split a header /
-// log line or smuggle a NUL into a DB text column.
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE = /[\x00-\x1F\x7F]/;
+const MANUAL_ISSUER = "platos:mcp-manual";
+const EXTERNAL_ISSUER = "platos:external";
+const EXTERNAL_CHANNEL = "external";
 
 function sanitizeChannel(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
@@ -47,20 +19,13 @@ function sanitizeChannel(raw: unknown): string | null {
 function sanitizeHandle(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
   const handle = raw.trim();
-  if (handle.length < 1 || handle.length > 256) return null;
-  if (CONTROL_CHAR_RE.test(handle)) return null;
-  return handle;
+  return handle.length >= 1 && handle.length <= 256 && !CONTROL_CHAR_RE.test(handle)
+    ? handle
+    : null;
 }
 
-// The adopted EXTERNAL id (Walle user id = Composio `user_id`). Same bounds as
-// `externalUserId`: trimmed, 1..256, no control chars (a control char here
-// could split the outbound URL / header it is later substituted into).
 function sanitizeExternalId(raw: unknown): string | null {
-  if (typeof raw !== "string") return null;
-  const externalId = raw.trim();
-  if (externalId.length < 1 || externalId.length > 256) return null;
-  if (CONTROL_CHAR_RE.test(externalId)) return null;
-  return externalId;
+  return sanitizeHandle(raw);
 }
 
 function scopeTuple(scope: RequestScope) {
@@ -71,35 +36,46 @@ function scopeTuple(scope: RequestScope) {
   };
 }
 
-/** Shape the identity row returns for read + write responses. */
+function currentEnvironmentPresence(environmentId: string) {
+  return {
+    OR: [
+      { threads: { some: { environmentId } } },
+      { memories: { some: { environmentId } } },
+      { messageAttachments: { some: { environmentId } } },
+      { toolCallAudits: { some: { environmentId } } },
+      { safetyEvents: { some: { environmentId } } },
+    ],
+  };
+}
+
 function projectIdentity(row: {
   channel: string;
-  handle: string;
-  verified: boolean;
-  sourceEntityId: string | null;
+  subject: string;
+  verifiedAt: Date | null;
+  profile: unknown;
   createdAt: Date | string;
 }) {
+  const profile = row.profile && typeof row.profile === "object" && !Array.isArray(row.profile)
+    ? row.profile as Record<string, unknown>
+    : null;
   return {
     channel: row.channel,
-    handle: row.handle,
-    verified: row.verified,
-    sourceEntityId: row.sourceEntityId ?? null,
-    createdAt:
-      row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
+    handle: row.subject,
+    verified: row.verifiedAt !== null,
+    sourceEntityId: typeof profile?.["sourceEntityId"] === "string"
+      ? profile["sourceEntityId"]
+      : null,
+    metadata: profile,
+    createdAt: row.createdAt instanceof Date ? row.createdAt.toISOString() : row.createdAt,
   };
 }
 
 export function buildEndUserToolHandlers(deps: {
-  prisma: any;
+  prisma: ControlDatabaseClient;
   toolAudit: ToolAuditService;
 }): McpToolHandler[] {
   const { prisma, toolAudit } = deps;
 
-  /**
-   * Fire-and-forget audit trail for mutating end-user tools. Mirrors the
-   * shape used by `entities.ts` / `index.ts` so MCP-driven identity edits
-   * surface in the same dashboard rows.
-   */
   function auditMutation(
     scope: RequestScope,
     toolName: string,
@@ -109,32 +85,24 @@ export function buildEndUserToolHandlers(deps: {
     startedAt: number,
     error?: string,
   ): void {
-    toolAudit
-      .record({
-        scope: scopeTuple(scope),
-        toolName,
-        userId: scope.userId ?? null,
-        args,
-        result,
-        ...(error !== undefined ? { error } : {}),
-        status,
-        latencyMs: Date.now() - startedAt,
-        source: "mcp_platform",
-      })
-      .catch(() => undefined);
+    toolAudit.record({
+      scope: scopeTuple(scope),
+      toolName,
+      userId: scope.userId ?? null,
+      args,
+      result,
+      ...(error !== undefined ? { error } : {}),
+      status,
+      latencyMs: Date.now() - startedAt,
+      source: "mcp_platform",
+    }).catch(() => undefined);
   }
 
   return [
     {
       name: "end_users.get",
       description:
-        "Fetch a single PlatosEndUser in the token's scope by EXACTLY ONE " +
-        "of `externalUserId` (the opaque id forwarded by the entity backend) " +
-        "or `platosEndUserId` (the canonical cuid). Returns the person's " +
-        "profile (id, externalUserId, displayName, email, threadCount, " +
-        "lastActiveAt, metadata) plus every linked identity (channel, " +
-        "handle, verified, sourceEntityId, createdAt). Scope-pinned — " +
-        "cross-scope ids return `{ error: 'not_found' }`.",
+        "Fetch one organization-owned EndUser by exactly one of externalUserId or platosEndUserId, including canonical identities and scope-local thread activity.",
       inputSchema: {
         type: "object",
         properties: {
@@ -144,76 +112,81 @@ export function buildEndUserToolHandlers(deps: {
         additionalProperties: false,
       },
       async execute(params, scope) {
-        const externalUserId =
-          typeof params["externalUserId"] === "string"
-            ? (params["externalUserId"] as string).trim()
-            : "";
-        const platosEndUserId =
-          typeof params["platosEndUserId"] === "string"
-            ? (params["platosEndUserId"] as string).trim()
-            : "";
-        const hasExternal = externalUserId.length > 0;
-        const hasPk = platosEndUserId.length > 0;
-        // Exactly one selector — an ambiguous or empty call is a caller
-        // error, not a 404.
-        if (hasExternal === hasPk) {
+        const externalUserId = typeof params["externalUserId"] === "string"
+          ? params["externalUserId"].trim()
+          : "";
+        const platosEndUserId = typeof params["platosEndUserId"] === "string"
+          ? params["platosEndUserId"].trim()
+          : "";
+        if (!!externalUserId === !!platosEndUserId) {
           return {
             error: "invalid_params",
-            message:
-              "supply exactly one of `externalUserId` or `platosEndUserId`",
+            message: "supply exactly one of `externalUserId` or `platosEndUserId`",
           };
         }
 
-        const tuple = scopeTuple(scope);
-        // findFirst (never findUnique) so the scope tuple is always part of
-        // the WHERE — a forged cuid from another scope can't be read.
-        const user = await prisma.platosEndUser.findFirst({
-          where: hasPk
-            ? { id: platosEndUserId, ...tuple }
-            : { externalUserId, ...tuple },
-        });
+        const user = platosEndUserId
+          ? await prisma.endUser.findFirst({
+              where: {
+                id: platosEndUserId,
+                organizationId: scope.organizationId,
+                ...currentEnvironmentPresence(scope.environmentId),
+              },
+            })
+          : await prisma.endUser.findFirst({
+              where: {
+                organizationId: scope.organizationId,
+                ...currentEnvironmentPresence(scope.environmentId),
+                identities: {
+                  some: {
+                    issuer: EXTERNAL_ISSUER,
+                    channel: EXTERNAL_CHANNEL,
+                    subject: externalUserId,
+                    disabledAt: null,
+                  },
+                },
+              },
+            });
         if (!user) {
           return {
             error: "not_found",
-            ...(hasPk ? { platosEndUserId } : { externalUserId }),
+            ...(platosEndUserId ? { platosEndUserId } : { externalUserId }),
           };
         }
 
-        const identities = await prisma.platosEndUserIdentity.findMany({
-          where: { platosEndUserId: user.id, ...tuple },
-          orderBy: { createdAt: "asc" },
-        });
-
+        const [identities, threadStats] = await Promise.all([
+          prisma.endUserIdentity.findMany({
+            where: { endUserId: user.id, organizationId: scope.organizationId, disabledAt: null },
+            orderBy: { createdAt: "asc" },
+          }),
+          prisma.thread.aggregate({
+            where: { environmentId: scope.environmentId, endUserId: user.id },
+            _count: { _all: true },
+            _max: { updatedAt: true },
+          }),
+        ]);
+        const externalIdentity = identities.find(
+          (identity) => identity.issuer === EXTERNAL_ISSUER && identity.channel === EXTERNAL_CHANNEL,
+        );
+        const emailIdentity = identities.find((identity) => identity.channel === "email");
         return {
           id: user.id,
-          externalUserId: user.externalUserId,
+          externalUserId: externalIdentity?.subject ?? null,
           displayName: user.displayName ?? null,
-          email: user.email ?? null,
-          threadCount: user.threadCount ?? 0,
-          lastActiveAt:
-            user.lastActiveAt instanceof Date
-              ? user.lastActiveAt.toISOString()
-              : (user.lastActiveAt ?? null),
-          metadata: user.metadata ?? null,
-          identities: (identities as any[]).map(projectIdentity),
+          email: emailIdentity?.subject ?? null,
+          threadCount: threadStats._count._all,
+          lastActiveAt: threadStats._max.updatedAt?.toISOString() ?? null,
+          metadata: null,
+          identities: identities
+            .filter((identity) => identity.issuer !== EXTERNAL_ISSUER)
+            .map(projectIdentity),
         };
       },
     },
-
     {
       name: "end_users.link_identity",
       description:
-        "Manually attach a channel-native identity to a PlatosEndUser. " +
-        "The person must already exist in the token's scope. `channel` is " +
-        "lowercased + must match /^[a-z0-9_-]{1,32}$/ (e.g. email, phone, " +
-        "slack, teams, whatsapp); `handle` is the channel-native id " +
-        "(email addr, E.164 phone, Slack user id) — trimmed, 1..256 chars, " +
-        "no control chars. Manual links carry NO trust anchor " +
-        "(sourceEntityId = null). If the (channel, handle) already points " +
-        "at a DIFFERENT person the call returns `{ error: " +
-        "'identity_conflict' }` naming the existing linkage and does NOT " +
-        "re-point (link-not-merge). Re-linking the SAME person updates the " +
-        "verified flag + metadata.",
+        "Attach a canonical EndUserIdentity to an organization-owned EndUser. Existing identities are never re-pointed to another person.",
       inputSchema: {
         type: "object",
         required: ["platosEndUserId", "channel", "handle"],
@@ -231,148 +204,92 @@ export function buildEndUserToolHandlers(deps: {
         const platosEndUserId = String(params["platosEndUserId"] ?? "").trim();
         const channel = sanitizeChannel(params["channel"]);
         const handle = sanitizeHandle(params["handle"]);
-        const verified = params["verified"] === true;
-        const metadata =
-          params["metadata"] &&
-          typeof params["metadata"] === "object" &&
-          !Array.isArray(params["metadata"])
-            ? (params["metadata"] as Record<string, unknown>)
-            : undefined;
-
-        if (!platosEndUserId) {
-          const err = "platosEndUserId required";
-          auditMutation(scope, "end_users.link_identity", params, null, "failed", startedAt, err);
-          return { error: "invalid_params", message: err };
+        if (!platosEndUserId || !channel || !handle) {
+          const message = !platosEndUserId
+            ? "platosEndUserId required"
+            : !channel
+              ? "invalid channel"
+              : "invalid handle";
+          auditMutation(scope, "end_users.link_identity", params, null, "failed", startedAt, "invalid_params");
+          return { error: "invalid_params", message };
         }
-        if (!channel) {
-          const err = "channel must match /^[a-z0-9_-]{1,32}$/ (after lowercasing)";
-          auditMutation(scope, "end_users.link_identity", params, null, "failed", startedAt, err);
-          return { error: "invalid_channel", message: err };
+        if (params["verified"] === true) {
+          return {
+            error: "trusted_claim_required",
+            message: "Manual MCP identities cannot manufacture a verified claim.",
+          };
         }
-        if (!handle) {
-          const err = "handle must be trimmed, 1..256 chars, no control chars";
-          auditMutation(scope, "end_users.link_identity", params, null, "failed", startedAt, err);
-          return { error: "invalid_handle", message: err };
-        }
-
-        const tuple = scopeTuple(scope);
         try {
-          // 1. The person must exist IN SCOPE — no cross-scope linking.
-          const user = await prisma.platosEndUser.findFirst({
-            where: { id: platosEndUserId, ...tuple },
+          const user = await prisma.endUser.findFirst({
+            where: {
+              id: platosEndUserId,
+              organizationId: scope.organizationId,
+              ...currentEnvironmentPresence(scope.environmentId),
+            },
             select: { id: true },
           });
-          if (!user) {
-            auditMutation(
-              scope,
-              "end_users.link_identity",
-              params,
-              null,
-              "failed",
-              startedAt,
-              "not_found",
-            );
-            return { error: "not_found", platosEndUserId };
-          }
-
-          // 2. Detect an existing linkage for this (channel, handle) in
-          //    scope. link-not-merge: a handle already owned by another
-          //    person is NEVER re-pointed.
-          const existing = await prisma.platosEndUserIdentity.findFirst({
-            where: { ...tuple, channel, handle },
+          if (!user) return { error: "not_found", platosEndUserId };
+          const existing = await prisma.endUserIdentity.findUnique({
+            where: {
+              organizationId_issuer_channel_subject: {
+                organizationId: scope.organizationId,
+                issuer: MANUAL_ISSUER,
+                channel,
+                subject: handle,
+              },
+            },
           });
-          if (existing && existing.platosEndUserId !== platosEndUserId) {
-            const conflict = {
+          if (existing && existing.endUserId !== platosEndUserId) {
+            const result = {
               error: "identity_conflict",
               channel,
               handle,
-              existingPlatosEndUserId: existing.platosEndUserId,
-              message:
-                `(${channel}, ${handle}) is already linked to ` +
-                `${existing.platosEndUserId}; unlink it first to re-point.`,
+              existingPlatosEndUserId: existing.endUserId,
             };
-            auditMutation(
-              scope,
-              "end_users.link_identity",
-              params,
-              conflict,
-              "failed",
-              startedAt,
-              "identity_conflict",
-            );
-            return conflict;
+            auditMutation(scope, "end_users.link_identity", params, result, "failed", startedAt, "identity_conflict");
+            return result;
           }
-
-          // 3. Upsert onto the resolved person. Manual link ⇒ no trust
-          //    anchor. Re-link of the same person updates verified/metadata.
+          const metadata = params["metadata"] && typeof params["metadata"] === "object" && !Array.isArray(params["metadata"])
+            ? params["metadata"]
+            : undefined;
           const row = existing
-            ? await prisma.platosEndUserIdentity.update({
+            ? await prisma.endUserIdentity.update({
                 where: { id: existing.id },
                 data: {
-                  verified,
-                  sourceEntityId: null,
-                  ...(metadata !== undefined ? { metadata } : {}),
+                  verifiedAt: null,
+                  ...(metadata !== undefined ? { profile: metadata } : {}),
+                  disabledAt: null,
                 },
               })
-            : await prisma.platosEndUserIdentity.create({
+            : await prisma.endUserIdentity.create({
                 data: {
-                  ...tuple,
-                  platosEndUserId,
+                  endUserId: platosEndUserId,
+                  organizationId: scope.organizationId,
+                  issuer: MANUAL_ISSUER,
                   channel,
-                  handle,
-                  verified,
-                  sourceEntityId: null,
-                  ...(metadata !== undefined ? { metadata } : {}),
+                  subject: handle,
+                  verifiedAt: null,
+                  ...(metadata !== undefined ? { profile: metadata } : {}),
                 },
               });
-
           const result = {
             ok: true,
             platosEndUserId,
             created: !existing,
-            identity: projectIdentity(row as any),
+            identity: projectIdentity(row),
           };
           auditMutation(scope, "end_users.link_identity", params, result, "success", startedAt);
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(
-            scope,
-            "end_users.link_identity",
-            params,
-            null,
-            "failed",
-            startedAt,
-            message,
-          );
-          return { error: "link_failed", message };
+        } catch {
+          auditMutation(scope, "end_users.link_identity", params, null, "failed", startedAt, "internal_error");
+          return { error: "link_failed", message: "Identity could not be linked." };
         }
       },
     },
-
     {
       name: "end_users.bind_external_id",
       description:
-        "Adopt an EXTERNAL id (e.g. the Walle DB user id = Composio " +
-        "`user_id`) onto the PlatosEndUser behind a VERIFIED (channel, handle) " +
-        "claim, so per-user Composio tools resolve `{{endUserId}}` to that " +
-        "external id. Keyed by the claim, NOT the cuid — callers (e.g. Walle " +
-        "finish-setup) supply only `(channel, handle, externalId)`.\n\n" +
-        "For Slack, `handle` is `<team>:<slackUserId>` where `<team> = " +
-        "teamId ?? enterpriseId` (an org/Grid install has teamId null ⇒ keyed " +
-        "by enterpriseId) — the SAME team-qualified handle the channel runtime " +
-        "mints. `channel` is lowercased + must match /^[a-z0-9_-]{1,32}$/; " +
-        "`externalId` is trimmed, 1..256 chars, no control chars.\n\n" +
-        "Behaviour: if a (channel, handle) identity exists, adopt its owner; " +
-        "else find-or-create a person by externalUserId=`<channel>:<handle>` " +
-        "and create the identity row with verified:true FORCED (so a later " +
-        "inbound message anchors on it) — regardless of the `verified` input " +
-        "flag. Then set linkedExternalId with idempotent OVERWRITE: an " +
-        "identical re-call is a no-op (created:false); a re-bind of the same " +
-        "claim to a NEW externalId re-links (moves the Composio identity). If " +
-        "a DIFFERENT person in scope already holds that externalId the call is " +
-        "refused with `{ error: 'external_id_conflict', existingPlatosEndUserId }`. " +
-        "Scope-pinned; audited (records old→new on a re-link).",
+        "Verify that an authenticated runtime external id belongs to the person behind a verified channel claim. This tool never creates or promotes identity trust.",
       inputSchema: {
         type: "object",
         required: ["channel", "handle", "externalId"],
@@ -380,8 +297,6 @@ export function buildEndUserToolHandlers(deps: {
           channel: { type: "string" },
           handle: { type: "string" },
           externalId: { type: "string" },
-          // Retained for wire-compat / future use. Does NOT gate the anchor:
-          // the web-first CREATE path always forces verified:true (§A.3 G5).
           verified: { type: "boolean" },
         },
         additionalProperties: false,
@@ -391,260 +306,118 @@ export function buildEndUserToolHandlers(deps: {
         const channel = sanitizeChannel(params["channel"]);
         const handle = sanitizeHandle(params["handle"]);
         const externalId = sanitizeExternalId(params["externalId"]);
-
-        if (!channel) {
-          const err = "channel must match /^[a-z0-9_-]{1,32}$/ (after lowercasing)";
-          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, err);
-          return { error: "invalid_channel", message: err };
+        if (!channel || !handle || !externalId) {
+          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, "invalid_params");
+          return { error: "invalid_params", message: "channel, handle, and externalId must be valid" };
         }
-        if (!handle) {
-          const err = "handle must be trimmed, 1..256 chars, no control chars";
-          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, err);
-          return { error: "invalid_handle", message: err };
-        }
-        if (!externalId) {
-          const err = "externalId must be trimmed, 1..256 chars, no control chars";
-          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, err);
-          return { error: "invalid_external_id", message: err };
-        }
-
-        const tuple = scopeTuple(scope);
         try {
-          // ── Step 1/2: adopt by the VERIFIED (channel, handle) claim. If the
-          //    identity row exists we adopt WHOEVER owns it — never re-point
-          //    the claim (link-not-merge). ──────────────────────────────────
-          let personId: string;
-          // `created` = we minted the web-first identity ANCHOR in step 3.
-          // Row-exists adoption, race-lost adoption, and a pure re-bind all
-          // return created:false.
-          let created = false;
-
-          const existingIdentity = await prisma.platosEndUserIdentity.findFirst({
-            where: { ...tuple, channel, handle },
-            select: { platosEndUserId: true },
-          });
-
-          if (existingIdentity) {
-            personId = existingIdentity.platosEndUserId as string;
-          } else {
-            // ── Step 3: web/finish-setup happened first — no identity row.
-            //    Find-or-create the person by externalUserId=`<channel>:<handle>`
-            //    (mirrors the authorScope.userId convention so a LATER inbound's
-            //    resolveEndUser step-(b) collapses onto the SAME person), then
-            //    lay down the (channel, handle) identity with verified:true
-            //    FORCED (§A.3 G5 — an unverified anchor would be ignored by
-            //    resolveEndUser step-(a), minting a SECOND person for the human).
-            const syntheticExternalUserId = `${channel}:${handle}`;
-            const existingPerson = await prisma.platosEndUser.findFirst({
-              where: { ...tuple, externalUserId: syntheticExternalUserId },
-              select: { id: true },
-            });
-            if (existingPerson) {
-              personId = existingPerson.id as string;
-            } else {
-              try {
-                const mintedPerson = await prisma.platosEndUser.create({
-                  data: {
-                    ...tuple,
-                    externalUserId: syntheticExternalUserId,
-                    lastActiveAt: new Date(),
-                  },
-                  select: { id: true },
-                });
-                personId = mintedPerson.id as string;
-              } catch {
-                // Race: a concurrent insert won the externalUserId unique.
-                // Re-read + adopt the winner (link-not-merge).
-                const winner = await prisma.platosEndUser.findFirst({
-                  where: { ...tuple, externalUserId: syntheticExternalUserId },
-                  select: { id: true },
-                });
-                if (!winner) throw new Error("person find-or-create race unresolved");
-                personId = winner.id as string;
-              }
-            }
-
-            // Create the forced-verified anchor. sourceEntityId carries the
-            // asserting entity as the trust anchor (same trust level the
-            // channel runtime asserts verified slack claims under).
-            try {
-              await prisma.platosEndUserIdentity.create({
-                data: {
-                  ...tuple,
-                  platosEndUserId: personId,
-                  channel,
-                  handle,
-                  verified: true, // FORCED (§A.3 G5) — ignores the input flag.
-                  sourceEntityId: scope.entityId ?? null,
+          const claim = await prisma.endUserIdentity.findFirst({
+              where: {
+                organizationId: scope.organizationId,
+                issuer: `channel:${channel}`,
+                channel,
+                subject: handle,
+                disabledAt: null,
+                verifiedAt: { not: null },
+                endUser: {
+                  organizationId: scope.organizationId,
+                  ...currentEnvironmentPresence(scope.environmentId),
                 },
-              });
-              created = true;
-            } catch {
-              // Race: the (channel, handle) row was created between our step-1
-              // read and here. Re-read + adopt its owner (link-not-merge — the
-              // claim is authoritative, never re-pointed).
-              const raced = await prisma.platosEndUserIdentity.findFirst({
-                where: { ...tuple, channel, handle },
-                select: { platosEndUserId: true },
-              });
-              if (raced) personId = raced.platosEndUserId as string;
-            }
-          }
-
-          // ── Step 4: set linkedExternalId with idempotent OVERWRITE (§A.3 G4).
-          const person = await prisma.platosEndUser.findFirst({
-            where: { id: personId, ...tuple },
-            select: { id: true, linkedExternalId: true },
-          });
-          if (!person) {
-            // The person we just resolved vanished (cross-scope / delete race).
-            auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, "not_found");
-            return { error: "not_found", channel, handle };
-          }
-          const oldLinked = (person.linkedExternalId as string | null) ?? null;
-
-          if (oldLinked === externalId) {
-            // Identical re-call → no-op.
-            const result = { ok: true, platosEndUserId: personId, externalId, created: false };
-            auditMutation(scope, "end_users.bind_external_id", params, result, "success", startedAt);
+              },
+            });
+          if (!claim) {
+            const result = {
+              error: "trusted_claim_required" as const,
+              message: "A verified runtime identity in the current Environment is required.",
+            };
+            auditMutation(scope, "end_users.bind_external_id", params, result, "failed", startedAt, result.error);
             return result;
           }
-
-          // Cross-person collision pre-check: the scoped @@unique (NULL-distinct)
-          // guards CROSS-PERSON reuse of one Composio user_id. Re-binding the
-          // SAME person's own claim never trips this (it targets the same row).
-          const clash = await prisma.platosEndUser.findFirst({
-            where: { ...tuple, linkedExternalId: externalId },
-            select: { id: true },
-          });
-          if (clash && (clash.id as string) !== personId) {
-            const conflict = {
-              error: "external_id_conflict",
-              existingPlatosEndUserId: clash.id as string,
-            };
-            auditMutation(scope, "end_users.bind_external_id", params, conflict, "failed", startedAt, "external_id_conflict");
-            return conflict;
-          }
-
-          // Overwrite (first set OR deliberate re-link). The @@unique is the
-          // race backstop: a concurrent cross-person claim throws here.
-          try {
-            await prisma.platosEndUser.update({
-              where: { id: personId },
-              data: { linkedExternalId: externalId },
+          const existingExternal = await prisma.endUserIdentity.findUnique({
+              where: {
+                organizationId_issuer_channel_subject: {
+                  organizationId: scope.organizationId,
+                  issuer: EXTERNAL_ISSUER,
+                  channel: EXTERNAL_CHANNEL,
+                  subject: externalId,
+                },
+              },
             });
-          } catch {
-            // Unique-violation race — a different person grabbed externalId
-            // between the pre-check and the write. Re-read the owner.
-            const raceClash = await prisma.platosEndUser.findFirst({
-              where: { ...tuple, linkedExternalId: externalId },
-              select: { id: true },
-            });
-            const conflict = {
-              error: "external_id_conflict",
-              existingPlatosEndUserId: (raceClash?.id as string) ?? null,
+          if (!existingExternal || existingExternal.endUserId !== claim.endUserId || !existingExternal.verifiedAt) {
+            const result = {
+              error: "trusted_claim_required" as const,
+              message: "The external id must already be verified by authenticated runtime persistence.",
             };
-            auditMutation(scope, "end_users.bind_external_id", params, conflict, "failed", startedAt, "external_id_conflict");
-            return conflict;
+            auditMutation(scope, "end_users.bind_external_id", params, result, "failed", startedAt, result.error);
+            return result;
           }
-
-          const result = { ok: true, platosEndUserId: personId, externalId, created };
-          // Record old→new on a re-link so the move (Composio identity change)
-          // is traceable in the audit trail; wire output stays the clean shape.
+          const result = {
+            ok: true as const,
+            platosEndUserId: claim.endUserId,
+            externalId,
+            created: false,
+          };
           auditMutation(
             scope,
             "end_users.bind_external_id",
             params,
-            oldLinked !== null ? { ...result, relinkedFrom: oldLinked } : result,
+            result,
             "success",
             startedAt,
           );
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, message);
-          return { error: "bind_failed", message };
+        } catch {
+          auditMutation(scope, "end_users.bind_external_id", params, null, "failed", startedAt, "internal_error");
+          return { error: "bind_failed", message: "External identity could not be bound." };
         }
       },
     },
-
     {
       name: "end_users.unlink_identity",
-      description:
-        "Detach a channel-native identity by its (channel, handle) within " +
-        "the token's scope. `channel` is lowercased before lookup; `handle` " +
-        "is trimmed. Scope-pinned — an identity in another scope is invisible " +
-        "and returns `{ ok: false, error: 'not_found' }`. Returns the row " +
-        "that was unlinked (channel, handle, verified, sourceEntityId, " +
-        "platosEndUserId) so the caller can re-link if needed. Never merges " +
-        "or re-points other rows.",
+      description: "Detach one channel identity in the token's organization without re-pointing any other identity.",
       inputSchema: {
         type: "object",
         required: ["channel", "handle"],
-        properties: {
-          channel: { type: "string" },
-          handle: { type: "string" },
-        },
+        properties: { channel: { type: "string" }, handle: { type: "string" } },
         additionalProperties: false,
       },
       async execute(params, scope) {
         const startedAt = Date.now();
         const channel = sanitizeChannel(params["channel"]);
         const handle = sanitizeHandle(params["handle"]);
-
-        if (!channel) {
-          const err = "channel must match /^[a-z0-9_-]{1,32}$/ (after lowercasing)";
-          auditMutation(scope, "end_users.unlink_identity", params, null, "failed", startedAt, err);
-          return { error: "invalid_channel", message: err };
-        }
-        if (!handle) {
-          const err = "handle must be trimmed, 1..256 chars, no control chars";
-          auditMutation(scope, "end_users.unlink_identity", params, null, "failed", startedAt, err);
-          return { error: "invalid_handle", message: err };
-        }
-
-        const tuple = scopeTuple(scope);
+        if (!channel || !handle) return { error: "invalid_params", message: "invalid channel or handle" };
         try {
-          // find-then-delete so we can (a) scope-filter the delete and
-          // (b) return exactly what was removed.
-          const existing = await prisma.platosEndUserIdentity.findFirst({
-            where: { ...tuple, channel, handle },
+          const existing = await prisma.endUserIdentity.findFirst({
+            where: {
+              organizationId: scope.organizationId,
+              issuer: MANUAL_ISSUER,
+              channel,
+              subject: handle,
+              disabledAt: null,
+              endUser: {
+                organizationId: scope.organizationId,
+                ...currentEnvironmentPresence(scope.environmentId),
+              },
+            },
           });
           if (!existing) {
             const result = { ok: false, error: "not_found", channel, handle };
-            auditMutation(
-              scope,
-              "end_users.unlink_identity",
-              params,
-              result,
-              "failed",
-              startedAt,
-              "not_found",
-            );
+            auditMutation(scope, "end_users.unlink_identity", params, result, "failed", startedAt, "not_found");
             return result;
           }
-          await prisma.platosEndUserIdentity.delete({ where: { id: existing.id } });
+          await prisma.endUserIdentity.delete({ where: { id: existing.id } });
           const result = {
             ok: true,
             unlinked: {
-              ...projectIdentity(existing as any),
-              platosEndUserId: existing.platosEndUserId,
+              ...projectIdentity(existing),
+              platosEndUserId: existing.endUserId,
             },
           };
           auditMutation(scope, "end_users.unlink_identity", params, result, "success", startedAt);
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(
-            scope,
-            "end_users.unlink_identity",
-            params,
-            null,
-            "failed",
-            startedAt,
-            message,
-          );
-          return { error: "unlink_failed", message };
+        } catch {
+          auditMutation(scope, "end_users.unlink_identity", params, null, "failed", startedAt, "internal_error");
+          return { error: "unlink_failed", message: "Identity could not be unlinked." };
         }
       },
     },

--- a/apps/agent/src/mcp-platform/tools/entities.ts
+++ b/apps/agent/src/mcp-platform/tools/entities.ts
@@ -26,15 +26,11 @@ import type { ToolExecutorService } from "../../tool-gateway/tool-executor.servi
 import type { ToolRegistryService } from "../../tool-gateway/tool-registry.service";
 import type { EntityMcpDiscoveryService } from "../../tool-gateway/mcp-transport/entity-mcp-discovery.service";
 import type { McpToolHandler } from "../mcp-router";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 import type { RequestScope } from "../../auth/scope.guard";
 import type { McpBearerTokenService } from "../mcp-bearer-token.service";
 import type { MessageCryptoService } from "../../monitoring/message-crypto.service";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
-
-// RFC 7230 token regex — mirrors the validation in
-// agent.controller.ts:patchEntity testCredentials path. Direct API callers
-// can't smuggle in \r\n and split a header.
-const HEADER_NAME_RE = /^[A-Za-z0-9!#$%&'*+.^_`|~-]+$/;
 
 function scopeTuple(scope: RequestScope) {
   return {
@@ -51,7 +47,7 @@ export function buildEntityToolHandlers(deps: {
   bearerTokens: McpBearerTokenService;
   messageCrypto: MessageCryptoService;
   toolAudit: ToolAuditService;
-  prisma: any;
+  prisma: ControlDatabaseClient;
   // MCP-connected-entity (design Commit 5) — kicks outbound tools/list
   // discovery when an mcp-kind entity is registered / manually refreshed.
   // Optional (best-effort); absent in slim test harnesses.
@@ -62,7 +58,6 @@ export function buildEntityToolHandlers(deps: {
     toolExecutor,
     toolRegistry,
     bearerTokens,
-    messageCrypto,
     toolAudit,
     prisma,
     entityMcpDiscovery,
@@ -526,8 +521,8 @@ export function buildEntityToolHandlers(deps: {
         // Join with PlatosToolHealth for the same shape the dashboard renders.
         const entityPk = tools[0]?.entityPk ?? null;
         const healthRows = entityPk
-          ? await prisma.platosToolHealth.findMany({
-              where: { environmentId: scope.environmentId, entityId: entityPk },
+          ? await prisma.toolHealth.findMany({
+              where: { environmentId: scope.environmentId, entityExternalId: entityId },
             })
           : [];
         const healthByToolId = new Map<string, any>();
@@ -617,9 +612,8 @@ export function buildEntityToolHandlers(deps: {
     {
       name: "entities.get_linked_agents",
       description:
-        "List the agents allowed to use this entity's tools. Empty array " +
-        "= unrestricted (every agent in scope sees the tools); non-empty " +
-        "= only the listed PlatosAgent.id values.",
+        "Legacy compatibility endpoint. Entity-level agent allow-lists are unsupported " +
+        "by the canonical control schema.",
       inputSchema: {
         type: "object",
         required: ["entityId"],
@@ -635,8 +629,8 @@ export function buildEntityToolHandlers(deps: {
         );
         if (!entity) return { error: "not_found", entityId };
         return {
-          entityId,
-          linkedAgentIds: (entity as { linkedAgentIds?: string[] }).linkedAgentIds ?? [],
+          error: "unsupported",
+          message: "Entity-level agent allow-lists are not supported by the canonical control schema.",
         };
       },
     },
@@ -644,10 +638,8 @@ export function buildEntityToolHandlers(deps: {
     {
       name: "entities.set_linked_agents",
       description:
-        "Replace the per-entity agent allow-list. Every supplied agentId " +
-        "must belong to (org, project, env) — forged ids return an error. " +
-        "Empty array clears the restriction (= every agent in scope sees " +
-        "the tools). Mirrors PATCH /entities/:id linkedAgentIds.",
+        "Legacy compatibility endpoint. Entity-level agent allow-lists are unsupported " +
+        "by the canonical control schema.",
       inputSchema: {
         type: "object",
         required: ["entityId", "agentIds"],
@@ -659,14 +651,6 @@ export function buildEntityToolHandlers(deps: {
       },
       async execute(params, scope) {
         const entityId = String(params["entityId"]);
-        const rawIds = (params["agentIds"] as unknown[]) ?? [];
-        const cleaned = Array.from(
-          new Set(
-            rawIds
-              .map((x) => (typeof x === "string" ? x.trim() : ""))
-              .filter((x): x is string => x.length > 0),
-          ),
-        );
         const startedAt = Date.now();
         const entity = await auth.getEntity(
           scope.organizationId,
@@ -685,42 +669,19 @@ export function buildEntityToolHandlers(deps: {
           );
           return { error: "not_found", entityId };
         }
-        // Forged-id guard: each id must belong to this scope.
-        if (cleaned.length > 0) {
-          const known = await prisma.platosAgent.findMany({
-            where: {
-              id: { in: cleaned },
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-              environmentId: scope.environmentId,
-            },
-            select: { id: true },
-          });
-          const knownIds = new Set((known as Array<{ id: string }>).map((a) => a.id));
-          const bogus = cleaned.filter((id) => !knownIds.has(id));
-          if (bogus.length > 0) {
-            auditMutation(
-              scope,
-              "entities.set_linked_agents",
-              params,
-              null,
-              "failed",
-              startedAt,
-              "unknown_agent_ids",
-            );
-            return { error: "unknown_agent_ids", unknownAgentIds: bogus };
-          }
-        }
-        await prisma.platosConnectedEntity.update({
-          where: { id: (entity as { id: string }).id },
-          data: { linkedAgentIds: cleaned },
-        });
-        // Mirror the in-memory matrix cache so next-turn enumeration sees
-        // the new allow-list without a full registry rebuild — same path
-        // used by agent.controller.ts:patchEntity.
-        toolRegistry.syncEntityLinkedAgents((entity as { id: string }).id, cleaned);
-        const result = { ok: true, entityId, count: cleaned.length };
-        auditMutation(scope, "entities.set_linked_agents", params, result, "success", startedAt);
+        const result = {
+          error: "unsupported",
+          message: "Entity-level agent allow-lists are not supported by the canonical control schema.",
+        };
+        auditMutation(
+          scope,
+          "entities.set_linked_agents",
+          params,
+          null,
+          "failed",
+          startedAt,
+          result.message,
+        );
         return result;
       },
     },
@@ -728,9 +689,8 @@ export function buildEntityToolHandlers(deps: {
     {
       name: "entities.get_test_credentials",
       description:
-        "Fetch the entity's stored test-credential headers — DECRYPTED in " +
-        "memory, returned in plaintext. Caller already has scope access; " +
-        "encryption is purely an at-rest defence. Audit-logged.",
+        "Legacy compatibility endpoint. Entity test credentials are unsupported by " +
+        "the canonical control schema.",
       inputSchema: {
         type: "object",
         required: ["entityId"],
@@ -757,82 +717,28 @@ export function buildEntityToolHandlers(deps: {
           );
           return { error: "not_found", entityId };
         }
-        const encrypted = (entity as { testCredentials?: string | null }).testCredentials;
-        if (!encrypted) {
-          // Read still audited so we can prove no plaintext was served.
-          auditMutation(
-            scope,
-            "entities.get_test_credentials",
-            params,
-            { empty: true },
-            "success",
-            startedAt,
-          );
-          return { entityId, headers: [], empty: true };
-        }
-        try {
-          const envelope = JSON.parse(encrypted);
-          const decrypted = messageCrypto.decryptJsonField(envelope) as {
-            headers?: Array<{ name: string; value: string }>;
-            userId?: string;
-            updatedAt?: string;
-            updatedByUserId?: string;
-          } | null;
-          if (!decrypted || (decrypted as any).__platos_enc === 1) {
-            auditMutation(
-              scope,
-              "entities.get_test_credentials",
-              params,
-              null,
-              "failed",
-              startedAt,
-              "decryption_failed",
-            );
-            return {
-              error: "decryption_failed",
-              message: "Test credentials present but the encryption key changed.",
-            };
-          }
-          const result = {
-            entityId,
-            headers: decrypted.headers ?? [],
-            userId: decrypted.userId,
-            updatedAt: decrypted.updatedAt,
-            updatedByUserId: decrypted.updatedByUserId,
-          };
-          // Audit the access — log a redacted summary (count only, never
-          // header values) so the audit log itself doesn't become a leak.
-          auditMutation(
-            scope,
-            "entities.get_test_credentials",
-            params,
-            { entityId, headerCount: (decrypted.headers ?? []).length },
-            "success",
-            startedAt,
-          );
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(
-            scope,
-            "entities.get_test_credentials",
-            params,
-            null,
-            "failed",
-            startedAt,
-            message,
-          );
-          return { error: "decryption_failed", message };
-        }
+        const result = {
+          error: "unsupported",
+          message: "Entity test credentials are not supported by the canonical control schema.",
+        };
+        auditMutation(
+          scope,
+          "entities.get_test_credentials",
+          params,
+          null,
+          "failed",
+          startedAt,
+          result.message,
+        );
+        return result;
       },
     },
 
     {
       name: "entities.set_test_credentials",
       description:
-        "Store encrypted test-credential headers used when 'Test' is " +
-        "clicked from the dashboard. Validates RFC 7230 names + 4096-char " +
-        "value cap + 32-header total. Pass `null` to clear. Audit-logged.",
+        "Legacy compatibility endpoint. Entity test credentials are unsupported by " +
+        "the canonical control schema.",
       inputSchema: {
         type: "object",
         required: ["entityId"],
@@ -884,90 +790,19 @@ export function buildEntityToolHandlers(deps: {
           );
           return { error: "not_found", entityId };
         }
-        const entityPk = (entity as { id: string }).id;
-        const raw = params["testCredentials"] as
-          | { headers: Array<{ name: string; value: string }>; userId?: string }
-          | null
-          | undefined;
-
-        if (raw === null) {
-          await prisma.platosConnectedEntity.update({
-            where: { id: entityPk },
-            data: { testCredentials: null },
-          });
-          auditMutation(
-            scope,
-            "entities.set_test_credentials",
-            { entityId, cleared: true },
-            { ok: true, cleared: true },
-            "success",
-            startedAt,
-          );
-          return { ok: true, cleared: true };
-        }
-
-        if (!raw || typeof raw !== "object" || !Array.isArray(raw.headers)) {
-          return { error: "headers must be an array" };
-        }
-        if (raw.headers.length > 32) {
-          return { error: "Too many test-credential headers (max 32).", limit: 32 };
-        }
-        const invalidHeaders: string[] = [];
-        const cleaned: Array<{ name: string; value: string }> = [];
-        for (const h of raw.headers) {
-          if (
-            !h ||
-            typeof h !== "object" ||
-            typeof h.name !== "string" ||
-            typeof h.value !== "string"
-          ) {
-            return { error: "Every header needs a string name + string value." };
-          }
-          const name = h.name.trim();
-          const value = h.value.trim();
-          if (!HEADER_NAME_RE.test(name)) {
-            invalidHeaders.push(name);
-            continue;
-          }
-          if (value.length > 4096) {
-            return {
-              error: "Header values capped at 4096 chars.",
-              headerName: name,
-            };
-          }
-          cleaned.push({ name, value });
-        }
-        if (invalidHeaders.length > 0) {
-          return {
-            error: "One or more header names violate RFC 7230.",
-            invalidHeaders,
-          };
-        }
-        const userId =
-          typeof raw.userId === "string" && raw.userId.trim().length > 0
-            ? raw.userId.trim()
-            : undefined;
-        const stash = {
-          headers: cleaned,
-          userId,
-          updatedAt: new Date().toISOString(),
-          updatedByUserId: scope.userId,
-        };
-        const encrypted = messageCrypto.encryptJsonField(stash);
-        await prisma.platosConnectedEntity.update({
-          where: { id: entityPk },
-          data: { testCredentials: JSON.stringify(encrypted) },
-        });
-        // Redacted audit — count + name list only, never header values.
         auditMutation(
           scope,
           "entities.set_test_credentials",
-          { entityId, headerCount: cleaned.length, headerNames: cleaned.map((h) => h.name) },
-          { ok: true, headerCount: cleaned.length },
-          "success",
+          { entityId },
+          null,
+          "failed",
           startedAt,
+          "unsupported by canonical control schema",
         );
-        return { ok: true, headerCount: cleaned.length };
+        return {
+          error: "unsupported",
+          message: "Entity test credentials are not supported by the canonical control schema.",
+        };
       },
     },
 
@@ -993,8 +828,8 @@ export function buildEntityToolHandlers(deps: {
         );
         if (!entity) return { error: "not_found", entityId };
         const entityPk = (entity as { id: string }).id;
-        const config = await prisma.platosEntityMcpConfig.findUnique({
-          where: { entityPk },
+        const config = await prisma.entityMcpConfig.findUnique({
+          where: { entityId: entityPk },
         });
         if (!config) {
           return {
@@ -1014,15 +849,15 @@ export function buildEntityToolHandlers(deps: {
           };
         }
         return {
-          entityPk: config.entityPk,
+          entityPk: config.entityId,
           entityId,
           enabled: config.enabled,
           identityMode: config.identityMode,
           identityProviders: config.identityProviders,
-          bearerTokenCount: config.bearerTokenCount,
+          bearerTokenCount: await prisma.mcpBearerToken.count({ where: { entityId: entityPk } }),
           branding: config.branding,
           toolAllowlist: config.toolAllowlist,
-          consentCopy: config.consentCopy,
+          consentCopy: null,
           redirectUriAllowlist: config.redirectUriAllowlist,
           rateLimitPerMinute: config.rateLimitPerMinute,
           injectMcpContext: config.injectMcpContext === true,
@@ -1068,9 +903,9 @@ export function buildEntityToolHandlers(deps: {
           return { error: "not_found", entityId };
         }
         const entityPk = (entity as { id: string }).id;
-        await prisma.platosEntityMcpConfig.upsert({
-          where: { entityPk },
-          create: { entityPk, enabled },
+        await prisma.entityMcpConfig.upsert({
+          where: { entityId: entityPk },
+          create: { entityId: entityPk, enabled, identityMode: "bearer" },
           update: { enabled },
         });
         const result = { ok: true, entityId, enabled };
@@ -1121,9 +956,9 @@ export function buildEntityToolHandlers(deps: {
           return { error: "not_found", entityId };
         }
         const entityPk = (entity as { id: string }).id;
-        await prisma.platosEntityMcpConfig.upsert({
-          where: { entityPk },
-          create: { entityPk, injectMcpContext: enabled },
+        await prisma.entityMcpConfig.upsert({
+          where: { entityId: entityPk },
+          create: { entityId: entityPk, injectMcpContext: enabled, identityMode: "bearer" },
           update: { injectMcpContext: enabled },
         });
         // Bust the in-memory tool registry cache so the new flag takes

--- a/apps/agent/src/mcp-platform/tools/index.ts
+++ b/apps/agent/src/mcp-platform/tools/index.ts
@@ -91,6 +91,7 @@ import type { ProviderHealthService } from "../../auth/provider-health.service";
 import type { OrganizationService } from "../../admin/organization.service";
 import type { EnvironmentService } from "../../admin/environment.service";
 import type { AgentClusterService } from "../../agent-runtime/agent-cluster.service";
+import type { ChannelPersistenceService } from "../../channels/channel-persistence.service";
 
 /**
  * Factory that builds the handler list. Takes the services as
@@ -146,6 +147,7 @@ export function buildPlatformToolHandlers(deps: {
   orgs: OrganizationService;
   envs: EnvironmentService;
   clusters: AgentClusterService;
+  channelPersistence: ChannelPersistenceService;
   /**
    * Connect channels.* — evict the channels runtime's cached Chat instance
    * after update / delete / rotate_webhook_secret so credential/config/routing
@@ -782,7 +784,7 @@ export function buildPlatformToolHandlers(deps: {
   handlers.push(
     ...buildChannelToolHandlers({
       prisma: deps.prisma,
-      messageCrypto: deps.messageCrypto,
+      channelPersistence: deps.channelPersistence,
       toolAudit: deps.toolAudit,
       // Evict the cached Chat instance after mutations (stale-credential fix).
       invalidateRuntime: deps.invalidateChannelRuntime,
@@ -798,7 +800,7 @@ export function buildPlatformToolHandlers(deps: {
   handlers.push(
     ...buildChannelAppToolHandlers({
       prisma: deps.prisma,
-      messageCrypto: deps.messageCrypto,
+      channelPersistence: deps.channelPersistence,
       toolAudit: deps.toolAudit,
       // Evict the cached decrypted bot token(s) after mutations.
       invalidateApp: deps.invalidateChannelApp,
@@ -943,9 +945,8 @@ export function buildPlatformToolHandlers(deps: {
   );
 
   // ── MCPF-W4 alert_channels.* (6 tools) ────────────────────────────
-  // Wraps ProjectAlertChannel CRUD + a webhook test path. SLACK + EMAIL
-  // tests delegate to the webapp delivery service (the agent doesn't
-  // hold the Slack OAuth tokens or the email transport).
+  // Preserves the alert-channel inventory with stable unavailable responses
+  // until WIN-124 adds canonical persistence.
   handlers.push(
     ...buildAlertChannelToolHandlers({
       toolAudit: deps.toolAudit,
@@ -954,9 +955,8 @@ export function buildPlatformToolHandlers(deps: {
   );
 
   // ── MCPF-W6 monitoring.* (5 tools) ────────────────────────────────
-  // Read-only operator surface: list TaskRuns, fetch full thread traces,
-  // list traces with cost rollups, probe provider health. No approval
-  // gates (everything is read).
+  // Read-only operator surface: run history is explicitly unavailable;
+  // canonical thread traces, cost rollups, and provider health remain active.
   handlers.push(
     ...buildMonitoringToolHandlers({
       traces: deps.traces,
@@ -972,8 +972,7 @@ export function buildPlatformToolHandlers(deps: {
   //   environments.create / environments.delete
   //   environments.set_secret / environments.delete_secret
   //   clusters.create / clusters.add_agent
-  // Secrets NEVER leak through MCP — list returns names only, set/delete
-  // audit the name only.
+  // Credential tools fail before persistence/audit until WIN-124 lands.
   handlers.push(
     ...buildSettingsToolHandlers({
       orgs: deps.orgs,

--- a/apps/agent/src/mcp-platform/tools/macros.ts
+++ b/apps/agent/src/mcp-platform/tools/macros.ts
@@ -41,6 +41,7 @@ import type { McpRouter, McpToolHandler, JsonRpcRequest } from "../mcp-router";
 import type { VerifiedToken } from "../token.service";
 import type { RequestScope } from "../../auth/scope.guard";
 import { resolvePath } from "../../agent-runtime/context-resolver";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
 
@@ -50,6 +51,21 @@ function tuple(scope: RequestScope): ScopeTuple {
     projectId: scope.projectId,
     environmentId: scope.environmentId,
   };
+}
+
+function macroScopeWhere(scope: ScopeTuple) {
+  return {
+    environmentId: scope.environmentId,
+    environment: {
+      projectId: scope.projectId,
+      project: { organizationId: scope.organizationId },
+    },
+  } as const;
+}
+
+function publicMacro<T extends { sharedWithOrganization: boolean }>(row: T) {
+  const { sharedWithOrganization, ...rest } = row;
+  return { ...rest, sharedWithOrg: sharedWithOrganization };
 }
 
 export interface MacroStep {
@@ -145,30 +161,26 @@ function substitutePlaceholders(value: unknown, params: unknown): unknown {
 
 function isOwnerOrSharedInScope(
   row: {
-    organizationId: string;
-    projectId: string;
     environmentId: string;
     createdBy: string;
-    sharedWithOrg: boolean;
+    sharedWithOrganization: boolean;
   },
   scope: ScopeTuple,
   userId: string | null,
 ): "owner" | "shared" | null {
   if (
-    row.organizationId !== scope.organizationId ||
-    row.projectId !== scope.projectId ||
     row.environmentId !== scope.environmentId
   ) {
     return null;
   }
   if (userId && row.createdBy === userId) return "owner";
-  if (row.sharedWithOrg) return "shared";
+  if (row.sharedWithOrganization) return "shared";
   return null;
 }
 
 export function buildMacroToolHandlers(deps: {
   state: MacroRecordingState;
-  prisma: any;
+  prisma: ControlDatabaseClient;
   /**
    * Back-reference so `macros.replay` can re-dispatch each step through
    * the same JSON-RPC router (same permission gate + audit + scope
@@ -226,9 +238,9 @@ export function buildMacroToolHandlers(deps: {
         if (!finalized) {
           throw new Error(`no active recording with id '${recordingId}' for this token`);
         }
-        const macro = await prisma.platosMacro.create({
+        const macro = await prisma.macro.create({
           data: {
-            ...tuple(scope),
+            environmentId: scope.environmentId,
             name,
             description,
             steps: finalized.steps as any,
@@ -236,7 +248,7 @@ export function buildMacroToolHandlers(deps: {
             createdBy: finalized.createdBy,
           },
         });
-        return { macro };
+        return { macro: publicMacro(macro) };
       },
     },
     {
@@ -253,15 +265,15 @@ export function buildMacroToolHandlers(deps: {
       async execute(params, scope, token) {
         const limit = (params["limit"] as number) ?? 100;
         const userId = token.mintedByUserId;
-        const macros = await prisma.platosMacro.findMany({
+        const macros = await prisma.macro.findMany({
           where: {
-            ...tuple(scope),
-            OR: [{ createdBy: userId }, { sharedWithOrg: true }],
+            ...macroScopeWhere(tuple(scope)),
+            OR: [{ createdBy: userId }, { sharedWithOrganization: true }],
           },
           orderBy: [{ updatedAt: "desc" }],
           take: limit,
         });
-        return { macros };
+        return { macros: macros.map(publicMacro) };
       },
     },
     {
@@ -275,12 +287,14 @@ export function buildMacroToolHandlers(deps: {
       },
       async execute(params, scope, token) {
         const macroId = String(params["macroId"]);
-        const row = await prisma.platosMacro.findUnique({ where: { id: macroId } });
+        const row = await prisma.macro.findFirst({
+          where: { id: macroId, ...macroScopeWhere(tuple(scope)) },
+        });
         if (!row) throw new Error(`macro ${macroId} not found`);
         if (!isOwnerOrSharedInScope(row, tuple(scope), token.mintedByUserId)) {
           throw new Error(`macro ${macroId} not found in scope`);
         }
-        return { macro: row };
+        return { macro: publicMacro(row) };
       },
     },
     {
@@ -301,13 +315,12 @@ export function buildMacroToolHandlers(deps: {
       },
       async execute(params, scope, token) {
         const macroId = String(params["macroId"]);
-        const row = await prisma.platosMacro.findUnique({ where: { id: macroId } });
+        const row = await prisma.macro.findFirst({
+          where: { id: macroId, ...macroScopeWhere(tuple(scope)) },
+        });
         if (!row) throw new Error(`macro ${macroId} not found`);
         // Scope-match + owner gate (shared readers cannot mutate).
         if (
-          row.organizationId !== scope.organizationId ||
-          row.projectId !== scope.projectId ||
-          row.environmentId !== scope.environmentId ||
           row.createdBy !== token.mintedByUserId
         ) {
           throw new Error(`macro ${macroId} not editable by this token`);
@@ -315,10 +328,12 @@ export function buildMacroToolHandlers(deps: {
         const data: Record<string, unknown> = {};
         if (typeof params["name"] === "string") data["name"] = params["name"];
         if ("description" in params) data["description"] = params["description"] ?? null;
-        if (typeof params["sharedWithOrg"] === "boolean") data["sharedWithOrg"] = params["sharedWithOrg"];
+        if (typeof params["sharedWithOrg"] === "boolean") {
+          data["sharedWithOrganization"] = params["sharedWithOrg"];
+        }
         if ("paramSchema" in params) data["paramSchema"] = params["paramSchema"] ?? null;
-        const updated = await prisma.platosMacro.update({ where: { id: macroId }, data });
-        return { macro: updated };
+        const updated = await prisma.macro.update({ where: { id: macroId }, data });
+        return { macro: publicMacro(updated) };
       },
     },
     {
@@ -333,17 +348,16 @@ export function buildMacroToolHandlers(deps: {
       },
       async execute(params, scope, token) {
         const macroId = String(params["macroId"]);
-        const row = await prisma.platosMacro.findUnique({ where: { id: macroId } });
+        const row = await prisma.macro.findFirst({
+          where: { id: macroId, ...macroScopeWhere(tuple(scope)) },
+        });
         if (!row) return { ok: false, macroId };
         if (
-          row.organizationId !== scope.organizationId ||
-          row.projectId !== scope.projectId ||
-          row.environmentId !== scope.environmentId ||
           row.createdBy !== token.mintedByUserId
         ) {
           throw new Error(`macro ${macroId} not deletable by this token`);
         }
-        await prisma.platosMacro.delete({ where: { id: macroId } });
+        await prisma.macro.delete({ where: { id: macroId } });
         return { ok: true, macroId };
       },
     },
@@ -363,21 +377,20 @@ export function buildMacroToolHandlers(deps: {
       async execute(params, scope, token) {
         const macroId = String(params["macroId"]);
         const sharedWithOrg = Boolean(params["sharedWithOrg"]);
-        const row = await prisma.platosMacro.findUnique({ where: { id: macroId } });
+        const row = await prisma.macro.findFirst({
+          where: { id: macroId, ...macroScopeWhere(tuple(scope)) },
+        });
         if (!row) throw new Error(`macro ${macroId} not found`);
         if (
-          row.organizationId !== scope.organizationId ||
-          row.projectId !== scope.projectId ||
-          row.environmentId !== scope.environmentId ||
           row.createdBy !== token.mintedByUserId
         ) {
           throw new Error(`macro ${macroId} not editable by this token`);
         }
-        const updated = await prisma.platosMacro.update({
+        const updated = await prisma.macro.update({
           where: { id: macroId },
-          data: { sharedWithOrg },
+          data: { sharedWithOrganization: sharedWithOrg },
         });
-        return { macro: updated };
+        return { macro: publicMacro(updated) };
       },
     },
     {
@@ -396,12 +409,14 @@ export function buildMacroToolHandlers(deps: {
       async execute(params, scope, token) {
         const macroId = String(params["macroId"]);
         const replayParams = (params["params"] as Record<string, unknown> | undefined) ?? {};
-        const row = await prisma.platosMacro.findUnique({ where: { id: macroId } });
+        const row = await prisma.macro.findFirst({
+          where: { id: macroId, ...macroScopeWhere(tuple(scope)) },
+        });
         if (!row) throw new Error(`macro ${macroId} not found`);
         if (!isOwnerOrSharedInScope(row, tuple(scope), token.mintedByUserId)) {
           throw new Error(`macro ${macroId} not found in scope`);
         }
-        const steps = Array.isArray(row.steps) ? (row.steps as MacroStep[]) : [];
+        const steps = Array.isArray(row.steps) ? (row.steps as unknown as MacroStep[]) : [];
         const router = getRouter();
 
         const results: Array<{

--- a/apps/agent/src/mcp-platform/tools/mcp.ts
+++ b/apps/agent/src/mcp-platform/tools/mcp.ts
@@ -17,6 +17,7 @@ import type { McpBearerTokenService } from "../mcp-bearer-token.service";
 import type { AuthService } from "../../auth/auth.service";
 import type { McpToolHandler } from "../mcp-router";
 import type { RequestScope } from "../../auth/scope.guard";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
 
@@ -31,7 +32,7 @@ function tuple(scope: RequestScope): ScopeTuple {
 export function buildMcpToolHandlers(deps: {
   auth: AuthService;
   bearerTokens: McpBearerTokenService;
-  prisma: any;
+  prisma: ControlDatabaseClient;
 }): McpToolHandler[] {
   const { auth, bearerTokens, prisma } = deps;
 
@@ -143,19 +144,19 @@ export function buildMcpToolHandlers(deps: {
           deletedAt: null,
         };
         if (entityPkFilter !== undefined) {
-          where["entityPk"] = entityPkFilter;
+          where["entityId"] = entityPkFilter;
         } else {
           // Default: only entity-pinned MCP clients (the platform-wide
           // K.10 clients aren't MCP-specific).
-          where["entityPk"] = { not: null };
+          where["entityId"] = { not: null };
         }
-        const clients = await prisma.platosOAuthClient.findMany({
+        const clients = await prisma.oAuthClient.findMany({
           where,
           select: {
             id: true,
             clientId: true,
             clientName: true,
-            entityPk: true,
+            entityId: true,
             redirectUris: true,
             createdAt: true,
           },
@@ -164,12 +165,12 @@ export function buildMcpToolHandlers(deps: {
         if (clients.length === 0) {
           return { clients: [] };
         }
-        const clientIds = (clients as Array<{ clientId: string }>).map((c) => c.clientId);
+        const clientIds = (clients as Array<{ id: string }>).map((c) => c.id);
         const now = new Date();
-        const activeTokens = await prisma.platosOAuthAccessToken.findMany({
+        const activeTokens = await prisma.oAuthAccessToken.findMany({
           where: {
             clientId: { in: clientIds },
-            scopeTuple: { path: ["organizationId"], equals: scope.organizationId },
+            organizationId: scope.organizationId,
             revokedAt: null,
             expiresAt: { gt: now },
           },
@@ -203,16 +204,16 @@ export function buildMcpToolHandlers(deps: {
             id: string;
             clientId: string;
             clientName: string;
-            entityPk: string | null;
+            entityId: string | null;
             redirectUris: string[];
             createdAt: Date;
           }>).map((c) => {
-            const stats = byClient.get(c.clientId);
+            const stats = byClient.get(c.id);
             return {
               id: c.id,
               clientId: c.clientId,
               clientName: c.clientName,
-              entityPk: c.entityPk ?? null,
+              entityPk: c.entityId ?? null,
               redirectUris: c.redirectUris,
               createdAt:
                 c.createdAt instanceof Date ? c.createdAt.toISOString() : String(c.createdAt),

--- a/apps/agent/src/mcp-platform/tools/monitoring.ts
+++ b/apps/agent/src/mcp-platform/tools/monitoring.ts
@@ -5,7 +5,7 @@
  * trace viewer + cost rollups + provider health entirely via MCP.
  *
  * Tools:
- *   • `runs.list_all`   — list trigger.dev TaskRuns in scope
+ *   • `runs.list_all`   — stable unavailable response until canonical run history exists
  *   • `runs.get_trace`  — fetch full thread trace (messages + spans + rollup)
  *   • `traces.list`     — list threads with cost rollups (lightweight sibling)
  *   • `traces.get`      — alias for `runs.get_trace` (operator-friendly name)
@@ -36,17 +36,14 @@ export function buildMonitoringToolHandlers(deps: {
   providerHealth: ProviderHealthService;
   prisma: any;
 }): McpToolHandler[] {
-  const { traces, providerHealth, prisma } = deps;
+  const { traces, providerHealth } = deps;
 
   return [
     {
       name: "runs.list_all",
       description:
-        "List trigger.dev TaskRuns in the caller's scope. Filters by " +
-        "optional `taskIdentifier`, `status` (PENDING / EXECUTING / " +
-        "COMPLETED_SUCCESSFULLY / COMPLETED_WITH_ERRORS / FAILED / " +
-        "CANCELED / etc.), and `since` (ISO timestamp). Newest-first. " +
-        "Returns metadata only — payload + traceContext are NEVER echoed.",
+        "Task run history is unavailable until a canonical run-history " +
+        "model is added to the control database.",
       inputSchema: {
         type: "object",
         properties: {
@@ -58,44 +55,11 @@ export function buildMonitoringToolHandlers(deps: {
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const reqScope = scope as RequestScope;
-        const limit = Math.max(1, Math.min((params["limit"] as number) ?? 50, 200));
-        const offset = Math.max(0, (params["offset"] as number) ?? 0);
-        const where: Record<string, unknown> = {
-          runtimeEnvironmentId: reqScope.environmentId,
-          projectId: reqScope.projectId,
+      async execute() {
+        return {
+          error: "unavailable",
+          message: "Task run history is not available through the canonical control database.",
         };
-        if (params["taskIdentifier"]) where["taskIdentifier"] = String(params["taskIdentifier"]);
-        if (params["status"]) where["status"] = String(params["status"]);
-        if (params["since"]) {
-          const since = new Date(String(params["since"]));
-          if (!isNaN(since.getTime())) where["createdAt"] = { gte: since };
-        }
-        const runs = await prisma.taskRun.findMany({
-          where,
-          orderBy: { createdAt: "desc" },
-          take: limit,
-          skip: offset,
-          select: {
-            id: true,
-            friendlyId: true,
-            taskIdentifier: true,
-            status: true,
-            traceId: true,
-            spanId: true,
-            attemptNumber: true,
-            usageDurationMs: true,
-            costInCents: true,
-            baseCostInCents: true,
-            startedAt: true,
-            executedAt: true,
-            completedAt: true,
-            createdAt: true,
-            updatedAt: true,
-          },
-        });
-        return { runs, count: runs.length };
       },
     },
     {

--- a/apps/agent/src/mcp-platform/tools/orchestration.ts
+++ b/apps/agent/src/mcp-platform/tools/orchestration.ts
@@ -31,6 +31,7 @@ import type { SkillRegistryService } from "../../skills/skill-registry.service";
 import type { MemoryService } from "../../memory/memory.service";
 import type { GoldenSetService } from "../../evals/golden-set.service";
 import type { McpToolHandler } from "../mcp-router";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 import type { RequestScope } from "../../auth/scope.guard";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
@@ -54,7 +55,7 @@ export interface OrchestrationDeps {
    * agent contextMapping update + the entities.provision tool-mapping
    * stubs, both of which have no dedicated service method.
    */
-  prisma: any;
+  prisma: ControlDatabaseClient;
 }
 
 export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpToolHandler[] {
@@ -66,7 +67,8 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
       name: "agents.deploy_with_skills",
       description:
         "Composite — create a new agent + enable a list of scope-resident skills on it + " +
-        "(optionally) set its contextMapping. Returns the fully-configured agent. " +
+        "return the fully-configured agent. contextMapping is rejected because it has no " +
+        "canonical persistence field. " +
         "Destructive — defaults to require_approval at platform tier.",
       inputSchema: {
         type: "object",
@@ -94,6 +96,13 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
         const systemPrompt = params["systemPrompt"] as string | undefined;
         const skillSlugs = (params["skillSlugs"] as string[]) ?? [];
         const contextMapping = params["contextMapping"] as Record<string, unknown> | null | undefined;
+
+        if (contextMapping !== undefined && contextMapping !== null) {
+          return {
+            error: "unsupported",
+            message: "contextMapping is not supported by the canonical control schema",
+          };
+        }
 
         // Step 1 — create the agent. Hard fail — nothing to return otherwise.
         const dto: CreateAgentDto = {
@@ -128,33 +137,16 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
           }
         }
 
-        // Step 3 — optional contextMapping. Fail-open: surface in warnings,
-        // keep the agent.
-        let contextMappingApplied = false;
-        let contextMappingWarning: string | null = null;
-        if (contextMapping !== undefined && contextMapping !== null) {
-          try {
-            await prisma.platosAgent.update({
-              where: { id: agent.id },
-              data: { contextMapping: contextMapping as any },
-            });
-            contextMappingApplied = true;
-          } catch (err: any) {
-            contextMappingWarning = err?.message || String(err);
-          }
-        }
-
-        // Step 4 — re-fetch so the returned record reflects the contextMapping
-        // + versioning side-effects from skill enablement.
+        // Step 4 — re-fetch so the returned record reflects versioning
+        // side-effects from skill enablement.
         const fresh = await agentCrud.findById(agent.id, scope);
 
         return {
           agent: fresh ?? agent,
           enabledSkills,
-          contextMappingApplied,
+          contextMappingApplied: false,
           warnings: {
             skills: skillWarnings,
-            ...(contextMappingWarning ? { contextMapping: contextMappingWarning } : {}),
           },
         };
       },
@@ -222,34 +214,30 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
             // owns that name, and post-migration `findUnique({name})` throws
             // (name is no longer a unique key) — silently swallowed into
             // toolWarnings, so stubs would stop being created.
-            const existing = await prisma.platosToolDefinition.findFirst({
+            const existing = await prisma.tool.findFirst({
               where: {
                 name: toolName,
-                organizationId: scope.organizationId,
-                projectId: scope.projectId,
+                schemaHash: "stub",
               },
             });
             const toolDef = existing
               ? existing
-              : await prisma.platosToolDefinition.create({
+              : await prisma.tool.create({
                   data: {
                     name: toolName,
-                    organizationId: scope.organizationId,
-                    projectId: scope.projectId,
                     description: `[stub] ${toolName} — schema pending tool-sync handshake.`,
                     paramSchema: { type: "object", additionalProperties: true } as any,
                     schemaHash: "stub",
-                    bm25Tokens: [toolName],
                     category: null,
                   },
                 });
             // Then upsert the per-(tool, entity, env) mapping stub.
-            await prisma.platosEntityToolMapping.upsert({
+            await prisma.environmentEntityTool.upsert({
               where: {
-                toolId_entityId_environmentId: {
+                environmentId_entityId_toolId: {
+                  environmentId: scope.environmentId,
                   toolId: toolDef.id,
                   entityId: entity.id,
-                  environmentId: scope.environmentId,
                 },
               },
               update: { enabled: false, callbackUrl },
@@ -379,7 +367,8 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
       description:
         "Composite — snapshot an existing agent's config and create a fresh copy in the " +
         "SAME scope with a new name + slug. Copies promptBlocks, dynamicBlocks, tool + " +
-        "meta-tool config, memory/extraction policy, output schema, and contextMapping. " +
+        "meta-tool config, memory/extraction policy, and output schema. contextMapping " +
+        "is not part of the canonical agent graph and is not copied. " +
         "Does NOT copy threads, versions, or canary pointers — the clone starts clean.",
       inputSchema: {
         type: "object",
@@ -432,32 +421,9 @@ export function buildOrchestrationToolHandlers(deps: OrchestrationDeps): McpTool
         };
         const cloned = await agentCrud.create(scope, createDto);
 
-        // Step 2 — copy contextMapping via direct Prisma update. The CRUD
-        // service's create/update DTOs don't expose this field today; the
-        // schema does (CTX.1). Fail-open: if the copy errors, the clone
-        // still exists, we just note it in warnings.
-        let contextMappingCopied = false;
-        let contextMappingWarning: string | null = null;
-        try {
-          const srcRow = await prisma.platosAgent.findFirst({
-            where: {
-              id: sourceAgentId,
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-              environmentId: scope.environmentId,
-            },
-            select: { contextMapping: true },
-          });
-          if (srcRow?.contextMapping != null) {
-            await prisma.platosAgent.update({
-              where: { id: cloned.id },
-              data: { contextMapping: srcRow.contextMapping as any },
-            });
-            contextMappingCopied = true;
-          }
-        } catch (err: any) {
-          contextMappingWarning = err?.message || String(err);
-        }
+        const contextMappingCopied = false;
+        const contextMappingWarning =
+          "contextMapping is not supported by the canonical control schema";
 
         const fresh = await agentCrud.findById(cloned.id, scope);
         return {

--- a/apps/agent/src/mcp-platform/tools/platos_tasks.ts
+++ b/apps/agent/src/mcp-platform/tools/platos_tasks.ts
@@ -1,44 +1,17 @@
+import { Prisma, type Job } from "@platos/tenancy-database";
 import { configureExternalTriggerSdk } from "../../shared/external-trigger-config";
-
-/**
- * Theme MCPF-W4 — PlatosTask management MCP tools (10 tools).
- *
- * Wraps the operator-authored custom-task surface introduced by PIFSP-12.
- * Each handler is scope-pinned via the verified MCP token and hits Prisma
- * directly through the shared client (no separate service layer — the
- * existing PlatosTasksController is also a thin Prisma wrapper).
- *
- * Tools:
- *   • `platos_tasks.list`              — list custom tasks in scope
- *   • `platos_tasks.get`               — fetch one task (handler source included)
- *   • `platos_tasks.create`            — create + syntax-check + activate (gated)
- *   • `platos_tasks.update`            — patch fields / replace handler (gated)
- *   • `platos_tasks.delete`            — drop a task (gated)
- *   • `platos_tasks.run`               — manually dispatch via trigger.dev (gated)
- *   • `platos_tasks.get_runs`          — list recent TaskRun rows for a task
- *   • `platos_tasks.get_run`           — fetch a single TaskRun (scope-checked)
- *   • `platos_tasks.set_enabled`       — toggle isActive flag (gated)
- *   • `platos_tasks.validate_handler`  — syntax-check a handler source (read-only)
- *
- * Tier-1 require_approval (set in `permission-gateway.service.ts`
- * PLATFORM_TIER_MINIMUMS):
- *   - platos_tasks.create
- *   - platos_tasks.update
- *   - platos_tasks.delete
- *   - platos_tasks.run
- *   - platos_tasks.set_enabled
- *
- * Audit logging mirrors `entities.ts`: mutations record metadata only —
- * never the raw handler source (it can carry secrets the operator hardcoded
- * before SecretStore was an option). Read-only tools (`list`, `get`,
- * `get_runs`, `get_run`, `validate_handler`) skip the audit pipe entirely.
- */
-
-import type { McpToolHandler } from "../mcp-router";
 import type { RequestScope } from "../../auth/scope.guard";
 import type { ToolAuditService } from "../../monitoring/tool-audit.service";
+import {
+  type ControlDatabaseClient,
+  environmentScopeWhere,
+} from "../../shared/database.provider";
+import type { McpToolHandler } from "../mcp-router";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
+
+const TASK_ID_RE = /^[a-z0-9-]{1,64}$/;
+const TRIGGER_TYPES = new Set(["manual", "schedule", "webhook", "agent-spawn"]);
 
 function tuple(scope: RequestScope): ScopeTuple {
   return {
@@ -48,47 +21,17 @@ function tuple(scope: RequestScope): ScopeTuple {
   };
 }
 
-function scopeWhere(scope: RequestScope) {
-  return {
-    organizationId: scope.organizationId,
-    projectId: scope.projectId,
-    environmentId: scope.environmentId,
-  };
-}
-
-const TASK_ID_RE = /^[a-z0-9-]{1,64}$/;
-const TRIGGER_TYPES = new Set(["manual", "schedule", "webhook", "agent-spawn"]);
-
-/**
- * Compile-check operator JS without executing it. Returns null on clean
- * parse, otherwise a one-line error message.
- */
 function checkSyntax(source: string): string | null {
   try {
     // eslint-disable-next-line no-new-func
     new Function("payload", "ctx", source);
     return null;
-  } catch (err: any) {
-    return err?.message ?? "Syntax error";
+  } catch (error: unknown) {
+    return error instanceof Error ? error.message : "Syntax error";
   }
 }
 
-/**
- * MCPF-followup — detect ESM-only syntax in operator handler source.
- * `new Function(...)` runs in a CommonJS-style context, so `export
- * default`, top-level `import`, and bare `import.meta` references
- * surface as opaque "Unexpected token 'export'" parse errors. Returning
- * a more specific hint short-circuits the user-facing error message.
- *
- * Returns the matched hint or null when no ESM-specific syntax found.
- * False positives are acceptable here — the call site only runs this
- * when the underlying parse fails or as a pre-check before
- * `checkSyntax`.
- */
 function detectEsmSyntax(source: string): string | null {
-  // Strip line + block comments to keep the regex tight without
-  // pulling a parser dependency. Conservative — only handles the
-  // obvious cases.
   const stripped = source
     .replace(/\/\*[\s\S]*?\*\//g, "")
     .replace(/(^|[^:'"`])\/\/[^\n]*/g, "$1");
@@ -98,32 +41,35 @@ function detectEsmSyntax(source: string): string | null {
   if (/(^|\n)\s*import\s+[\w*{}\s,]+\s+from\s+['"][^'"]+['"]/.test(stripped)) {
     return "ESM `import ... from ...` statement detected";
   }
-  if (/import\.meta\b/.test(stripped)) {
-    return "ESM `import.meta` reference detected";
-  }
+  if (/import\.meta\b/.test(stripped)) return "ESM `import.meta` reference detected";
   return null;
 }
 
-/**
- * Strip server-side artifacts before returning a row through MCP. The
- * `compiledHandler` column is an internal cache — operator-facing tools
- * should always echo the canonical `handler` source.
- */
-function publicTask<T extends Record<string, any>>(row: T): Omit<T, "compiledHandler"> {
-  const { compiledHandler: _drop, ...rest } = row;
-  void _drop;
-  return rest;
-}
-
-function toIso(d: Date | string | null | undefined): string | null {
-  if (!d) return null;
-  if (d instanceof Date) return d.toISOString();
-  return String(d);
+function publicJob(job: Job, includeHandler: boolean) {
+  return {
+    id: job.id,
+    taskId: job.externalId ?? job.id,
+    displayName: job.displayName,
+    description: job.description,
+    triggerType: job.triggerType,
+    scheduleCron: job.scheduleCron,
+    scheduleTimezone: job.scheduleTimezone,
+    allowedAgentIds: job.allowedAgentIds,
+    payloadSchema: job.payloadSchema,
+    ...(includeHandler ? { handler: job.handler } : {}),
+    timeout: job.timeoutSeconds,
+    maxRetries: job.maxRetries,
+    isActive: job.status === "ACTIVE",
+    createdBy: job.createdBy,
+    createdAt: job.createdAt.toISOString(),
+    updatedAt: job.updatedAt.toISOString(),
+    lastRunAt: job.lastStartedAt?.toISOString() ?? null,
+  };
 }
 
 export function buildPlatosTaskToolHandlers(deps: {
   toolAudit: ToolAuditService;
-  prisma: any;
+  prisma: ControlDatabaseClient;
 }): McpToolHandler[] {
   const { toolAudit, prisma } = deps;
 
@@ -134,93 +80,60 @@ export function buildPlatosTaskToolHandlers(deps: {
     result: unknown,
     status: "success" | "failed",
     startedAt: number,
-    error?: string,
+    errorCode?: string,
   ): void {
-    toolAudit
+    void toolAudit
       .record({
         scope: tuple(scope),
         toolName,
         userId: scope.userId ?? null,
         args,
         result,
-        ...(error !== undefined ? { error } : {}),
+        ...(errorCode ? { error: errorCode } : {}),
         status,
         latencyMs: Date.now() - startedAt,
         source: "mcp_platform",
       })
-      .catch(() => undefined);
+      .catch(() => {
+        // eslint-disable-next-line no-console
+        console.warn("[platos_tasks] tool audit write failed");
+      });
   }
 
   return [
     {
       name: "platos_tasks.list",
-      description:
-        "List operator-authored custom tasks (`PlatosTask`) in the current " +
-        "scope. Returns metadata only — `handler` source is omitted to keep " +
-        "the response small + avoid leaking embedded secrets in bulk reads. " +
-        "Use `platos_tasks.get` to fetch a specific task with handler code.",
+      description: "List canonical jobs in the current Environment. Handler source is omitted.",
       inputSchema: {
         type: "object",
         properties: {
-          triggerType: {
-            type: "string",
-            enum: ["manual", "schedule", "webhook", "agent-spawn"],
-          },
+          triggerType: { type: "string", enum: [...TRIGGER_TYPES] },
           isActive: { type: "boolean" },
           limit: { type: "integer", minimum: 1, maximum: 500 },
         },
         additionalProperties: false,
       },
       async execute(params, scope) {
-        const where: Record<string, unknown> = scopeWhere(scope as RequestScope);
-        if (typeof params["triggerType"] === "string") {
-          where["triggerType"] = String(params["triggerType"]);
-        }
-        if (typeof params["isActive"] === "boolean") {
-          where["isActive"] = params["isActive"];
-        }
-        const limit = (params["limit"] as number | undefined) ?? 100;
-        const tasks = await prisma.platosTask.findMany({
-          where,
-          orderBy: { createdAt: "desc" },
-          take: limit,
-          select: {
-            id: true,
-            taskId: true,
-            displayName: true,
-            description: true,
-            triggerType: true,
-            scheduleCron: true,
-            scheduleTimezone: true,
-            allowedAgentIds: true,
-            isActive: true,
-            handlerVersion: true,
-            timeout: true,
-            maxRetries: true,
-            createdBy: true,
-            createdAt: true,
-            updatedAt: true,
-            lastRunAt: true,
+        const requestScope = scope as RequestScope;
+        const jobs = await prisma.job.findMany({
+          where: {
+            ...environmentScopeWhere(requestScope),
+            ...(typeof params["triggerType"] === "string"
+              ? { triggerType: params["triggerType"] }
+              : {}),
+            ...(typeof params["isActive"] === "boolean"
+              ? { status: params["isActive"] ? "ACTIVE" : { not: "ACTIVE" } }
+              : {}),
           },
+          orderBy: { createdAt: "desc" },
+          take: Math.min(500, Math.max(1, Number(params["limit"] ?? 100))),
         });
-        return {
-          tasks: (tasks as Array<Record<string, any>>).map((t) => ({
-            ...t,
-            createdAt: toIso(t["createdAt"]),
-            updatedAt: toIso(t["updatedAt"]),
-            lastRunAt: toIso(t["lastRunAt"]),
-          })),
-        };
+        return { tasks: jobs.map((job) => publicJob(job, false)) };
       },
     },
-
     {
       name: "platos_tasks.get",
-      description:
-        "Fetch a single `PlatosTask` by id. Includes the raw `handler` " +
-        "source. Returns `{ error: 'not_found' }` for unknown / cross-scope " +
-        "ids — never echoes the row. Server-side `compiledHandler` cache is " +
-        "stripped before returning.",
+      description: "Fetch one canonical job in scope, including its handler source.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -229,37 +142,15 @@ export function buildPlatosTaskToolHandlers(deps: {
       },
       async execute(params, scope) {
         const id = String(params["id"]);
-        const row = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(scope as RequestScope) },
+        const job = await prisma.job.findFirst({
+          where: { id, ...environmentScopeWhere(scope as RequestScope) },
         });
-        if (!row) return { error: "not_found", id };
-        const safe = publicTask(row as Record<string, any>);
-        return {
-          task: {
-            ...safe,
-            createdAt: toIso(safe["createdAt"]),
-            updatedAt: toIso(safe["updatedAt"]),
-            lastRunAt: toIso(safe["lastRunAt"]),
-          },
-        };
+        return job ? { task: publicJob(job, true) } : { error: "not_found", id };
       },
     },
-
     {
       name: "platos_tasks.create",
-      description:
-        "Create a new operator-authored task. Required: `taskId` (1-64 " +
-        "lowercase alphanumeric + hyphens, unique within scope), " +
-        "`displayName`, `handler` (raw JavaScript source — must `export " +
-        "function run(payload, ctx)`). Optional: `triggerType` " +
-        "(manual|schedule|webhook|agent-spawn, default 'manual'), " +
-        "`scheduleCron`, `scheduleTimezone`, `allowedAgentIds`, " +
-        "`payloadSchema`, `timeout` (seconds, default 300), `maxRetries` " +
-        "(default 3). The handler is syntax-checked before save; rows with " +
-        "syntax errors are stored with `isActive=false` + a `syntaxError` " +
-        "field surfaced in the response. Audit-logged " +
-        "(`taskId`, `displayName`, `handlerLength` only — never the " +
-        "handler source itself).",
+      description: "Create a canonical Environment-owned job after syntax validation.",
       inputSchema: {
         type: "object",
         required: ["taskId", "displayName", "handler"],
@@ -267,10 +158,7 @@ export function buildPlatosTaskToolHandlers(deps: {
           taskId: { type: "string", minLength: 1, maxLength: 64 },
           displayName: { type: "string", minLength: 1, maxLength: 200 },
           description: { type: "string", maxLength: 2000 },
-          triggerType: {
-            type: "string",
-            enum: ["manual", "schedule", "webhook", "agent-spawn"],
-          },
+          triggerType: { type: "string", enum: [...TRIGGER_TYPES] },
           scheduleCron: { type: "string", maxLength: 200 },
           scheduleTimezone: { type: "string", maxLength: 100 },
           allowedAgentIds: { type: "array", items: { type: "string" }, maxItems: 100 },
@@ -283,122 +171,74 @@ export function buildPlatosTaskToolHandlers(deps: {
       },
       async execute(params, scope) {
         const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const taskId = String(params["taskId"]).trim();
-        const displayName = String(params["displayName"]).trim();
-        const handler = String(params["handler"]);
-        const description = (params["description"] as string | undefined)?.trim();
-        const triggerType = (params["triggerType"] as string | undefined) ?? "manual";
-        const scheduleCron = params["scheduleCron"] as string | undefined;
-        const scheduleTimezone = params["scheduleTimezone"] as string | undefined;
-        const allowedAgentIds = (params["allowedAgentIds"] as string[] | undefined) ?? [];
-        const payloadSchema = params["payloadSchema"] as Record<string, unknown> | undefined;
-        const timeout = (params["timeout"] as number | undefined) ?? 300;
-        const maxRetries = (params["maxRetries"] as number | undefined) ?? 3;
-        // Audit shape — everything except the handler body itself.
+        const requestScope = scope as RequestScope;
+        const taskId = String(params["taskId"] ?? "").trim();
+        const displayName = String(params["displayName"] ?? "").trim();
+        const handler = String(params["handler"] ?? "");
+        const triggerType = String(params["triggerType"] ?? "manual");
         const auditArgs = {
           taskId,
           displayName,
           triggerType,
           handlerLength: handler.length,
-          allowedAgentIdsCount: allowedAgentIds.length,
-          isScheduled: !!scheduleCron,
         };
 
         if (!TASK_ID_RE.test(taskId)) {
-          const err = "taskId must be 1-64 lowercase alphanumeric + hyphens";
-          auditMutation(reqScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, err);
-          return { error: "invalid_task_id", message: err };
+          auditMutation(requestScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, "invalid_task_id");
+          return { error: "invalid_task_id", message: "taskId must be 1-64 lowercase alphanumeric + hyphens" };
+        }
+        if (!displayName || !handler.trim()) {
+          auditMutation(requestScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, "invalid_input");
+          return { error: "invalid_input", message: "displayName and handler are required" };
         }
         if (!TRIGGER_TYPES.has(triggerType)) {
-          const err = `triggerType must be one of ${[...TRIGGER_TYPES].join(", ")}`;
-          auditMutation(reqScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, err);
-          return { error: "invalid_trigger_type", message: err };
+          auditMutation(requestScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, "invalid_trigger_type");
+          return { error: "invalid_trigger_type" };
         }
-        if (!handler.trim()) {
-          const err = "handler source is required";
-          auditMutation(reqScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, err);
-          return { error: "handler_required", message: err };
-        }
-
-        const existing = await prisma.platosTask.findFirst({
-          where: { taskId, ...scopeWhere(reqScope) },
+        const duplicate = await prisma.job.findFirst({
+          where: { externalId: taskId, ...environmentScopeWhere(requestScope) },
           select: { id: true },
         });
-        if (existing) {
-          auditMutation(
-            reqScope,
-            "platos_tasks.create",
-            auditArgs,
-            null,
-            "failed",
-            startedAt,
-            "duplicate_task_id",
-          );
-          return { error: "already_exists", message: "A task with this taskId already exists in this scope." };
-        }
+        if (duplicate) return { error: "already_exists" };
 
         const syntaxError = checkSyntax(handler);
-        const isActive = syntaxError === null;
         try {
-          const created = await prisma.platosTask.create({
+          const job = await prisma.job.create({
             data: {
-              ...scopeWhere(reqScope),
-              taskId,
+              environmentId: requestScope.environmentId,
+              externalId: taskId,
               displayName,
-              description: description ?? null,
+              description: typeof params["description"] === "string" ? params["description"].trim() : null,
               triggerType,
-              scheduleCron: scheduleCron ?? null,
-              scheduleTimezone: scheduleTimezone ?? null,
-              allowedAgentIds,
-              payloadSchema: payloadSchema ?? null,
+              scheduleCron: typeof params["scheduleCron"] === "string" ? params["scheduleCron"] : null,
+              scheduleTimezone:
+                typeof params["scheduleTimezone"] === "string" ? params["scheduleTimezone"] : null,
+              allowedAgentIds: Array.isArray(params["allowedAgentIds"])
+                ? params["allowedAgentIds"].filter((value): value is string => typeof value === "string")
+                : [],
+              payloadSchema:
+                params["payloadSchema"] && typeof params["payloadSchema"] === "object"
+                  ? (params["payloadSchema"] as Prisma.InputJsonObject)
+                  : undefined,
               handler,
-              compiledHandler: isActive ? handler : null,
-              isActive,
-              timeout,
-              maxRetries,
-              createdBy: reqScope.userId ?? "mcp:platform",
+              timeoutSeconds: Number(params["timeout"] ?? 300),
+              maxRetries: Number(params["maxRetries"] ?? 3),
+              status: syntaxError ? "FAILED" : "ACTIVE",
+              createdBy: requestScope.userId,
             },
           });
-          const safe = publicTask(created as Record<string, any>);
-          const result = {
-            task: {
-              ...safe,
-              createdAt: toIso(safe["createdAt"]),
-              updatedAt: toIso(safe["updatedAt"]),
-              lastRunAt: toIso(safe["lastRunAt"]),
-            },
-            syntaxError,
-          };
-          auditMutation(
-            reqScope,
-            "platos_tasks.create",
-            auditArgs,
-            { id: created.id, isActive: created.isActive, syntaxError },
-            "success",
-            startedAt,
-          );
+          const result = { task: publicJob(job, true), syntaxError };
+          auditMutation(requestScope, "platos_tasks.create", auditArgs, { id: job.id }, "success", startedAt);
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, message);
-          if (/unique/i.test(message) || err?.code === "P2002") {
-            return { error: "already_exists", message: "A task with this taskId already exists in this scope." };
-          }
-          return { error: "create_failed", message };
+        } catch {
+          auditMutation(requestScope, "platos_tasks.create", auditArgs, null, "failed", startedAt, "create_failed");
+          return { error: "create_failed", message: "The task could not be created." };
         }
       },
     },
-
     {
       name: "platos_tasks.update",
-      description:
-        "Patch a task by id. Any field omitted is left untouched. " +
-        "If `handler` is supplied AND differs from the stored value, it is " +
-        "syntax-checked, `handlerVersion` is bumped, and `isActive` flips " +
-        "based on the syntax check (a clean handler reactivates a " +
-        "previously-broken task). Audit-logged (changed fields + new " +
-        "`handlerLength` if rewritten — never the handler source).",
+      description: "Update canonical job fields. Handler changes are syntax checked.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -406,10 +246,7 @@ export function buildPlatosTaskToolHandlers(deps: {
           id: { type: "string" },
           displayName: { type: "string", minLength: 1, maxLength: 200 },
           description: { type: ["string", "null"], maxLength: 2000 },
-          triggerType: {
-            type: "string",
-            enum: ["manual", "schedule", "webhook", "agent-spawn"],
-          },
+          triggerType: { type: "string", enum: [...TRIGGER_TYPES] },
           scheduleCron: { type: ["string", "null"], maxLength: 200 },
           scheduleTimezone: { type: ["string", "null"], maxLength: 100 },
           allowedAgentIds: { type: "array", items: { type: "string" }, maxItems: 100 },
@@ -423,108 +260,92 @@ export function buildPlatosTaskToolHandlers(deps: {
       },
       async execute(params, scope) {
         const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
+        const requestScope = scope as RequestScope;
         const id = String(params["id"]);
-
-        const existing = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(reqScope) },
-          select: { id: true, handlerVersion: true, handler: true, taskId: true },
+        const existing = await prisma.job.findFirst({
+          where: { id, ...environmentScopeWhere(requestScope) },
         });
-        if (!existing) {
-          auditMutation(reqScope, "platos_tasks.update", { id }, null, "failed", startedAt, "not_found");
-          return { error: "not_found", id };
-        }
+        if (!existing) return { error: "not_found", id };
 
-        const data: Record<string, unknown> = {};
+        const data: Prisma.JobUpdateInput = {};
         const changedFields: string[] = [];
-        const setIf = (key: string, value: unknown) => {
-          data[key] = value;
-          changedFields.push(key);
-        };
-        if (params["displayName"] !== undefined) setIf("displayName", String(params["displayName"]).trim());
+        if (params["displayName"] !== undefined) {
+          data.displayName = String(params["displayName"]).trim();
+          changedFields.push("displayName");
+        }
         if (params["description"] !== undefined) {
-          setIf(
-            "description",
-            params["description"] === null ? null : String(params["description"]).trim(),
-          );
+          data.description = params["description"] === null ? null : String(params["description"]).trim();
+          changedFields.push("description");
         }
         if (params["triggerType"] !== undefined) {
-          const t = String(params["triggerType"]);
-          if (!TRIGGER_TYPES.has(t)) {
-            auditMutation(reqScope, "platos_tasks.update", { id, triggerType: t }, null, "failed", startedAt, "invalid_trigger_type");
-            return { error: "invalid_trigger_type", message: `triggerType must be one of ${[...TRIGGER_TYPES].join(", ")}` };
-          }
-          setIf("triggerType", t);
+          const triggerType = String(params["triggerType"]);
+          if (!TRIGGER_TYPES.has(triggerType)) return { error: "invalid_trigger_type" };
+          data.triggerType = triggerType;
+          changedFields.push("triggerType");
         }
-        if (params["scheduleCron"] !== undefined) setIf("scheduleCron", params["scheduleCron"]);
-        if (params["scheduleTimezone"] !== undefined) setIf("scheduleTimezone", params["scheduleTimezone"]);
-        if (params["allowedAgentIds"] !== undefined) setIf("allowedAgentIds", params["allowedAgentIds"]);
-        if (params["payloadSchema"] !== undefined) setIf("payloadSchema", params["payloadSchema"]);
-        if (params["timeout"] !== undefined) setIf("timeout", params["timeout"]);
-        if (params["maxRetries"] !== undefined) setIf("maxRetries", params["maxRetries"]);
-        if (params["isActive"] !== undefined) setIf("isActive", params["isActive"]);
+        if (params["scheduleCron"] !== undefined) {
+          data.scheduleCron = params["scheduleCron"] === null ? null : String(params["scheduleCron"]);
+          changedFields.push("scheduleCron");
+        }
+        if (params["scheduleTimezone"] !== undefined) {
+          data.scheduleTimezone = params["scheduleTimezone"] === null ? null : String(params["scheduleTimezone"]);
+          changedFields.push("scheduleTimezone");
+        }
+        if (Array.isArray(params["allowedAgentIds"])) {
+          data.allowedAgentIds = params["allowedAgentIds"].filter(
+            (value): value is string => typeof value === "string",
+          );
+          changedFields.push("allowedAgentIds");
+        }
+        if (params["payloadSchema"] !== undefined) {
+          data.payloadSchema = params["payloadSchema"] === null
+            ? Prisma.JsonNull
+            : (params["payloadSchema"] as Prisma.InputJsonObject);
+          changedFields.push("payloadSchema");
+        }
+        if (params["timeout"] !== undefined) {
+          data.timeoutSeconds = Number(params["timeout"]);
+          changedFields.push("timeout");
+        }
+        if (params["maxRetries"] !== undefined) {
+          data.maxRetries = Number(params["maxRetries"]);
+          changedFields.push("maxRetries");
+        }
+        if (params["isActive"] !== undefined) {
+          data.status = params["isActive"] ? "ACTIVE" : "CANCELLED";
+          changedFields.push("isActive");
+        }
 
         let syntaxError: string | null = null;
-        let newHandlerLength: number | undefined;
         if (typeof params["handler"] === "string" && params["handler"] !== existing.handler) {
-          const handler = String(params["handler"]);
-          syntaxError = checkSyntax(handler);
-          data["handler"] = handler;
-          data["compiledHandler"] = syntaxError === null ? handler : null;
-          data["isActive"] = syntaxError === null;
-          data["handlerVersion"] = existing.handlerVersion + 1;
-          newHandlerLength = handler.length;
-          changedFields.push("handler", "handlerVersion", "isActive");
+          syntaxError = checkSyntax(params["handler"]);
+          data.handler = params["handler"];
+          data.status = syntaxError ? "FAILED" : "ACTIVE";
+          changedFields.push("handler");
         }
-
-        if (Object.keys(data).length === 0) {
-          auditMutation(reqScope, "platos_tasks.update", { id }, null, "failed", startedAt, "no_op");
-          return { error: "no_changes", message: "supply at least one field to update" };
-        }
-
-        const auditArgs = {
-          id,
-          taskId: existing.taskId,
-          changedFields: Array.from(new Set(changedFields)),
-          ...(newHandlerLength !== undefined ? { handlerLength: newHandlerLength } : {}),
-        };
+        if (changedFields.length === 0) return { error: "no_changes" };
 
         try {
-          const updated = await prisma.platosTask.update({ where: { id }, data });
-          const safe = publicTask(updated as Record<string, any>);
-          const result = {
-            task: {
-              ...safe,
-              createdAt: toIso(safe["createdAt"]),
-              updatedAt: toIso(safe["updatedAt"]),
-              lastRunAt: toIso(safe["lastRunAt"]),
-            },
-            syntaxError,
-          };
+          const job = await prisma.job.update({ where: { id }, data });
+          const result = { task: publicJob(job, true), syntaxError };
           auditMutation(
-            reqScope,
+            requestScope,
             "platos_tasks.update",
-            auditArgs,
-            { id: updated.id, handlerVersion: updated.handlerVersion, isActive: updated.isActive, syntaxError },
+            { id, taskId: existing.externalId, changedFields },
+            { id },
             "success",
             startedAt,
           );
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "platos_tasks.update", auditArgs, null, "failed", startedAt, message);
-          return { error: "update_failed", message };
+        } catch {
+          auditMutation(requestScope, "platos_tasks.update", { id, changedFields }, null, "failed", startedAt, "update_failed");
+          return { error: "update_failed", message: "The task could not be updated." };
         }
       },
     },
-
     {
       name: "platos_tasks.delete",
-      description:
-        "Delete a task by id. Removes the row + cascades nothing (TaskRun " +
-        "rows are not joined to PlatosTask — they remain in the trigger " +
-        "engine's history). Returns `{ error: 'not_found' }` for unknown / " +
-        "cross-scope ids. Audit-logged.",
+      description: "Delete one canonical job in the current Environment.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -533,149 +354,87 @@ export function buildPlatosTaskToolHandlers(deps: {
       },
       async execute(params, scope) {
         const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
+        const requestScope = scope as RequestScope;
         const id = String(params["id"]);
-        const existing = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(reqScope) },
-          select: { id: true, taskId: true, displayName: true },
+        const existing = await prisma.job.findFirst({
+          where: { id, ...environmentScopeWhere(requestScope) },
+          select: { externalId: true, displayName: true },
         });
-        if (!existing) {
-          auditMutation(reqScope, "platos_tasks.delete", { id }, null, "failed", startedAt, "not_found");
-          return { error: "not_found", id };
-        }
-        try {
-          await prisma.platosTask.delete({ where: { id } });
-          const result = { deleted: true, id, taskId: existing.taskId, displayName: existing.displayName };
-          auditMutation(
-            reqScope,
-            "platos_tasks.delete",
-            { id, taskId: existing.taskId },
-            result,
-            "success",
-            startedAt,
-          );
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "platos_tasks.delete", { id }, null, "failed", startedAt, message);
-          return { error: "delete_failed", message };
-        }
+        if (!existing) return { error: "not_found", id };
+        const deleted = await prisma.job.deleteMany({
+          where: { id, ...environmentScopeWhere(requestScope) },
+        });
+        if (deleted.count !== 1) return { error: "delete_failed" };
+        const result = {
+          deleted: true,
+          id,
+          taskId: existing.externalId ?? id,
+          displayName: existing.displayName,
+        };
+        auditMutation(requestScope, "platos_tasks.delete", { id }, result, "success", startedAt);
+        return result;
       },
     },
-
     {
       name: "platos_tasks.run",
-      description:
-        "Manually dispatch a task via trigger.dev. Refuses if `isActive` " +
-        "is false. Requires `TRIGGER_SECRET_KEY` set in the agent " +
-        "environment (returns `{ queued: false, message: ... }` if " +
-        "missing). Optional `payload` is JSON-stringified into the " +
-        "execution context. Returns `{ queued: true, runId, taskId }` on " +
-        "success. Audit-logged (taskId + payload-key list — payload values " +
-        "are NOT echoed in the audit row to avoid leaking PII).",
+      description: "Dispatch an active canonical job through Trigger.dev.",
       inputSchema: {
         type: "object",
         required: ["id"],
-        properties: {
-          id: { type: "string" },
-          payload: { type: "object" },
-        },
+        properties: { id: { type: "string" }, payload: { type: "object" } },
         additionalProperties: false,
       },
       async execute(params, scope) {
         const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
+        const requestScope = scope as RequestScope;
         const id = String(params["id"]);
         const payload = (params["payload"] as Record<string, unknown> | undefined) ?? {};
-        const auditArgs = {
-          id,
-          payloadKeys: Object.keys(payload).slice(0, 50),
-        };
-
-        const task = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(reqScope), isActive: true },
-          select: { id: true, taskId: true, displayName: true },
+        const job = await prisma.job.findFirst({
+          where: { id, status: "ACTIVE", ...environmentScopeWhere(requestScope) },
+          select: { id: true, externalId: true, displayName: true },
         });
-        if (!task) {
-          auditMutation(reqScope, "platos_tasks.run", auditArgs, null, "failed", startedAt, "not_found_or_inactive");
-          return { error: "not_found_or_inactive", id };
-        }
+        if (!job) return { error: "not_found_or_inactive", id };
 
         const triggerSdk = await import("@trigger.dev/sdk");
         if (configureExternalTriggerSdk(triggerSdk).status !== "configured") {
-          const message =
-            "External Trigger endpoint and credentials are not configured — task execution unavailable.";
-          auditMutation(
-            reqScope,
-            "platos_tasks.run",
-            auditArgs,
-            null,
-            "failed",
-            startedAt,
-            "trigger_unavailable",
-          );
-          return { queued: false, message, taskId: task.taskId };
+          return { queued: false, message: "Task execution is unavailable.", taskId: job.externalId ?? id };
         }
-
         try {
-          // Lazy import — same pattern as PlatosTasksController.run().
-          const run = await triggerSdk.tasks.trigger("platos-custom-task", {
-            taskRowId: id,
-            payload,
-            scope: {
-              organizationId: reqScope.organizationId,
-              projectId: reqScope.projectId,
-              environmentId: reqScope.environmentId,
-              userId: reqScope.userId,
+          const run = await triggerSdk.tasks.trigger(
+            "platos-custom-task",
+            {
+              taskRowId: id,
+              payload,
+              scope: { ...tuple(requestScope), userId: requestScope.userId },
+              invokedBy: "manual",
             },
-            invokedBy: "manual",
-          // Per-org queue isolation matches Wave-3 scaling commits + the
-          // PlatosTasksController dispatch path (no queue arg in the
-          // controller today; using SDK default to stay consistent).
-          }, {
-            // L7 — stamp trigger-time scope so get_run_details / replay_run can
-            // verify ownership; without it, a run dispatched via this MCP tool
-            // would be DENIED to its own owner (fail-closed).
-            tags: [
-              `org:${reqScope.organizationId}`,
-              `project:${reqScope.projectId}`,
-              `env:${reqScope.environmentId}`,
-              `user:${reqScope.userId}`,
-            ],
-            metadata: {
-              organizationId: reqScope.organizationId,
-              projectId: reqScope.projectId,
-              environmentId: reqScope.environmentId,
-              userId: reqScope.userId,
+            {
+              tags: [
+                `org:${requestScope.organizationId}`,
+                `project:${requestScope.projectId}`,
+                `env:${requestScope.environmentId}`,
+                `user:${requestScope.userId}`,
+              ],
+              metadata: { ...tuple(requestScope), userId: requestScope.userId },
             },
-          });
-          const result = { queued: true, runId: run.id, taskId: task.taskId, displayName: task.displayName };
-          auditMutation(
-            reqScope,
-            "platos_tasks.run",
-            auditArgs,
-            { runId: run.id, taskId: task.taskId },
-            "success",
-            startedAt,
           );
+          const result = {
+            queued: true,
+            runId: run.id,
+            taskId: job.externalId ?? id,
+            displayName: job.displayName,
+          };
+          auditMutation(requestScope, "platos_tasks.run", { id, payloadKeys: Object.keys(payload) }, result, "success", startedAt);
           return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "platos_tasks.run", auditArgs, null, "failed", startedAt, message);
-          return { error: "dispatch_failed", message };
+        } catch {
+          auditMutation(requestScope, "platos_tasks.run", { id }, null, "failed", startedAt, "dispatch_failed");
+          return { error: "dispatch_failed", message: "The task could not be dispatched." };
         }
       },
     },
-
     {
       name: "platos_tasks.get_runs",
-      description:
-        "List recent `TaskRun` rows for a `PlatosTask`. Filters " +
-        "`taskIdentifier='platos-custom-task'` + the agent's environment, " +
-        "then matches each run's `payload.taskRowId` against the supplied " +
-        "task `id`. Returns runs ordered most-recent first. Optional " +
-        "`status` narrows the underlying enum (PENDING, EXECUTING, " +
-        "COMPLETED_SUCCESSFULLY, FAILED, etc.). Default limit 50, max 200.",
+      description: "Run history is unavailable through the canonical control database.",
       inputSchema: {
         type: "object",
         required: ["id"],
@@ -687,291 +446,94 @@ export function buildPlatosTaskToolHandlers(deps: {
         additionalProperties: false,
       },
       async execute(params, scope) {
-        const reqScope = scope as RequestScope;
         const id = String(params["id"]);
-        const status = params["status"] as string | undefined;
-        const limit = (params["limit"] as number | undefined) ?? 50;
-
-        // Confirm the task exists in scope before exposing run data.
-        const task = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(reqScope) },
-          select: { id: true, taskId: true },
+        const job = await prisma.job.findFirst({
+          where: { id, ...environmentScopeWhere(scope as RequestScope) },
+          select: { id: true },
         });
-        if (!task) return { error: "not_found", id };
-
-        // Fetch a generous slice of recent platos-custom-task runs for the
-        // env, then filter on the embedded `taskRowId`. We over-fetch by
-        // a 5x factor so that even when many tasks share one env, the
-        // requested limit is reachable.
-        const rawRuns = await prisma.taskRun.findMany({
-          where: {
-            taskIdentifier: "platos-custom-task",
-            runtimeEnvironmentId: reqScope.environmentId,
-            projectId: reqScope.projectId,
-            ...(status ? { status: String(status) } : {}),
-          },
-          orderBy: { createdAt: "desc" },
-          take: Math.min(limit * 5, 500),
-          select: {
-            id: true,
-            friendlyId: true,
-            status: true,
-            payload: true,
-            payloadType: true,
-            createdAt: true,
-            startedAt: true,
-            completedAt: true,
-            usageDurationMs: true,
-            costInCents: true,
-            attemptNumber: true,
-          },
-        });
-
-        const matched: Array<Record<string, unknown>> = [];
-        for (const r of rawRuns as Array<Record<string, any>>) {
-          if (matched.length >= limit) break;
-          let parsedPayload: any = null;
-          if (typeof r["payload"] === "string") {
-            try {
-              parsedPayload = JSON.parse(r["payload"]);
-            } catch {
-              continue;
-            }
-          }
-          const rowId = parsedPayload?.taskRowId;
-          if (rowId !== id) continue;
-          matched.push({
-            id: r["id"],
-            friendlyId: r["friendlyId"],
-            status: r["status"],
-            attemptNumber: r["attemptNumber"],
-            usageDurationMs: r["usageDurationMs"],
-            costInCents: r["costInCents"],
-            createdAt: toIso(r["createdAt"]),
-            startedAt: toIso(r["startedAt"]),
-            completedAt: toIso(r["completedAt"]),
-            invokedBy: parsedPayload?.invokedBy ?? null,
-          });
-        }
-        return { taskId: task.taskId, runs: matched };
+        if (!job) return { error: "not_found", id };
+        return {
+          error: "unsupported",
+          message: "Task run history is not available through the canonical control database.",
+        };
       },
     },
-
     {
       name: "platos_tasks.get_run",
-      description:
-        "Fetch a single `TaskRun` (by friendly id `run_*` or full cuid). " +
-        "Restricted to runs whose `taskIdentifier='platos-custom-task'` and " +
-        "whose `runtimeEnvironmentId` + `projectId` match the caller's " +
-        "scope. Returns the parsed payload + status + timings. Returns " +
-        "`{ error: 'not_found' }` for cross-scope or non-platos-task runs.",
+      description: "Run details are unavailable through the canonical control database.",
       inputSchema: {
         type: "object",
         required: ["runId"],
         properties: { runId: { type: "string" } },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const reqScope = scope as RequestScope;
-        const runId = String(params["runId"]).trim();
-        const isFriendly = runId.startsWith("run_");
-        const where: Record<string, unknown> = {
-          taskIdentifier: "platos-custom-task",
-          runtimeEnvironmentId: reqScope.environmentId,
-          projectId: reqScope.projectId,
+      async execute() {
+        return {
+          error: "unsupported",
+          message: "Task run details are not available through the canonical control database.",
         };
-        where[isFriendly ? "friendlyId" : "id"] = runId;
-        const run = await prisma.taskRun.findFirst({
-          where,
-          select: {
-            id: true,
-            friendlyId: true,
-            status: true,
-            statusReason: true,
-            payload: true,
-            payloadType: true,
-            taskIdentifier: true,
-            attemptNumber: true,
-            createdAt: true,
-            queuedAt: true,
-            startedAt: true,
-            executedAt: true,
-            completedAt: true,
-            usageDurationMs: true,
-            costInCents: true,
-            traceId: true,
-            spanId: true,
-          },
-        });
-        if (!run) return { error: "not_found", runId };
-        let parsedPayload: unknown = null;
-        if (typeof run.payload === "string") {
-          try {
-            parsedPayload = JSON.parse(run.payload);
-          } catch {
-            parsedPayload = null;
-          }
-        }
-        // Confirm the run belongs to a task in this scope (defence in depth —
-        // taskRowId in the payload must match a PlatosTask in the same scope).
-        const taskRowId = (parsedPayload as any)?.taskRowId;
-        if (taskRowId) {
-          const task = await prisma.platosTask.findFirst({
-            where: { id: String(taskRowId), ...scopeWhere(reqScope) },
-            select: { id: true, taskId: true },
-          });
-          if (!task) return { error: "not_found", runId };
-          return {
-            run: {
-              id: run.id,
-              friendlyId: run.friendlyId,
-              status: run.status,
-              statusReason: run.statusReason,
-              attemptNumber: run.attemptNumber,
-              usageDurationMs: run.usageDurationMs,
-              costInCents: run.costInCents,
-              traceId: run.traceId,
-              spanId: run.spanId,
-              createdAt: toIso(run.createdAt),
-              queuedAt: toIso(run.queuedAt),
-              startedAt: toIso(run.startedAt),
-              executedAt: toIso(run.executedAt),
-              completedAt: toIso(run.completedAt),
-              taskRowId: task.id,
-              taskId: task.taskId,
-              invokedBy: (parsedPayload as any)?.invokedBy ?? null,
-              payload: (parsedPayload as any)?.payload ?? null,
-            },
-          };
-        }
-        return { error: "not_found", runId };
       },
     },
-
     {
       name: "platos_tasks.set_enabled",
-      description:
-        "Toggle the `isActive` flag on a task. Disabling a task makes it " +
-        "non-dispatchable via `platos_tasks.run` and " +
-        "`run_platos_task` meta-tool. Re-enabling will run a fresh " +
-        "syntax check on the stored handler — if it fails, the call " +
-        "rejects with `{ error: 'syntax_error' }` and `isActive` stays " +
-        "false. Audit-logged.",
+      description: "Enable or disable a canonical job by changing its WorkStatus.",
       inputSchema: {
         type: "object",
         required: ["id", "enabled"],
-        properties: {
-          id: { type: "string" },
-          enabled: { type: "boolean" },
-        },
+        properties: { id: { type: "string" }, enabled: { type: "boolean" } },
         additionalProperties: false,
       },
       async execute(params, scope) {
         const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
+        const requestScope = scope as RequestScope;
         const id = String(params["id"]);
-        const enabled = !!params["enabled"];
-        const auditArgs = { id, enabled };
-
-        const existing = await prisma.platosTask.findFirst({
-          where: { id, ...scopeWhere(reqScope) },
-          select: { id: true, taskId: true, handler: true, isActive: true },
+        const enabled = params["enabled"] === true;
+        const job = await prisma.job.findFirst({
+          where: { id, ...environmentScopeWhere(requestScope) },
         });
-        if (!existing) {
-          auditMutation(reqScope, "platos_tasks.set_enabled", auditArgs, null, "failed", startedAt, "not_found");
-          return { error: "not_found", id };
-        }
-        if (existing.isActive === enabled) {
-          // Idempotent no-op — audit + return without write.
-          auditMutation(
-            reqScope,
-            "platos_tasks.set_enabled",
-            auditArgs,
-            { id, isActive: enabled, noOp: true },
-            "success",
-            startedAt,
-          );
-          return { id, taskId: existing.taskId, isActive: enabled, changed: false };
-        }
+        if (!job) return { error: "not_found", id };
         if (enabled) {
-          const syntaxError = checkSyntax(existing.handler ?? "");
-          if (syntaxError) {
-            auditMutation(
-              reqScope,
-              "platos_tasks.set_enabled",
-              auditArgs,
-              null,
-              "failed",
-              startedAt,
-              "syntax_error",
-            );
-            return { error: "syntax_error", message: syntaxError };
-          }
+          const syntaxError = checkSyntax(job.handler);
+          if (syntaxError) return { error: "syntax_error", message: syntaxError };
         }
-        try {
-          const updated = await prisma.platosTask.update({
-            where: { id },
-            data: {
-              isActive: enabled,
-              ...(enabled
-                ? { compiledHandler: existing.handler }
-                : { compiledHandler: null }),
-            },
-            select: { id: true, taskId: true, isActive: true },
-          });
-          const result = { id: updated.id, taskId: updated.taskId, isActive: updated.isActive, changed: true };
-          auditMutation(reqScope, "platos_tasks.set_enabled", auditArgs, result, "success", startedAt);
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "platos_tasks.set_enabled", auditArgs, null, "failed", startedAt, message);
-          return { error: "set_enabled_failed", message };
+        const nextStatus = enabled ? "ACTIVE" : "CANCELLED";
+        if (job.status === nextStatus) {
+          return { id, taskId: job.externalId ?? id, isActive: enabled, changed: false };
         }
+        const updated = await prisma.job.update({
+          where: { id },
+          data: { status: nextStatus },
+        });
+        const result = {
+          id,
+          taskId: updated.externalId ?? id,
+          isActive: updated.status === "ACTIVE",
+          changed: true,
+        };
+        auditMutation(requestScope, "platos_tasks.set_enabled", { id, enabled }, result, "success", startedAt);
+        return result;
       },
     },
-
     {
       name: "platos_tasks.validate_handler",
-      description:
-        "Compile-check a JavaScript handler source without executing it. " +
-        "Uses `new Function(payload, ctx, source)` to surface parse errors. " +
-        "Returns `{ valid: true }` on a clean parse, " +
-        "`{ valid: false, error: '...' }` otherwise. No DB writes, no " +
-        "audit — pure utility for the dashboard editor + agent IDE flows.\n\n" +
-        "**SYNTAX: CommonJS only.** The runtime executor (platos-custom-task) " +
-        "wraps the handler in a function expression, so use either:\n" +
-        "  • a bare expression body that returns a value, or\n" +
-        "  • `module.exports = async (payload, ctx) => { … }`\n" +
-        "ESM syntax (`export default`, top-level `import`, top-level `await` " +
-        "outside an async fn) WILL fail to compile here and at runtime — " +
-        "this is intentional, the executor uses CommonJS-style `new Function` " +
-        "rather than dynamic `import()`. If you need npm modules, use " +
-        "`require(\"name\")` from inside the handler body.",
+      description: "Syntax-check CommonJS handler source without executing it.",
       inputSchema: {
         type: "object",
         required: ["handler"],
-        properties: {
-          handler: { type: "string", minLength: 1, maxLength: 200_000 },
-        },
+        properties: { handler: { type: "string", minLength: 1, maxLength: 200_000 } },
         additionalProperties: false,
       },
       async execute(params) {
         const handler = String(params["handler"]);
-        // MCPF-followup — pre-detect ESM syntax + return a clearer error
-        // than "Unexpected token 'export'". Matches the most common
-        // failure modes; not a full parser. False positives are
-        // acceptable because the handler executor would reject them
-        // anyway.
         const esmHint = detectEsmSyntax(handler);
         if (esmHint) {
           return {
             valid: false,
-            error: `${esmHint} — platos_tasks handlers run in a CommonJS context. Rewrite as \`module.exports = async (payload, ctx) => { … }\` and use \`require(...)\` for imports.`,
+            error: `${esmHint} — handlers run in a CommonJS context.`,
           };
         }
-        const err = checkSyntax(handler);
-        if (err === null) return { valid: true };
-        return { valid: false, error: err };
+        const error = checkSyntax(handler);
+        return error ? { valid: false, error } : { valid: true };
       },
     },
   ];

--- a/apps/agent/src/mcp-platform/tools/reflection-budget.test.ts
+++ b/apps/agent/src/mcp-platform/tools/reflection-budget.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RequestScope } from "../../auth/scope.guard";
+import { buildReflectionToolHandlers } from "./reflection";
+
+const scope: RequestScope = {
+  organizationId: "org-a",
+  projectId: "project-a",
+  environmentId: "env-a",
+  userId: "operator-a",
+  principal: "operator",
+};
+
+describe("platos.explain_turn canonical budget events", () => {
+  it("filters canonical detector/action values and projects compatibility kinds", async () => {
+    const safetyFindMany = vi.fn().mockResolvedValue([
+      {
+        action: "block",
+        detail: "Daily budget exhausted",
+        createdAt: new Date("2026-08-19T12:00:00.000Z"),
+      },
+      {
+        action: "warn",
+        detail: "Approaching daily budget",
+        createdAt: new Date("2026-08-19T11:00:00.000Z"),
+      },
+    ]);
+    const handlers = buildReflectionToolHandlers({
+      agentCrud: {} as any,
+      conversation: {
+        getThread: vi.fn().mockResolvedValue({
+          id: "thread-a",
+          agentId: "agent-a",
+          status: "ACTIVE",
+        }),
+      } as any,
+      spans: { getThreadSpans: vi.fn().mockResolvedValue([]) } as any,
+      toolAudit: {
+        list: vi.fn().mockResolvedValue({ rows: [], total: 0 }),
+      } as any,
+      approvals: {
+        list: vi.fn().mockResolvedValue({ rows: [], total: 0, pendingCount: 0 }),
+      } as any,
+      prisma: {
+        turn: {
+          findFirst: vi.fn().mockResolvedValue({
+            id: "turn-a",
+            output: null,
+            costCents: null,
+            steps: [],
+            createdAt: new Date("2026-08-19T12:00:00.000Z"),
+            status: "SUCCEEDED",
+          }),
+        },
+        environmentEntityTool: { findMany: vi.fn().mockResolvedValue([]) },
+        entity: { findMany: vi.fn().mockResolvedValue([]) },
+        safetyEvent: { findMany: safetyFindMany },
+      } as any,
+    });
+    const handler = handlers.find((candidate) => candidate.name === "platos.explain_turn")!;
+
+    const result: any = await handler.execute(
+      { threadId: "thread-a", messageId: "turn-a" },
+      scope,
+      {} as any,
+    );
+
+    expect(safetyFindMany).toHaveBeenCalledWith({
+      where: {
+        environmentId: "env-a",
+        threadId: "thread-a",
+        detector: "budget",
+        action: { in: ["block", "warn"] },
+      },
+      orderBy: { createdAt: "desc" },
+      select: { action: true, detail: true, createdAt: true },
+      take: 50,
+    });
+    expect(result.budgetBlocks).toEqual([
+      {
+        kind: "budget_block",
+        reason: "Daily budget exhausted",
+        createdAt: "2026-08-19T12:00:00.000Z",
+      },
+      {
+        kind: "budget_warning",
+        reason: "Approaching daily budget",
+        createdAt: "2026-08-19T11:00:00.000Z",
+      },
+    ]);
+  });
+});

--- a/apps/agent/src/mcp-platform/tools/reflection.ts
+++ b/apps/agent/src/mcp-platform/tools/reflection.ts
@@ -37,6 +37,7 @@ import type { ToolAuditService } from "../../monitoring/tool-audit.service";
 import type { MonitoringApprovalsService } from "../../monitoring/approvals.service";
 import type { CostService } from "../../monitoring/cost.service";
 import type { McpToolHandler } from "../mcp-router";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
 import type { RequestScope } from "../../auth/scope.guard";
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
@@ -68,7 +69,7 @@ export interface ReflectionDeps {
    *   - tool matrix snapshot (PlatosEntityToolMapping + PlatosToolDefinition)
    *   - MCP feeder list (PlatosConnectedEntity)
    */
-  prisma: any;
+  prisma: ControlDatabaseClient;
 }
 
 // ── small line-diff helper ─────────────────────────────────────────────
@@ -207,14 +208,26 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
         // 2. Load the target message — bound to the verified threadId so a
         //    crafted messageId belonging to another scope's thread can't
         //    leak through. Prisma `findFirst` scoped by threadId short-circuits.
-        const message = await prisma.platosAgentMessage.findFirst({
+        const message = await prisma.turn.findFirst({
           where: { id: messageId, threadId },
           select: {
             id: true,
-            role: true,
-            content: true,
-            toolCalls: true,
-            responseJson: true,
+            output: true,
+            costCents: true,
+            steps: {
+              select: {
+                inputTokens: true,
+                outputTokens: true,
+                toolCalls: {
+                  select: {
+                    toolName: true,
+                    arguments: true,
+                    result: true,
+                    status: true,
+                  },
+                },
+              },
+            },
             createdAt: true,
             status: true,
           },
@@ -224,102 +237,84 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
         }
 
         const agentId = thread.agentId;
-        const responseJson = (message.responseJson ?? {}) as Record<string, unknown>;
-        const usage = (responseJson["usage"] ?? {}) as {
-          inputTokens?: number;
-          outputTokens?: number;
-        };
-        const costCents = Number(responseJson["cost_cents"] ?? 0) || 0;
+        const usage = message.steps.reduce(
+          (total, step) => ({
+            inputTokens: total.inputTokens + (step.inputTokens ?? 0),
+            outputTokens: total.outputTokens + (step.outputTokens ?? 0),
+          }),
+          { inputTokens: 0, outputTokens: 0 },
+        );
+        const costCents = Number(message.costCents ?? 0) || 0;
 
         // 3. Tools-in-scope at turn time. Best-effort snapshot via the
         //    tool matrix — we don't store per-message tool lists, so this
         //    is the CURRENT matrix, not the historical one. Flagged as
         //    such in the response.
-        let toolsInScope: Array<{ name: string; enabled: boolean; entityId: string | null; toolId: string }> = [];
-        try {
-          const rows = await prisma.platosEntityToolMapping.findMany({
-            where: { environmentId: scope.environmentId },
-            select: {
-              enabled: true,
-              toolId: true,
-              entity: { select: { entityId: true } },
-              tool: { select: { name: true } },
-            },
-          });
-          toolsInScope = (rows as any[]).map((r) => ({
-            name: r.tool?.name ?? "(unknown)",
-            enabled: !!r.enabled,
-            entityId: r.entity?.entityId ?? null,
-            toolId: r.toolId,
-          }));
-        } catch {
-          // Schema drift / mock prisma in tests — leave empty rather than
-          // failing the whole explanation.
-          toolsInScope = [];
-        }
+        const toolRows = await prisma.environmentEntityTool.findMany({
+          where: { environmentId: scope.environmentId },
+          select: {
+            enabled: true,
+            toolId: true,
+            entity: { select: { externalId: true } },
+            tool: { select: { name: true } },
+          },
+        });
+        const toolsInScope = toolRows.map((row) => ({
+          name: row.tool.name,
+          enabled: row.enabled,
+          entityId: row.entity.externalId,
+          toolId: row.toolId,
+        }));
 
         // 4. Tools the LLM actually picked — stored on the assistant
          //   message's toolCalls column as produced by the runtime.
-        const rawToolCalls = Array.isArray(message.toolCalls)
-          ? (message.toolCalls as Array<Record<string, unknown>>)
-          : [];
-        const pickedTools = rawToolCalls.map((tc) => ({
-          type: (tc["type"] as string) ?? "unknown",
-          tool: (tc["tool"] as string) ?? (tc["toolName"] as string) ?? "(unknown)",
-          args: tc["args"] ?? tc["arguments"] ?? null,
-          result: tc["result"] ?? null,
+        const pickedTools = message.steps.flatMap((step) => step.toolCalls).map((toolCall) => ({
+          type: "tool",
+          tool: toolCall.toolName,
+          args: toolCall.arguments,
+          result: toolCall.result,
+          status: toolCall.status,
         }));
 
         // 5. MCP feeders — every connected entity in the project owns an
         //    `mcpUrls` list. These are the servers whose tools end up in
         //    the matrix via the tool-sync handshake.
-        let mcpFeeders: Array<{ entityId: string; displayName: string; mcpUrls: string[] }> = [];
-        try {
-          const entities = await prisma.platosConnectedEntity.findMany({
-            where: {
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-            },
-            select: { entityId: true, displayName: true, mcpUrls: true },
-          });
-          mcpFeeders = (entities as any[]).map((e) => ({
-            entityId: e.entityId,
-            displayName: e.displayName,
-            mcpUrls: Array.isArray(e.mcpUrls) ? (e.mcpUrls as string[]) : [],
-          }));
-        } catch {
-          mcpFeeders = [];
-        }
+        const entities = await prisma.entity.findMany({
+          where: {
+            projectId: scope.projectId,
+            project: { organizationId: scope.organizationId },
+          },
+          select: { externalId: true, displayName: true, mcpUrls: true },
+        });
+        const mcpFeeders = entities.map((entity) => ({
+          entityId: entity.externalId,
+          displayName: entity.displayName,
+          mcpUrls: entity.mcpUrls,
+        }));
 
         // 6. Approvals in this thread. `list` is already scope-filtered
         //    server-side.
         const approvalPage = await approvals.list(tuple(scope), { threadId, limit: 200 });
 
-        // 7. Budget blocks — surfaced by the runtime as safety rows tagged
-        //    `budget_block`. Best-effort direct read; we don't import
+        // 7. Budget blocks — canonical safety rows use detector="budget"
+        //    with action="block" or "warn". Best-effort direct read; we don't import
         //    SafetyEventService here since the feature set is read-only.
-        let budgetBlocks: Array<{ kind: string; reason: string | null; createdAt: string }> = [];
-        try {
-          const rows = await prisma.platosSafetyEvent.findMany({
-            where: {
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-              environmentId: scope.environmentId,
-              threadId,
-              kind: { in: ["budget_block", "budget_warning"] },
-            },
-            orderBy: { createdAt: "desc" },
-            select: { kind: true, reason: true, createdAt: true },
-            take: 50,
-          });
-          budgetBlocks = (rows as any[]).map((r) => ({
-            kind: r.kind,
-            reason: r.reason ?? null,
-            createdAt: r.createdAt instanceof Date ? r.createdAt.toISOString() : String(r.createdAt),
-          }));
-        } catch {
-          budgetBlocks = [];
-        }
+        const budgetRows = await prisma.safetyEvent.findMany({
+          where: {
+            environmentId: scope.environmentId,
+            threadId,
+            detector: "budget",
+            action: { in: ["block", "warn"] },
+          },
+          orderBy: { createdAt: "desc" },
+          select: { action: true, detail: true, createdAt: true },
+          take: 50,
+        });
+        const budgetBlocks = budgetRows.map((row) => ({
+          kind: row.action === "block" ? "budget_block" : "budget_warning",
+          reason: row.detail,
+          createdAt: row.createdAt.toISOString(),
+        }));
 
         // 8. Timeline — derive from the spans log. For the one-message
         //    detail we filter spans by time window (message.createdAt ±
@@ -380,7 +375,7 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
           },
           message: {
             id: message.id,
-            role: message.role,
+            role: "assistant",
             createdAt: new Date(message.createdAt).toISOString(),
             status: message.status,
           },
@@ -670,28 +665,9 @@ export function buildReflectionToolHandlers(deps: ReflectionDeps): McpToolHandle
         if (!a) throw new Error(`agent A ${agentIdA} not found in scope`);
         if (!b) throw new Error(`agent B ${agentIdB} not found in scope`);
 
-        // contextMapping lives on PlatosAgent but isn't on the CRUD
-        // AgentRecord type today (CTX.1 schema extension). Pull it
-        // directly via prisma, scope-filtered just in case.
-        let contextMappingA: Record<string, unknown> | null = null;
-        let contextMappingB: Record<string, unknown> | null = null;
-        try {
-          const rows = await prisma.platosAgent.findMany({
-            where: {
-              id: { in: [agentIdA, agentIdB] },
-              organizationId: scope.organizationId,
-              projectId: scope.projectId,
-              environmentId: scope.environmentId,
-            },
-            select: { id: true, contextMapping: true },
-          });
-          for (const r of rows as Array<{ id: string; contextMapping: any }>) {
-            if (r.id === agentIdA) contextMappingA = (r.contextMapping ?? null) as Record<string, unknown> | null;
-            if (r.id === agentIdB) contextMappingB = (r.contextMapping ?? null) as Record<string, unknown> | null;
-          }
-        } catch {
-          // Leave both null — diff will just show no changes on that field.
-        }
+        // No canonical Agent or AgentVersion field maps to legacy contextMapping.
+        const contextMappingA: Record<string, unknown> | null = null;
+        const contextMappingB: Record<string, unknown> | null = null;
 
         const identity = {
           name: a.name === b.name ? null : { from: a.name, to: b.name },

--- a/apps/agent/src/mcp-platform/tools/settings.ts
+++ b/apps/agent/src/mcp-platform/tools/settings.ts
@@ -1,9 +1,9 @@
 /**
  * Theme MCPF-W6 — Settings / Admin MCP tools (17 tools).
  *
- * Wraps Organization + Project + RuntimeEnvironment + SecretStore +
- * AgentCluster surfaces so an operator can manage scope topology
- * + secrets + clusters entirely via MCP.
+ * Wraps Organization + Project + Environment + AgentCluster surfaces so an
+ * operator can manage scope topology and clusters via MCP. Environment
+ * credential operations remain registered but unavailable pending WIN-124.
  *
  * Layout:
  *   • Org (7)          — list / get / update / list_members / add_member
@@ -21,7 +21,7 @@
  *   - clusters.create / clusters.add_agent
  *
  * Audit redaction discipline:
- *   - Secret writes log NAME ONLY — never the value or any prefix of it.
+ *   - Unavailable secret writes return before any audit or persistence call.
  *   - Member operations log `memberId` + `role` — never email/name/avatar.
  *   - Cluster operations log `clusterId` + `agentId` only.
  *   - Read tools don't audit (Wave 1-5 pattern).
@@ -33,6 +33,14 @@ import type { ToolAuditService } from "../../monitoring/tool-audit.service";
 import type { OrganizationService } from "../../admin/organization.service";
 import type { EnvironmentService } from "../../admin/environment.service";
 import type { AgentClusterService } from "../../agent-runtime/agent-cluster.service";
+
+function environmentCredentialsUnavailable() {
+  return {
+    error: "unavailable",
+    message:
+      "Environment credential management is unavailable pending the canonical WIN-124 persistence cutover.",
+  } as const;
+}
 
 type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environmentId">;
 
@@ -429,30 +437,18 @@ export function buildSettingsToolHandlers(deps: {
     {
       name: "environments.list_secrets",
       description:
-        "List secret NAMES (and version + timestamps) for the caller's " +
-        "(project, environment) scope. Caller must be an org member. " +
-        "**NEVER returns secret values** — use the dashboard or " +
-        "deploy-pipeline injection to read them.",
+        "Environment credential management is unavailable pending the " +
+        "canonical WIN-124 persistence cutover.",
       inputSchema: { type: "object", properties: {}, additionalProperties: false },
-      async execute(_params, scope) {
-        const reqScope = scope as RequestScope;
-        try {
-          const secrets = await envs.listSecrets(tuple(reqScope), reqScope.userId ?? null);
-          return { secrets, count: secrets.length };
-        } catch (err: any) {
-          if (err?.message === "access_denied") return { error: "access_denied" };
-          return { error: "list_failed", message: err?.message ?? String(err) };
-        }
+      async execute() {
+        return environmentCredentialsUnavailable();
       },
     },
     {
       name: "environments.set_secret",
       description:
-        "Write a secret to the caller's (project, environment) scope. " +
-        "Owner-gated (ADMIN). Encrypted at rest with the webapp-shared " +
-        "`ENCRYPTION_KEY` (AES-256-GCM). Audit logs record the NAME " +
-        "only — never the value or any prefix. Validates name format " +
-        "(`^[A-Z][A-Z0-9_]{0,63}$`) + 8KiB value cap.",
+        "Environment credential management is unavailable pending the " +
+        "canonical WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["name", "value"],
@@ -462,58 +458,23 @@ export function buildSettingsToolHandlers(deps: {
         },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const name = String(params["name"]);
-        const value = String(params["value"]);
-        try {
-          const result = await envs.setSecret(tuple(reqScope), reqScope.userId ?? null, { name, value });
-          // Strip value from audit args — log NAME ONLY.
-          auditMutation(reqScope, "environments.set_secret", { name }, { ok: true, name }, "success", startedAt);
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "environments.set_secret", { name }, null, "failed", startedAt, message);
-          if (message === "access_denied") return { error: "access_denied" };
-          if (message === "name_invalid") return { error: "name_invalid" };
-          if (message === "value_required") return { error: "value_required" };
-          if (message === "value_too_long") return { error: "value_too_long" };
-          if (message === "encryption_key_not_set" || message === "encryption_key_invalid_length") {
-            return { error: "agent_misconfigured", message };
-          }
-          return { error: "set_failed", message };
-        }
+      async execute() {
+        return environmentCredentialsUnavailable();
       },
     },
     {
       name: "environments.delete_secret",
       description:
-        "Remove a secret from the caller's (project, environment) " +
-        "scope. Owner-gated. Idempotent — already-missing secrets " +
-        "return `{ deleted: false }` rather than throwing. Audit logs " +
-        "the NAME only.",
+        "Environment credential management is unavailable pending the " +
+        "canonical WIN-124 persistence cutover.",
       inputSchema: {
         type: "object",
         required: ["name"],
         properties: { name: { type: "string" } },
         additionalProperties: false,
       },
-      async execute(params, scope) {
-        const startedAt = Date.now();
-        const reqScope = scope as RequestScope;
-        const name = String(params["name"]);
-        try {
-          const result = await envs.deleteSecret(tuple(reqScope), reqScope.userId ?? null, { name });
-          auditMutation(reqScope, "environments.delete_secret", { name }, result, "success", startedAt);
-          return result;
-        } catch (err: any) {
-          const message = err?.message ?? String(err);
-          auditMutation(reqScope, "environments.delete_secret", { name }, null, "failed", startedAt, message);
-          if (message === "access_denied") return { error: "access_denied" };
-          if (message === "name_invalid") return { error: "name_invalid" };
-          return { error: "delete_failed", message };
-        }
+      async execute() {
+        return environmentCredentialsUnavailable();
       },
     },
 

--- a/apps/agent/src/mcp-platform/tools/unavailable-legacy-surfaces.test.ts
+++ b/apps/agent/src/mcp-platform/tools/unavailable-legacy-surfaces.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import { EnvironmentService } from "../../admin/environment.service";
+import type { RequestScope } from "../../auth/scope.guard";
+import type { ControlDatabaseClient } from "../../shared/database.provider";
+import { buildAlertChannelToolHandlers } from "./alert_channels";
+import { buildMonitoringToolHandlers } from "./monitoring";
+import { buildSettingsToolHandlers } from "./settings";
+
+const scope: RequestScope = {
+  organizationId: "org-a",
+  projectId: "project-a",
+  environmentId: "env-a",
+  userId: "user-a",
+  principal: "operator",
+};
+
+const environmentUnavailable = {
+  error: "unavailable",
+  message:
+    "Environment credential management is unavailable pending the canonical WIN-124 persistence cutover.",
+};
+
+const alertUnavailable = {
+  error: "unavailable",
+  message:
+    "Alert channel management is unavailable pending the canonical WIN-124 persistence cutover.",
+};
+
+describe("paused WIN-124 MCP surfaces", () => {
+  it.each([
+    "alert_channels.list",
+    "alert_channels.create",
+    "alert_channels.update",
+    "alert_channels.delete",
+    "alert_channels.test",
+    "alert_channels.get_integration",
+  ])("fails closed for %s without persistence or secret handling", async (name) => {
+    const projectAlertChannel = { findMany: vi.fn(), create: vi.fn(), update: vi.fn() };
+    const organizationIntegration = { findFirst: vi.fn() };
+    const toolAudit = { record: vi.fn() };
+    const handlers = buildAlertChannelToolHandlers({
+      toolAudit: toolAudit as any,
+      prisma: { projectAlertChannel, organizationIntegration },
+    });
+    const handler = handlers.find((candidate) => candidate.name === name)!;
+
+    const result = await handler.execute(
+      {
+        id: "channel-a",
+        type: "WEBHOOK",
+        name: "alerts",
+        alertTypes: ["TASK_RUN"],
+        channel: {
+          url: "https://example.com/sentinel-url",
+          secret: "sentinel-webhook-secret",
+        },
+      },
+      scope,
+      {} as any,
+    );
+
+    expect(result).toEqual(alertUnavailable);
+    expect(JSON.stringify(result)).not.toContain("sentinel");
+    expect(projectAlertChannel.findMany).not.toHaveBeenCalled();
+    expect(projectAlertChannel.create).not.toHaveBeenCalled();
+    expect(projectAlertChannel.update).not.toHaveBeenCalled();
+    expect(organizationIntegration.findFirst).not.toHaveBeenCalled();
+    expect(toolAudit.record).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "environments.list_secrets",
+    "environments.set_secret",
+    "environments.delete_secret",
+  ])("fails closed for %s before service calls or audit", async (name) => {
+    const envs = {
+      listSecrets: vi.fn(),
+      setSecret: vi.fn(),
+      deleteSecret: vi.fn(),
+    };
+    const toolAudit = { record: vi.fn() };
+    const handlers = buildSettingsToolHandlers({
+      orgs: {} as any,
+      envs: envs as any,
+      clusters: {} as any,
+      toolAudit: toolAudit as any,
+      prisma: {} as any,
+    });
+    const handler = handlers.find((candidate) => candidate.name === name)!;
+
+    const result = await handler.execute(
+      { name: "API_KEY", value: "sentinel-plaintext-secret" },
+      scope,
+      {} as any,
+    );
+
+    expect(result).toEqual(environmentUnavailable);
+    expect(JSON.stringify(result)).not.toContain("sentinel");
+    expect(envs.listSecrets).not.toHaveBeenCalled();
+    expect(envs.setSecret).not.toHaveBeenCalled();
+    expect(envs.deleteSecret).not.toHaveBeenCalled();
+    expect(toolAudit.record).not.toHaveBeenCalled();
+  });
+
+  it("keeps EnvironmentService credential methods unavailable without querying Prisma", async () => {
+    const service = new EnvironmentService({} as ControlDatabaseClient);
+
+    await expect(service.listSecrets(scope, "user-a")).rejects.toThrow(
+      "environment_credentials_unavailable",
+    );
+    await expect(
+      service.setSecret(scope, "user-a", {
+        name: "API_KEY",
+        value: "sentinel-plaintext-secret",
+      }),
+    ).rejects.toThrow("environment_credentials_unavailable");
+    await expect(
+      service.deleteSecret(scope, "user-a", { name: "API_KEY" }),
+    ).rejects.toThrow("environment_credentials_unavailable");
+  });
+});
+
+describe("canonical run-history absence", () => {
+  it("returns a stable unavailable response without querying TaskRun", async () => {
+    const findMany = vi.fn();
+    const handlers = buildMonitoringToolHandlers({
+      traces: {} as any,
+      providerHealth: {} as any,
+      prisma: { taskRun: { findMany } },
+    });
+    const handler = handlers.find((candidate) => candidate.name === "runs.list_all")!;
+
+    const result = await handler.execute(
+      { taskIdentifier: "sentinel-task", limit: 10 },
+      scope,
+      {} as any,
+    );
+
+    expect(result).toEqual({
+      error: "unavailable",
+      message: "Task run history is not available through the canonical control database.",
+    });
+    expect(findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agent/src/mcp-platform/tools/unsupported-canonical-surfaces.test.ts
+++ b/apps/agent/src/mcp-platform/tools/unsupported-canonical-surfaces.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RequestScope } from "../../auth/scope.guard";
+import { buildEntityToolHandlers } from "./entities";
+import { buildOrchestrationToolHandlers } from "./orchestration";
+
+const scope: RequestScope = {
+  organizationId: "org-1",
+  projectId: "project-1",
+  environmentId: "env-1",
+  userId: "user-1",
+  principal: "operator",
+};
+
+describe("unsupported canonical control surfaces", () => {
+  it.each([
+    "entities.get_linked_agents",
+    "entities.set_linked_agents",
+    "entities.get_test_credentials",
+    "entities.set_test_credentials",
+  ])("fails closed for %s", async (name) => {
+    const toolAudit = { record: vi.fn().mockResolvedValue(undefined) };
+    const messageCrypto = {
+      decryptJsonField: vi.fn(),
+      encryptJsonField: vi.fn(),
+    };
+    const handlers = buildEntityToolHandlers({
+      auth: { getEntity: vi.fn().mockResolvedValue({ id: "entity-pk" }) } as any,
+      toolExecutor: {} as any,
+      toolRegistry: {} as any,
+      bearerTokens: {} as any,
+      messageCrypto: messageCrypto as any,
+      toolAudit: toolAudit as any,
+      prisma: {} as any,
+    });
+    const handler = handlers.find((candidate) => candidate.name === name)!;
+
+    const result = await handler.execute(
+      {
+        entityId: "entity-1",
+        agentIds: ["agent-1"],
+        testCredentials: {
+          headers: [{ name: "Authorization", value: "sentinel-secret" }],
+        },
+      },
+      scope,
+      {} as any
+    );
+
+    expect(result).toMatchObject({ error: "unsupported" });
+    expect(messageCrypto.decryptJsonField).not.toHaveBeenCalled();
+    expect(messageCrypto.encryptJsonField).not.toHaveBeenCalled();
+  });
+
+  it("rejects contextMapping before creating an agent", async () => {
+    const create = vi.fn();
+    const handlers = buildOrchestrationToolHandlers({
+      agentCrud: { create } as any,
+      auth: {} as any,
+      skillRegistry: {} as any,
+      memory: {} as any,
+      goldenSet: {} as any,
+      prisma: {} as any,
+    });
+    const handler = handlers.find((candidate) => candidate.name === "agents.deploy_with_skills")!;
+
+    const result = await handler.execute(
+      {
+        name: "Agent",
+        model: "model",
+        skillSlugs: [],
+        contextMapping: { promptVars: ["email"] },
+      },
+      scope,
+      {} as any
+    );
+
+    expect(result).toEqual({
+      error: "unsupported",
+      message: "contextMapping is not supported by the canonical control schema",
+    });
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/agent/src/memory/conversation-postgres.integration.test.ts
+++ b/apps/agent/src/memory/conversation-postgres.integration.test.ts
@@ -8,6 +8,7 @@ import {
   ConversationRevisionNotSupportedError,
   ConversationService,
 } from "./conversation.service";
+import { ErasureService } from "../privacy/erasure.service";
 
 vi.setConfig({ testTimeout: 180_000, hookTimeout: 180_000 });
 
@@ -70,6 +71,13 @@ describe("ConversationService PostgreSQL integrity", () => {
         versionNumber: 1,
         model: "fixture:model",
         createdBy: user.id,
+      },
+    });
+    await prisma.agentBinding.create({
+      data: {
+        environmentId: environment.id,
+        agentId: agent.id,
+        activeAgentVersionId: agentVersion.id,
       },
     });
     const endUser = await prisma.endUser.create({
@@ -206,6 +214,156 @@ describe("ConversationService PostgreSQL integrity", () => {
       Array.from({ length: writeCount }, (_, index) => index + 1),
     );
     expect(new Set(rows.map((row) => row.inputText)).size).toBe(writeCount);
+  });
+
+  it("erases an ordinary authenticated runtime user through the canonical external tuple", async () => {
+    const externalUserId = "ordinary-runtime-subject";
+    const runtimeScope = {
+      ...scope(),
+      userId: externalUserId,
+      principal: "end-user" as const,
+      userIdentities: [
+        { channel: "email", handle: "ordinary-runtime@test.invalid", verified: true },
+      ],
+    };
+    const thread = await service.createThread(runtimeScope, ids.agentId, "Erase me");
+    const identities = await prisma.endUserIdentity.findMany({
+      where: { endUserId: thread.endUserId },
+      orderBy: [{ issuer: "asc" }, { channel: "asc" }],
+    });
+    expect(identities).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        issuer: "platos:external",
+        channel: "external",
+        subject: externalUserId,
+        verifiedAt: expect.any(Date),
+      }),
+      expect.objectContaining({
+        issuer: "platos",
+        channel: "session",
+        subject: externalUserId,
+        verifiedAt: expect.any(Date),
+      }),
+      expect.objectContaining({
+        issuer: "channel:email",
+        channel: "email",
+        subject: "ordinary-runtime@test.invalid",
+        verifiedAt: expect.any(Date),
+      }),
+    ]));
+
+    const audit = await prisma.toolCallAudit.create({
+      data: {
+        environmentId: ids.environmentId,
+        agentId: ids.agentId,
+        threadId: thread.id,
+        toolName: "runtime_tool",
+        arguments: {
+          __platosAudit: {
+            userId: null,
+            mcpUserId: null,
+            endUserId: externalUserId,
+          },
+          value: { plaintext: "subject payload" },
+        },
+        result: { plaintext: "subject result" },
+        error: "subject error",
+        status: "FAILED",
+        latencyMs: 12,
+      },
+    });
+    await prisma.safetyEvent.create({
+      data: {
+        environmentId: ids.environmentId,
+        agentId: ids.agentId,
+        detector: "runtime",
+        action: "block",
+        severity: "high",
+        metadata: { __platosSafety: { userId: externalUserId } },
+      },
+    });
+    const otherOrganization = await prisma.organization.create({
+      data: { slug: "erasure-other-org", name: "Erasure Other Org" },
+    });
+    const otherProject = await prisma.project.create({
+      data: {
+        organizationId: otherOrganization.id,
+        slug: "erasure-other-project",
+        name: "Erasure Other Project",
+      },
+    });
+    const otherEnvironment = await prisma.environment.create({
+      data: {
+        projectId: otherProject.id,
+        slug: "development",
+        name: "Development",
+      },
+    });
+    const otherAudit = await prisma.toolCallAudit.create({
+      data: {
+        environmentId: otherEnvironment.id,
+        toolName: "other_org_runtime_tool",
+        arguments: {
+          __platosAudit: {
+            userId: null,
+            mcpUserId: null,
+            endUserId: externalUserId,
+          },
+          value: { plaintext: "other organization payload" },
+        },
+        result: { plaintext: "other organization result" },
+        error: "other organization error",
+        status: "FAILED",
+        latencyMs: 21,
+      },
+    });
+    const otherSafety = await prisma.safetyEvent.create({
+      data: {
+        environmentId: otherEnvironment.id,
+        detector: "runtime",
+        action: "block",
+        severity: "high",
+        metadata: { __platosSafety: { userId: externalUserId } },
+      },
+    });
+
+    const erasure = new ErasureService(prisma, {} as any);
+    const subject = await erasure.discoverSubject(externalUserId, ids.organizationId);
+    expect(subject.platosEndUserIds).toEqual([thread.endUserId]);
+    const inventory = await erasure.inventory(subject, ids.organizationId);
+    expect(inventory).toMatchObject({ toolCallAudits: 1, safetyEvents: 1 });
+    const outcome = await (erasure as any).postgresExecutor(subject, ids.organizationId);
+
+    expect(outcome).toMatchObject({ status: "done", verificationStatus: "passed" });
+    await expect(prisma.endUser.findUnique({ where: { id: thread.endUserId } })).resolves.toBeNull();
+    await expect(prisma.safetyEvent.count({
+      where: {
+        environment: { project: { organizationId: ids.organizationId } },
+        metadata: { path: ["__platosSafety", "userId"], equals: externalUserId },
+      },
+    })).resolves.toBe(0);
+    await expect(prisma.toolCallAudit.findUnique({ where: { id: audit.id } })).resolves.toMatchObject({
+      endUserId: null,
+      arguments: {
+        __platosAudit: { userId: null, mcpUserId: null, endUserId: null },
+      },
+      result: null,
+      error: null,
+      toolName: "runtime_tool",
+      status: "FAILED",
+      latencyMs: 12,
+    });
+    await expect(prisma.toolCallAudit.findUnique({ where: { id: otherAudit.id } })).resolves.toMatchObject({
+      arguments: {
+        __platosAudit: { userId: null, mcpUserId: null, endUserId: externalUserId },
+        value: { plaintext: "other organization payload" },
+      },
+      result: { plaintext: "other organization result" },
+      error: "other organization error",
+    });
+    await expect(prisma.safetyEvent.findUnique({ where: { id: otherSafety.id } })).resolves.toMatchObject({
+      metadata: { __platosSafety: { userId: externalUserId } },
+    });
   });
 });
 

--- a/apps/agent/src/memory/conversation.service.ts
+++ b/apps/agent/src/memory/conversation.service.ts
@@ -108,16 +108,32 @@ export class ConversationService {
     const claims = Array.isArray(scope.userIdentities)
       ? scope.userIdentities.filter((claim) => claim && typeof claim.channel === "string" && typeof claim.handle === "string").slice(0, 8)
       : [];
-    const candidates = [
+    const externalIdentity = {
+      issuer: "platos:external",
+      channel: "external",
+      subject: scope.userId.trim().slice(0, 256),
+      verified: true,
+    };
+    const sessionIdentity = {
+      issuer: "platos",
+      channel: "session",
+      subject: scope.userId.trim().slice(0, 256),
+      verified: true,
+    };
+    const channelIdentities = [
       ...claims.filter((claim) => claim.verified === true).map((claim) => ({
         issuer: `channel:${claim.channel.trim().toLowerCase()}`,
         channel: claim.channel.trim().toLowerCase(),
         subject: claim.handle.trim().slice(0, 256),
         verified: true,
       })),
-      { issuer: "platos", channel: "session", subject: scope.userId, verified: true },
     ].filter((claim) => claim.subject.length > 0);
+    if (!externalIdentity.subject) {
+      throw new Error("Conversation persistence requires an authenticated external subject");
+    }
+    const candidates = [externalIdentity, sessionIdentity, ...channelIdentities];
 
+    let resolvedEndUserId: string | null = null;
     for (const claim of candidates) {
       const identity = await this.prisma.endUserIdentity.findFirst({
         where: {
@@ -130,38 +146,96 @@ export class ConversationService {
         },
         select: { endUserId: true, subject: true },
       });
-      if (identity) return { id: identity.endUserId, subject: identity.subject };
+      if (identity) {
+        resolvedEndUserId = identity.endUserId;
+        break;
+      }
     }
 
-    const fallback = candidates.at(-1);
-    if (!fallback) throw new Error("Conversation persistence requires an end-user subject");
     return this.prisma.$transaction(async (tx) => {
-      const raced = await tx.endUserIdentity.findFirst({
+      const racedExternal = await tx.endUserIdentity.findUnique({
         where: {
-          organizationId: scope.organizationId,
-          issuer: fallback.issuer,
-          channel: fallback.channel,
-          subject: fallback.subject,
+          organizationId_issuer_channel_subject: {
+            organizationId: scope.organizationId,
+            issuer: externalIdentity.issuer,
+            channel: externalIdentity.channel,
+            subject: externalIdentity.subject,
+          },
         },
+        select: { endUserId: true },
+      });
+      const endUserId = racedExternal?.endUserId ?? resolvedEndUserId ?? (await tx.endUser.create({
+        data: { organizationId: scope.organizationId, displayName: opts?.displayName ?? null },
+        select: { id: true },
+      })).id;
+      const profile = opts?.email ? { email: opts.email } : undefined;
+      const verifiedAt = new Date();
+      const canonical = await tx.endUserIdentity.upsert({
+        where: {
+          organizationId_issuer_channel_subject: {
+            organizationId: scope.organizationId,
+            issuer: externalIdentity.issuer,
+            channel: externalIdentity.channel,
+            subject: externalIdentity.subject,
+          },
+        },
+        create: {
+          endUserId,
+          organizationId: scope.organizationId,
+          issuer: externalIdentity.issuer,
+          channel: externalIdentity.channel,
+          subject: externalIdentity.subject,
+          profile,
+          verifiedAt,
+        },
+        update: { disabledAt: null, verifiedAt },
         select: { endUserId: true, subject: true },
       });
-      if (raced) return { id: raced.endUserId, subject: raced.subject };
-      const endUser = await tx.endUser.create({
-        data: { organizationId: scope.organizationId, displayName: opts?.displayName ?? null },
-      });
-      const profile = opts?.email ? { email: opts.email } : undefined;
-      const identity = await tx.endUserIdentity.create({
-        data: {
-          endUserId: endUser.id,
-          organizationId: scope.organizationId,
-          issuer: fallback.issuer,
-          channel: fallback.channel,
-          subject: fallback.subject,
-          profile,
-          verifiedAt: new Date(),
+      await tx.endUserIdentity.upsert({
+        where: {
+          organizationId_issuer_channel_subject: {
+            organizationId: scope.organizationId,
+            issuer: sessionIdentity.issuer,
+            channel: sessionIdentity.channel,
+            subject: sessionIdentity.subject,
+          },
         },
+        create: {
+          endUserId: canonical.endUserId,
+          organizationId: scope.organizationId,
+          issuer: sessionIdentity.issuer,
+          channel: sessionIdentity.channel,
+          subject: sessionIdentity.subject,
+          verifiedAt,
+        },
+        update: { disabledAt: null, verifiedAt },
       });
-      return { id: identity.endUserId, subject: identity.subject };
+      for (const claim of channelIdentities) {
+        const existing = await tx.endUserIdentity.findUnique({
+          where: {
+            organizationId_issuer_channel_subject: {
+              organizationId: scope.organizationId,
+              issuer: claim.issuer,
+              channel: claim.channel,
+              subject: claim.subject,
+            },
+          },
+          select: { endUserId: true },
+        });
+        if (!existing) {
+          await tx.endUserIdentity.create({
+            data: {
+              endUserId: canonical.endUserId,
+              organizationId: scope.organizationId,
+              issuer: claim.issuer,
+              channel: claim.channel,
+              subject: claim.subject,
+              verifiedAt,
+            },
+          });
+        }
+      }
+      return { id: canonical.endUserId, subject: canonical.subject };
     });
   }
 
@@ -179,7 +253,13 @@ export class ConversationService {
     meta: { displayName?: string | null; email?: string | null },
   ): Promise<void> {
     const identity = await this.prisma.endUserIdentity.findFirst({
-      where: { organizationId: scope.organizationId, issuer: "platos", channel: "session", subject: externalUserId },
+      where: {
+        organizationId: scope.organizationId,
+        issuer: "platos:external",
+        channel: "external",
+        subject: externalUserId,
+        disabledAt: null,
+      },
       select: { id: true, endUserId: true, profile: true },
     });
     if (!identity) return;
@@ -195,6 +275,7 @@ export class ConversationService {
   private async projectThread(row: any, requestedUserId?: string): Promise<Thread> {
     const identities = row.endUser?.identities ?? [];
     const userId = identities.find((identity: any) => identity.subject === requestedUserId)?.subject
+      ?? identities.find((identity: any) => identity.issuer === "platos:external" && identity.channel === "external")?.subject
       ?? identities.find((identity: any) => identity.issuer === "platos" && identity.channel === "session")?.subject
       ?? identities[0]?.subject
       ?? row.endUserId;
@@ -286,6 +367,14 @@ export class ConversationService {
         identities: {
           some: {
             OR: [
+              {
+                organizationId: scope.organizationId,
+                issuer: "platos:external",
+                channel: "external",
+                subject: scope.userId,
+                disabledAt: null,
+                verifiedAt: { not: null as Date | null },
+              },
               {
                 organizationId: scope.organizationId,
                 issuer: "platos",

--- a/apps/agent/src/memory/memory-scope.ts
+++ b/apps/agent/src/memory/memory-scope.ts
@@ -56,7 +56,12 @@ export async function resolveEndUser(
     select: {
       id: true,
       identities: {
-        where: { disabledAt: null },
+        where: {
+          issuer: "platos:external",
+          channel: "external",
+          disabledAt: null,
+          verifiedAt: { not: null },
+        },
         orderBy: { createdAt: "asc" },
         take: 1,
         select: { subject: true },
@@ -67,19 +72,20 @@ export async function resolveEndUser(
     return { id: direct.id, externalId: direct.identities[0]?.subject ?? direct.id };
   }
 
-  const sessionIdentity = await prisma.endUserIdentity.findFirst({
+  const externalIdentity = await prisma.endUserIdentity.findFirst({
     where: {
       organizationId: scope.organizationId,
-      issuer: "platos",
-      channel: "session",
+      issuer: "platos:external",
+      channel: "external",
       subject: userId,
       disabledAt: null,
+      verifiedAt: { not: null },
       endUser: { disabledAt: null },
     },
     select: { endUserId: true, subject: true },
   });
-  if (sessionIdentity) {
-    return { id: sessionIdentity.endUserId, externalId: sessionIdentity.subject };
+  if (externalIdentity) {
+    return { id: externalIdentity.endUserId, externalId: externalIdentity.subject };
   }
 
   const identity = await prisma.endUserIdentity.findFirst({

--- a/apps/agent/src/privacy/erasure.controller.ts
+++ b/apps/agent/src/privacy/erasure.controller.ts
@@ -56,7 +56,7 @@ export class ErasureController {
     const credential = await this.authorized(req);
     if (!credential || credential.scope.organizationId !== organizationId) return this.deny(res);
     const subject = await this.erasure.discoverSubject(externalUserId, organizationId);
-    const inventory = await this.erasure.inventory(subject);
+    const inventory = await this.erasure.inventory(subject, organizationId);
     return res.json({
       resolvedEndUsers: subject.platosEndUserIds.length,
       resolvedLegacyIds: subject.legacyUserIds.length,

--- a/apps/agent/src/privacy/erasure.service.test.ts
+++ b/apps/agent/src/privacy/erasure.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Prisma } from "@platos/tenancy-database";
 import {
   ErasureIdempotencyConflictError,
   ErasureService,
@@ -11,13 +12,13 @@ function operation(overrides: Record<string, unknown> = {}) {
     idempotencyKey: "key_1",
     subjectKeyHash: "00".repeat(32),
     organizationId: "org_1",
-    status: "blocked_legal_hold",
+    status: "CANCELLED",
     scopes: [],
     stores: [],
     inventory: {},
     policyVersion: ERASURE_POLICY_VERSION,
     legalHoldPolicyId: "hold_1",
-    attempts: 0,
+    retryCount: 0,
     requestedAt: new Date("2026-08-14T00:00:00.000Z"),
     startedAt: null,
     completedAt: null,
@@ -31,7 +32,7 @@ describe("ErasureService idempotency and retry subject binding", () => {
 
   beforeEach(() => {
     prisma = {
-      platosErasureOperation: {
+      erasureOperation: {
         findFirst: vi.fn(),
         create: vi.fn(),
         update: vi.fn(),
@@ -41,14 +42,14 @@ describe("ErasureService idempotency and retry subject binding", () => {
   });
 
   it("scopes the same idempotency key independently across organizations", async () => {
-    prisma.platosErasureOperation.findFirst.mockResolvedValue(null);
+    prisma.erasureOperation.findFirst.mockResolvedValue(null);
     vi.spyOn(service, "discoverSubject").mockResolvedValue({
       platosEndUserIds: ["end_user_1"],
       legacyUserIds: ["person_1"],
       scopes: [{ organizationId: "org_1", projectId: "project_1", environmentId: "env_1" }],
     });
     vi.spyOn(service, "inventory").mockResolvedValue({ resolved: 1 });
-    prisma.platosErasureOperation.create.mockImplementation(async ({ data }: any) =>
+    prisma.erasureOperation.create.mockImplementation(async ({ data }: any) =>
       operation(data)
     );
 
@@ -59,10 +60,10 @@ describe("ErasureService idempotency and retry subject binding", () => {
       legalHoldPolicyId: "hold_1",
     });
 
-    expect(prisma.platosErasureOperation.findFirst).toHaveBeenCalledWith({
+    expect(prisma.erasureOperation.findFirst).toHaveBeenCalledWith({
       where: { organizationId: "org_1", idempotencyKey: "shared_key" },
     });
-    expect(prisma.platosErasureOperation.create).toHaveBeenCalledWith({
+    expect(prisma.erasureOperation.create).toHaveBeenCalledWith({
       data: expect.objectContaining({ organizationId: "org_1", idempotencyKey: "shared_key" }),
     });
     expect(receipt.operationId).toBeDefined();
@@ -70,7 +71,7 @@ describe("ErasureService idempotency and retry subject binding", () => {
 
   it("rejects reuse in one organization for a different subject", async () => {
     const boundHash = (service as any).hash("person_1", "org_1");
-    prisma.platosErasureOperation.findFirst.mockResolvedValue(
+    prisma.erasureOperation.findFirst.mockResolvedValue(
       operation({ subjectKeyHash: boundHash })
     );
     const discover = vi.spyOn(service, "discoverSubject");
@@ -87,10 +88,10 @@ describe("ErasureService idempotency and retry subject binding", () => {
 
   it("re-reads and validates the subject after a concurrent create conflict", async () => {
     const hash = (service as any).hash("person_1", "org_1");
-    prisma.platosErasureOperation.findFirst
+    prisma.erasureOperation.findFirst
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(operation({ subjectKeyHash: hash }));
-    prisma.platosErasureOperation.create.mockRejectedValue({ code: "P2002" });
+    prisma.erasureOperation.create.mockRejectedValue({ code: "P2002" });
     vi.spyOn(service, "discoverSubject").mockResolvedValue({
       platosEndUserIds: ["end_user_1"],
       legacyUserIds: ["person_1"],
@@ -106,20 +107,227 @@ describe("ErasureService idempotency and retry subject binding", () => {
         legalHoldPolicyId: "hold_1",
       })
     ).resolves.toMatchObject({ operationId: "operation_1" });
-    expect(prisma.platosErasureOperation.findFirst).toHaveBeenLastCalledWith({
+    expect(prisma.erasureOperation.findFirst).toHaveBeenLastCalledWith({
       where: { organizationId: "org_1", idempotencyKey: "key_1" },
     });
   });
 
   it("rejects a retry subject mismatch before discovery or deletion", async () => {
     const hash = (service as any).hash("person_1", "org_1");
-    prisma.platosErasureOperation.findFirst.mockResolvedValue(operation({ subjectKeyHash: hash }));
+    prisma.erasureOperation.findFirst.mockResolvedValue(operation({ subjectKeyHash: hash }));
     const discover = vi.spyOn(service, "discoverSubject");
     const executors = vi.spyOn(service as any, "executors");
 
     await expect(service.retryErasureById("operation_1", "person_2")).resolves.toBeNull();
     expect(discover).not.toHaveBeenCalled();
     expect(executors).not.toHaveBeenCalled();
-    expect(prisma.platosErasureOperation.update).not.toHaveBeenCalled();
+    expect(prisma.erasureOperation.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("ErasureService canonical subject discovery and runtime metadata", () => {
+  it("resolves only the canonical external identity tuple", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ endUserId: "end_user_external" });
+    const environmentFindMany = vi.fn().mockResolvedValue([
+      { id: "env_1", projectId: "project_1" },
+    ]);
+    const service = new ErasureService(
+      {
+        endUserIdentity: { findFirst },
+        environment: { findMany: environmentFindMany },
+      } as any,
+      {} as any,
+    );
+
+    await expect(service.discoverSubject("duplicate-subject", "org_1")).resolves.toEqual({
+      platosEndUserIds: ["end_user_external"],
+      legacyUserIds: ["duplicate-subject"],
+      scopes: [
+        { organizationId: "org_1", projectId: "project_1", environmentId: "env_1" },
+      ],
+    });
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        organizationId: "org_1",
+        issuer: "platos:external",
+        channel: "external",
+        subject: "duplicate-subject",
+        disabledAt: null,
+      },
+      select: { endUserId: true },
+    });
+  });
+
+  it("matches every audit adapter field, redacts content, and verifies within one organization", async () => {
+    const deleted = vi.fn().mockResolvedValue({ count: 0 });
+    const safetyDeleteMany = vi.fn().mockResolvedValue({ count: 1 });
+    const auditUpdate = vi.fn().mockResolvedValue({});
+    const auditFindMany = vi.fn().mockResolvedValue([
+      {
+        id: "audit_1",
+      },
+    ]);
+    const tx = {
+      messageRating: { deleteMany: deleted },
+      messageAttachment: { deleteMany: deleted },
+      memoryRelationship: { deleteMany: deleted },
+      memoryEntity: { deleteMany: deleted },
+      memory: { deleteMany: deleted },
+      safetyEvent: { deleteMany: safetyDeleteMany },
+      thread: { deleteMany: deleted },
+      toolCallAudit: { findMany: auditFindMany, update: auditUpdate },
+      endUserIdentity: { deleteMany: deleted },
+      endUser: { deleteMany: deleted },
+    };
+    const auditCount = vi.fn().mockResolvedValue(0);
+    const retainedAuditFindMany = vi.fn().mockResolvedValue([
+      {
+        id: "audit_1",
+        endUserId: null,
+        arguments: {
+          __platosAudit: {
+            userId: null,
+            mcpUserId: null,
+            endUserId: null,
+          },
+        },
+        result: null,
+        error: null,
+      },
+    ]);
+    const safetyCount = vi.fn().mockResolvedValue(0);
+    const prisma = {
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) => callback(tx)),
+      thread: { count: vi.fn().mockResolvedValue(0) },
+      memory: { count: vi.fn().mockResolvedValue(0) },
+      toolCallAudit: { count: auditCount, findMany: retainedAuditFindMany },
+      safetyEvent: { count: safetyCount },
+      endUser: { count: vi.fn().mockResolvedValue(0) },
+    };
+    const service = new ErasureService(prisma as any, {} as any);
+
+    const result = await (service as any).postgresExecutor({
+      platosEndUserIds: ["end_user_1"],
+      legacyUserIds: ["external_1"],
+      scopes: [],
+    }, "org_1");
+
+    const auditWhere = {
+      environment: { project: { organizationId: "org_1" } },
+      OR: [
+        { endUserId: { in: ["end_user_1"] } },
+        {
+          arguments: {
+            path: ["__platosAudit", "userId"],
+            equals: "external_1",
+          },
+        },
+        {
+          arguments: {
+            path: ["__platosAudit", "mcpUserId"],
+            equals: "external_1",
+          },
+        },
+        {
+          arguments: {
+            path: ["__platosAudit", "endUserId"],
+            equals: "external_1",
+          },
+        },
+      ],
+    };
+    const safetyWhere = {
+      environment: { project: { organizationId: "org_1" } },
+      OR: [
+        { endUserId: { in: ["end_user_1"] } },
+        {
+          metadata: {
+            path: ["__platosSafety", "userId"],
+            equals: "external_1",
+          },
+        },
+      ],
+    };
+    expect(auditFindMany).toHaveBeenCalledWith({
+      where: auditWhere,
+      select: { id: true },
+    });
+    expect(auditUpdate).toHaveBeenCalledWith({
+      where: { id: "audit_1" },
+      data: {
+        endUserId: null,
+        arguments: {
+          __platosAudit: {
+            userId: null,
+            mcpUserId: null,
+            endUserId: null,
+          },
+        },
+        result: Prisma.DbNull,
+        error: null,
+      },
+    });
+    expect(safetyDeleteMany).toHaveBeenCalledWith({ where: safetyWhere });
+    expect(auditCount).toHaveBeenCalledWith({ where: auditWhere });
+    expect(retainedAuditFindMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: ["audit_1"] },
+        environment: { project: { organizationId: "org_1" } },
+      },
+      select: {
+        id: true,
+        endUserId: true,
+        arguments: true,
+        result: true,
+        error: true,
+      },
+    });
+    expect(safetyCount).toHaveBeenCalledWith({ where: safetyWhere });
+    expect(result).toMatchObject({
+      status: "done",
+      verificationStatus: "passed",
+      anonymized: 1,
+    });
+  });
+
+  it("uses the same three adapter fields and organization ancestry for inventory", async () => {
+    const auditCount = vi.fn().mockResolvedValue(1);
+    const safetyCount = vi.fn().mockResolvedValue(1);
+    const zero = vi.fn().mockResolvedValue(0);
+    const service = new ErasureService({
+      thread: { count: zero },
+      memory: { count: zero },
+      messageRating: { count: zero },
+      messageAttachment: { count: zero },
+      toolCallAudit: { count: auditCount },
+      safetyEvent: { count: safetyCount },
+    } as any, {} as any);
+
+    await expect(service.inventory({
+      platosEndUserIds: ["end_user_1"],
+      legacyUserIds: ["external_1"],
+      scopes: [],
+    }, "org_1")).resolves.toMatchObject({ toolCallAudits: 1, safetyEvents: 1 });
+
+    expect(auditCount).toHaveBeenCalledWith({
+      where: {
+        environment: { project: { organizationId: "org_1" } },
+        OR: [
+          { endUserId: { in: ["end_user_1"] } },
+          { arguments: { path: ["__platosAudit", "userId"], equals: "external_1" } },
+          { arguments: { path: ["__platosAudit", "mcpUserId"], equals: "external_1" } },
+          { arguments: { path: ["__platosAudit", "endUserId"], equals: "external_1" } },
+        ],
+      },
+    });
+    expect(safetyCount).toHaveBeenCalledWith({
+      where: {
+        environment: { project: { organizationId: "org_1" } },
+        OR: [
+          { endUserId: { in: ["end_user_1"] } },
+          { metadata: { path: ["__platosSafety", "userId"], equals: "external_1" } },
+        ],
+      },
+    });
   });
 });

--- a/apps/agent/src/privacy/erasure.service.ts
+++ b/apps/agent/src/privacy/erasure.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Inject, Optional, Logger } from "@nestjs/common";
 import { createHash, randomUUID, timingSafeEqual } from "node:crypto";
+import { Prisma } from "@platos/tenancy-database";
 import type Redis from "ioredis";
-import { PRISMA_TOKEN } from "../shared/database.provider";
+import { PRISMA_TOKEN, type ControlDatabaseClient } from "../shared/database.provider";
 import { REDIS_TOKEN } from "../shared/redis.provider";
 import {
   mergeSubjectKeys, isEmptySubject, subjectKeyHash,
@@ -9,7 +10,8 @@ import {
 } from "./subject-graph";
 import {
   pendingStore, assertContentFree,
-  type ErasureReceipt, type StoreOutcome,
+  deriveStatus,
+  type ErasureReceipt, type ErasureStatus, type StoreOutcome,
 } from "./erasure-receipt";
 import { runErasure, retryErasure, type StoreExecutors } from "./erasure-orchestrator";
 import { findLegalHold, parseLegalHoldList } from "./legal-hold";
@@ -37,14 +39,55 @@ export class ErasureIdempotencyConflictError extends Error {
   }
 }
 
+function toDatabaseStatus(status: ErasureStatus) {
+  if (status === "pending") return "PENDING" as const;
+  if (status === "running") return "ACTIVE" as const;
+  if (status === "completed") return "SUCCEEDED" as const;
+  if (status === "blocked_legal_hold") return "CANCELLED" as const;
+  return "FAILED" as const;
+}
+
+const CONTENT_FREE_AUDIT_ARGUMENTS = {
+  __platosAudit: {
+    userId: null,
+    mcpUserId: null,
+    endUserId: null,
+  },
+} as const;
+
+function isContentFreeAudit(row: {
+  endUserId: string | null;
+  arguments: unknown;
+  result: unknown;
+  error: string | null;
+}): boolean {
+  const argumentsValue = row.arguments;
+  if (!argumentsValue || typeof argumentsValue !== "object" || Array.isArray(argumentsValue)) {
+    return false;
+  }
+  const argumentEntries = Object.entries(argumentsValue as Record<string, unknown>);
+  const metadata = (argumentsValue as Record<string, unknown>).__platosAudit;
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) return false;
+  const metadataObject = metadata as Record<string, unknown>;
+  return row.endUserId === null
+    && row.result === null
+    && row.error === null
+    && argumentEntries.length === 1
+    && argumentEntries[0]?.[0] === "__platosAudit"
+    && Object.keys(metadataObject).sort().join(",") === "endUserId,mcpUserId,userId"
+    && metadataObject.userId === null
+    && metadataObject.mcpUserId === null
+    && metadataObject.endUserId === null;
+}
+
 @Injectable()
 export class ErasureService {
   private readonly logger = new Logger(ErasureService.name);
-  private readonly prisma: any;
+  private readonly prisma: ControlDatabaseClient;
   private readonly salt: string;
 
   constructor(
-    @Inject(PRISMA_TOKEN) prisma: any,
+    @Inject(PRISMA_TOKEN) prisma: ControlDatabaseClient,
     @Inject(REDIS_TOKEN) private readonly redis: Redis,
     @Optional() private readonly attachments?: ErasureObjectStore,
   ) {
@@ -86,63 +129,85 @@ export class ErasureService {
    * userId and missed every row linked by platosEndUserId instead.
    */
   async discoverSubject(externalUserId: string, organizationId: string): Promise<SubjectKeys> {
-    const endUsers: any[] = await this.prisma.platosEndUser.findMany({
+    const externalIdentity = await this.prisma.endUserIdentity.findFirst({
       where: {
         organizationId,
-        OR: [{ externalUserId }, { linkedExternalId: externalUserId }],
+        issuer: "platos:external",
+        channel: "external",
+        subject: externalUserId,
+        disabledAt: null,
       },
-      select: { id: true, externalUserId: true, linkedExternalId: true,
-                organizationId: true, projectId: true, environmentId: true },
+      select: { endUserId: true },
     });
-
-    // A person can be reachable only through a channel handle (an email or a
-    // Slack id) with no matching externalUserId anywhere.
-    const viaIdentity: any[] = await this.prisma.platosEndUserIdentity.findMany({
-      where: { organizationId, handle: externalUserId },
-      select: { platosEndUserId: true, organizationId: true, projectId: true, environmentId: true },
-    });
-
-    const identityOwners: any[] = viaIdentity.length
-      ? await this.prisma.platosEndUser.findMany({
-          where: { id: { in: [...new Set(viaIdentity.map((i) => i.platosEndUserId))] } },
-          select: { id: true, externalUserId: true, linkedExternalId: true,
-                    organizationId: true, projectId: true, environmentId: true },
+    const endUserIds = externalIdentity ? [externalIdentity.endUserId] : [];
+    const environments = endUserIds.length
+      ? await this.prisma.environment.findMany({
+          where: {
+            project: { organizationId },
+            OR: [
+              { threads: { some: { endUserId: { in: endUserIds } } } },
+              { memories: { some: { endUserId: { in: endUserIds } } } },
+              { messageAttachments: { some: { endUserId: { in: endUserIds } } } },
+              { toolCallAudits: { some: { endUserId: { in: endUserIds } } } },
+            ],
+          },
+          select: { id: true, projectId: true },
         })
       : [];
-
-    const all = [...endUsers, ...identityOwners];
-    const scopes: SubjectScope[] = all.map((u) => ({
-      organizationId: u.organizationId, projectId: u.projectId, environmentId: u.environmentId,
+    const scopes: SubjectScope[] = environments.map((environment) => ({
+      organizationId,
+      projectId: environment.projectId,
+      environmentId: environment.id,
     }));
 
-    // Historical denormalized ids: the request id itself, plus whatever the
-    // canonical rows were keyed by before adoption.
-    const legacy = [externalUserId, ...all.map((u) => u.externalUserId), ...all.map((u) => u.linkedExternalId)]
-      .filter((v): v is string => typeof v === "string" && v.length > 0);
-
     return mergeSubjectKeys({
-      platosEndUserIds: all.map((u) => u.id),
-      legacyUserIds: legacy,
-      scopes: [...scopes, ...viaIdentity.map((i) => ({
-        organizationId: i.organizationId, projectId: i.projectId, environmentId: i.environmentId }))],
+      platosEndUserIds: endUserIds,
+      legacyUserIds: endUserIds.length > 0 ? [externalUserId] : [],
+      scopes,
     });
   }
 
   /** Content-free inventory: counts and scope ids, never content. */
-  async inventory(subject: SubjectKeys): Promise<Record<string, number | unknown>> {
+  async inventory(
+    subject: SubjectKeys,
+    organizationId: string,
+  ): Promise<Record<string, number | unknown>> {
     if (isEmptySubject(subject)) return { resolved: 0 };
     const { platosEndUserIds: eu, legacyUserIds: lu } = subject;
-    const [threads, memories, ratings, attachments, audits] = await Promise.all([
-      this.prisma.platosAgentThread.count({ where: { OR: [{ platosEndUserId: { in: eu } }, { userId: { in: lu } }] } }),
-      this.prisma.platosMemory.count({ where: { OR: [{ platosEndUserId: { in: eu } }, { userId: { in: lu } }] } }),
-      this.prisma.platosMessageRating.count({ where: { userId: { in: lu } } }),
-      this.prisma.platosMessageAttachment.count({ where: { uploadedBy: { in: lu } } }),
-      this.prisma.platosToolCallAudit.count({ where: { OR: [{ platosEndUserId: { in: eu } }, { userId: { in: lu } }] } }),
+    const auditAdapterFields = ["userId", "mcpUserId", "endUserId"] as const;
+    const legacyAuditWhere = lu.flatMap((userId) =>
+      auditAdapterFields.map((field) => ({
+        arguments: { path: ["__platosAudit", field], equals: userId },
+      })),
+    );
+    const legacySafetyWhere = lu.map((userId) => ({
+      metadata: { path: ["__platosSafety", "userId"], equals: userId },
+    }));
+    const environmentOrganizationWhere = {
+      environment: { project: { organizationId } },
+    };
+    const [threads, memories, ratings, attachments, audits, safetyEvents] = await Promise.all([
+      this.prisma.thread.count({ where: { endUserId: { in: eu } } }),
+      this.prisma.memory.count({ where: { endUserId: { in: eu } } }),
+      this.prisma.messageRating.count({ where: { endUserId: { in: eu } } }),
+      this.prisma.messageAttachment.count({ where: { endUserId: { in: eu } } }),
+      this.prisma.toolCallAudit.count({
+        where: {
+          ...environmentOrganizationWhere,
+          OR: [{ endUserId: { in: eu } }, ...legacyAuditWhere],
+        },
+      }),
+      this.prisma.safetyEvent.count({
+        where: {
+          ...environmentOrganizationWhere,
+          OR: [{ endUserId: { in: eu } }, ...legacySafetyWhere],
+        },
+      }),
     ]);
     return {
       resolved: eu.length + lu.length,
       scopes: subject.scopes,
-      threads, memories, ratings, attachments, toolCallAudits: audits,
+      threads, memories, ratings, attachments, toolCallAudits: audits, safetyEvents,
     };
   }
 
@@ -157,8 +222,8 @@ export class ErasureService {
     if (!this.attachments?.available) {
       return { ...o, status: "not_provisioned", note: "no object-store client wired" };
     }
-    const rows: any[] = await this.prisma.platosMessageAttachment.findMany({
-      where: { uploadedBy: { in: subject.legacyUserIds } },
+    const rows: any[] = await this.prisma.messageAttachment.findMany({
+      where: { endUserId: { in: subject.platosEndUserIds } },
       select: { storageKey: true },
     });
     o.discovered = rows.length;
@@ -185,8 +250,8 @@ export class ErasureService {
 
   private redisExecutor = async (subject: SubjectKeys): Promise<StoreOutcome> => {
     const o = pendingStore("redis");
-    const threadRows: any[] = await this.prisma.platosAgentThread.findMany({
-      where: { OR: [{ platosEndUserId: { in: subject.platosEndUserIds } }, { userId: { in: subject.legacyUserIds } }] },
+    const threadRows: any[] = await this.prisma.thread.findMany({
+      where: { endUserId: { in: subject.platosEndUserIds } },
       select: { id: true },
     });
     const refs = {
@@ -255,41 +320,72 @@ export class ErasureService {
   };
 
   /** Postgres. Runs LAST: it holds the identifiers every other store uses. */
-  private postgresExecutor = async (subject: SubjectKeys): Promise<StoreOutcome> => {
+  private postgresExecutor = async (
+    subject: SubjectKeys,
+    organizationId: string,
+  ): Promise<StoreOutcome> => {
     const o = pendingStore("postgres");
     const eu = subject.platosEndUserIds;
     const lu = subject.legacyUserIds;
-    const both = { OR: [{ platosEndUserId: { in: eu } }, { userId: { in: lu } }] };
+    const subjectWhere = { endUserId: { in: eu } };
+    const auditAdapterFields = ["userId", "mcpUserId", "endUserId"] as const;
+    const environmentOrganizationWhere = {
+      environment: { project: { organizationId } },
+    };
+    const auditSubjectWhere = {
+      ...environmentOrganizationWhere,
+      OR: [
+        { endUserId: { in: eu } },
+        ...lu.flatMap((userId) =>
+          auditAdapterFields.map((field) => ({
+            arguments: { path: ["__platosAudit", field], equals: userId },
+          })),
+        ),
+      ],
+    };
+    const safetySubjectWhere = {
+      ...environmentOrganizationWhere,
+      OR: [
+        { endUserId: { in: eu } },
+        ...lu.map((userId) => ({
+          metadata: { path: ["__platosSafety", "userId"], equals: userId },
+        })),
+      ],
+    };
+    const retainedAuditIds: string[] = [];
 
     try {
-      await this.prisma.$transaction(async (tx: any) => {
-        // Children first: messages and attachment metadata hang off threads.
-        const threads: any[] = await tx.platosAgentThread.findMany({ where: both, select: { id: true } });
-        const threadIds = threads.map((t) => t.id);
-        if (threadIds.length) {
-          const msgs: any[] = await tx.platosAgentMessage.findMany({
-            where: { threadId: { in: threadIds } }, select: { id: true } });
-          const msgIds = msgs.map((m) => m.id);
-          if (msgIds.length) {
-            o.deleted += (await tx.platosMessageAttachment.deleteMany({ where: { messageId: { in: msgIds } } })).count;
-            o.deleted += (await tx.platosAgentMessage.deleteMany({ where: { id: { in: msgIds } } })).count;
-          }
-        }
-        o.deleted += (await tx.platosMessageRating.deleteMany({ where: { userId: { in: lu } } })).count;
-        o.deleted += (await tx.platosMessageAttachment.deleteMany({ where: { uploadedBy: { in: lu } } })).count;
-        o.deleted += (await tx.platosMemoryRelationship.deleteMany({ where: { userId: { in: lu } } })).count;
-        o.deleted += (await tx.platosMemoryEntity.deleteMany({ where: { userId: { in: lu } } })).count;
-        o.deleted += (await tx.platosMemory.deleteMany({ where: both })).count;
-        o.deleted += (await tx.platosSafetyEvent.deleteMany({ where: { userId: { in: lu } } })).count;
-        o.deleted += (await tx.platosAgentThread.deleteMany({ where: both })).count;
+      await this.prisma.$transaction(async (tx) => {
+        o.deleted += (await tx.messageRating.deleteMany({ where: subjectWhere })).count;
+        o.deleted += (await tx.messageAttachment.deleteMany({ where: subjectWhere })).count;
+        o.deleted += (await tx.memoryRelationship.deleteMany({ where: subjectWhere })).count;
+        o.deleted += (await tx.memoryEntity.deleteMany({ where: subjectWhere })).count;
+        o.deleted += (await tx.memory.deleteMany({ where: subjectWhere })).count;
+        o.deleted += (await tx.safetyEvent.deleteMany({ where: safetySubjectWhere })).count;
+        o.deleted += (await tx.thread.deleteMany({ where: subjectWhere })).count;
         // Audit rows are ANONYMIZED, not deleted: they are the record that the
         // erasure itself happened, and destroying them would remove the proof.
-        o.anonymized += (await tx.platosToolCallAudit.updateMany({
-          where: both, data: { userId: null, platosEndUserId: null } })).count;
+        const auditRows = await tx.toolCallAudit.findMany({
+          where: auditSubjectWhere,
+          select: { id: true },
+        });
+        for (const audit of auditRows) {
+          retainedAuditIds.push(audit.id);
+          await tx.toolCallAudit.update({
+            where: { id: audit.id },
+            data: {
+              endUserId: null,
+              arguments: CONTENT_FREE_AUDIT_ARGUMENTS as any,
+              result: Prisma.DbNull,
+              error: null,
+            },
+          });
+          o.anonymized++;
+        }
         // Canonical identity last — without it nothing can be rediscovered.
         if (eu.length) {
-          o.deleted += (await tx.platosEndUserIdentity.deleteMany({ where: { platosEndUserId: { in: eu } } })).count;
-          o.deleted += (await tx.platosEndUser.deleteMany({ where: { id: { in: eu } } })).count;
+          o.deleted += (await tx.endUserIdentity.deleteMany({ where: { endUserId: { in: eu } } })).count;
+          o.deleted += (await tx.endUser.deleteMany({ where: { id: { in: eu } } })).count;
         }
       });
     } catch (err: any) {
@@ -298,26 +394,44 @@ export class ErasureService {
     }
 
     // Negative verification: prove nothing identifying survives.
-    const [t, m, a, e] = await Promise.all([
-      this.prisma.platosAgentThread.count({ where: both }),
-      this.prisma.platosMemory.count({ where: both }),
-      this.prisma.platosToolCallAudit.count({ where: { OR: [{ platosEndUserId: { in: eu } }, { userId: { in: lu } }] } }),
-      eu.length ? this.prisma.platosEndUser.count({ where: { id: { in: eu } } }) : Promise.resolve(0),
+    const [t, m, auditSubjectSurvivors, retainedAudits, s, e] = await Promise.all([
+      this.prisma.thread.count({ where: subjectWhere }),
+      this.prisma.memory.count({ where: subjectWhere }),
+      this.prisma.toolCallAudit.count({ where: auditSubjectWhere }),
+      retainedAuditIds.length
+        ? this.prisma.toolCallAudit.findMany({
+            where: {
+              id: { in: retainedAuditIds },
+              ...environmentOrganizationWhere,
+            },
+            select: {
+              id: true,
+              endUserId: true,
+              arguments: true,
+              result: true,
+              error: true,
+            },
+          })
+        : Promise.resolve([]),
+      this.prisma.safetyEvent.count({ where: safetySubjectWhere }),
+      eu.length ? this.prisma.endUser.count({ where: { id: { in: eu } } }) : Promise.resolve(0),
     ]);
-    const survivors = t + m + a + e;
+    const retainedAuditViolations = retainedAuditIds.length - retainedAudits.filter(isContentFreeAudit).length;
+    const a = auditSubjectSurvivors + retainedAuditViolations;
+    const survivors = t + m + a + s + e;
     o.verificationStatus = survivors === 0 ? "passed" : "failed";
     o.status = "done";
     o.retained = 0;
-    o.note = `verification: threads=${t} memories=${m} audits=${a} endUsers=${e}`;
+    o.note = `verification: threads=${t} memories=${m} audits=${a} safetyEvents=${s} endUsers=${e}`;
     return o;
   };
 
-  private executors(): StoreExecutors {
+  private executors(organizationId: string): StoreExecutors {
     return {
       minio: this.minioExecutor,
       redis: this.redisExecutor,
       clickhouse: this.clickhouseExecutor,
-      postgres: this.postgresExecutor,
+      postgres: (subject) => this.postgresExecutor(subject, organizationId),
     };
   }
 
@@ -334,13 +448,13 @@ export class ErasureService {
     legalHoldPolicyId?: string | null;
   }): Promise<ErasureReceipt> {
     const hash = this.hash(args.externalUserId, args.organizationId);
-    const existing = await this.prisma.platosErasureOperation.findFirst({
+    const existing = await this.prisma.erasureOperation.findFirst({
       where: { organizationId: args.organizationId, idempotencyKey: args.idempotencyKey },
     });
     if (existing) return this.existingReceiptForSubject(existing, hash);
 
     const subject = await this.discoverSubject(args.externalUserId, args.organizationId);
-    const inventory = await this.inventory(subject);
+    const inventory = await this.inventory(subject, args.organizationId);
 
     // Server-side hold check, over every alias the subject resolves to. Runs
     // before the operation row is created so a held subject leaves no
@@ -357,24 +471,24 @@ export class ErasureService {
 
     let row: any;
     try {
-      row = await this.prisma.platosErasureOperation.create({
+      row = await this.prisma.erasureOperation.create({
         data: {
           id: randomUUID(),
           idempotencyKey: args.idempotencyKey,
           subjectKeyHash: hash,
           organizationId: args.organizationId,
-          status: heldBy ? "blocked_legal_hold" : "pending",
+          status: heldBy ? "CANCELLED" : "PENDING",
           scopes: subject.scopes as any,
           stores: [] as any,
           inventory: inventory as any,
           policyVersion: ERASURE_POLICY_VERSION,
           legalHoldPolicyId: heldBy ?? null,
-          attempts: 0,
+          retryCount: 0,
         },
       });
     } catch (error: any) {
       if (error?.code !== "P2002") throw error;
-      const raced = await this.prisma.platosErasureOperation.findFirst({
+      const raced = await this.prisma.erasureOperation.findFirst({
         where: { organizationId: args.organizationId, idempotencyKey: args.idempotencyKey },
       });
       if (!raced) throw error;
@@ -386,14 +500,14 @@ export class ErasureService {
     // the operator has to be able to evidence later.
     if (heldBy) return this.toReceipt(row);
 
-    const started = await runErasure(this.toReceipt(row), subject, this.executors(), {
+    const started = await runErasure(this.toReceipt(row), subject, this.executors(args.organizationId), {
       legalHold: args.legalHoldPolicyId ? { policyId: args.legalHoldPolicyId } : null,
     });
     return this.persist(started, [args.externalUserId, ...subject.legacyUserIds]);
   }
 
   async getErasure(operationId: string): Promise<ErasureReceipt | null> {
-    const row = await this.prisma.platosErasureOperation.findFirst({ where: { id: operationId } });
+    const row = await this.prisma.erasureOperation.findFirst({ where: { id: operationId } });
     return row ? this.toReceipt(row) : null;
   }
 
@@ -401,35 +515,45 @@ export class ErasureService {
     operationId: string,
     organizationId: string,
   ): Promise<boolean> {
-    return (await this.prisma.platosErasureOperation.count({
+    return (await this.prisma.erasureOperation.count({
       where: { id: operationId, organizationId },
     })) > 0;
   }
 
   async retryErasureById(operationId: string, externalUserId: string): Promise<ErasureReceipt | null> {
-    const row = await this.prisma.platosErasureOperation.findFirst({ where: { id: operationId } });
+    const row = await this.prisma.erasureOperation.findFirst({ where: { id: operationId } });
     if (!row) return null;
     if (!this.hashMatches(this.hash(externalUserId, row.organizationId), row.subjectKeyHash)) return null;
     const receipt = this.toReceipt(row);
     const subject = await this.discoverSubject(externalUserId, row.organizationId);
-    const next = await retryErasure(receipt, subject, this.executors(), {
+    const next = await retryErasure(receipt, subject, this.executors(row.organizationId), {
       legalHold: row.legalHoldPolicyId ? { policyId: row.legalHoldPolicyId } : null,
     });
     return this.persist(next, [externalUserId, ...subject.legacyUserIds]);
   }
 
   private toReceipt(row: any): ErasureReceipt {
+    const stores = (row.stores ?? []) as StoreOutcome[];
+    const status: ErasureStatus = row.legalHoldPolicyId
+      ? "blocked_legal_hold"
+      : row.status === "SUCCEEDED"
+        ? "completed"
+        : row.status === "ACTIVE"
+          ? "running"
+          : row.status === "FAILED"
+            ? deriveStatus(stores, { started: true })
+            : "pending";
     return {
       operationId: row.id,
       subjectKeyHash: row.subjectKeyHash,
       requestedAt: row.requestedAt?.toISOString?.() ?? String(row.requestedAt),
       startedAt: row.startedAt?.toISOString?.(),
       completedAt: row.completedAt?.toISOString?.(),
-      status: row.status,
+      status,
       scopes: (row.scopes ?? []) as any,
-      stores: (row.stores ?? []) as StoreOutcome[],
+      stores,
       policyVersion: row.policyVersion,
-      attempts: row.attempts ?? 0,
+      attempts: row.retryCount ?? 0,
       legalHoldPolicyId: row.legalHoldPolicyId ?? undefined,
     };
   }
@@ -437,12 +561,12 @@ export class ErasureService {
   private async persist(r: ErasureReceipt, forbidden: string[]): Promise<ErasureReceipt> {
     // Refuse to write a receipt that would recreate the identifier it documents.
     assertContentFree(r, forbidden);
-    await this.prisma.platosErasureOperation.update({
+    await this.prisma.erasureOperation.update({
       where: { id: r.operationId },
       data: {
-        status: r.status,
+        status: toDatabaseStatus(r.status),
         stores: r.stores as any,
-        attempts: r.attempts,
+        retryCount: r.attempts,
         startedAt: r.startedAt ? new Date(r.startedAt) : null,
         completedAt: r.completedAt ? new Date(r.completedAt) : null,
         legalHoldPolicyId: r.legalHoldPolicyId ?? null,

--- a/apps/agent/src/providers/provider-registry.service.test.ts
+++ b/apps/agent/src/providers/provider-registry.service.test.ts
@@ -18,6 +18,7 @@ describe("ProviderRegistryService clean provider state", () => {
       },
     };
     const scopedEnv = {
+      setMapForProvider: vi.fn().mockResolvedValue({ OPENAI_API_KEY: true }),
       hasProviderCredential: vi.fn().mockResolvedValue(true),
       get: vi.fn().mockResolvedValue(undefined),
     };
@@ -61,8 +62,12 @@ describe("ProviderRegistryService clean provider state", () => {
     };
     const service = new ProviderRegistryService(
       prisma as any,
-      { hasProviderCredential: vi.fn().mockResolvedValue(false), get: vi.fn() } as any,
-      { listFor: vi.fn() } as any,
+      {
+        setMapForProvider: vi.fn().mockResolvedValue({ OPENAI_API_KEY: false }),
+        hasProviderCredential: vi.fn().mockResolvedValue(false),
+        get: vi.fn(),
+      } as any,
+      { listFor: vi.fn() } as any
     );
 
     await service.link(scope, "openai");
@@ -74,13 +79,15 @@ describe("ProviderRegistryService clean provider state", () => {
       },
       select: { id: true },
     });
-    expect(tx.environmentProvider.upsert).toHaveBeenCalledWith(expect.objectContaining({
-      where: {
-        environmentId_providerId: {
-          environmentId: scope.environmentId,
-          providerId: "openai",
+    expect(tx.environmentProvider.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          environmentId_providerId: {
+            environmentId: scope.environmentId,
+            providerId: "openai",
+          },
         },
-      },
-    }));
+      })
+    );
   });
 });

--- a/apps/agent/src/tool-gateway/tool-executor.permission.test.ts
+++ b/apps/agent/src/tool-gateway/tool-executor.permission.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { RequestScope } from "../auth/scope.guard";
+import { ToolExecutorService } from "./tool-executor.service";
+
+const scope: RequestScope = {
+  organizationId: "org-1",
+  projectId: "project-1",
+  environmentId: "env-1",
+  userId: "user-1",
+  agentId: "agent-1",
+};
+
+function executorWith(options: {
+  permissionGateway?: { resolve: ReturnType<typeof vi.fn> };
+  approvalsService?: Record<string, unknown>;
+  redis?: Record<string, unknown>;
+}) {
+  const registry = { getScopedTools: vi.fn(() => []) };
+  const executor = new ToolExecutorService(
+    {} as any,
+    registry as any,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    options.permissionGateway as any,
+    options.approvalsService as any,
+    options.redis as any,
+    undefined,
+    undefined
+  );
+  const error = vi.fn();
+  (executor as any).logger = { error };
+  return { executor, registry, error };
+}
+
+afterEach(() => {
+  delete process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE;
+});
+
+describe("ToolExecutorService permission failures", () => {
+  it("fails closed and does not dispatch when permission resolution throws", async () => {
+    process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE = "1";
+    const secret = "postgres://operator:sentinel-secret@db.internal/control";
+    const resolve = vi.fn().mockRejectedValue(new Error(secret));
+    const { executor, registry, error } = executorWith({
+      permissionGateway: { resolve },
+    });
+
+    const result = await executor.execute({ tool: "safe.read", params: {} }, scope);
+
+    expect(result).toMatchObject({
+      tool: "safe.read",
+      status: "failed",
+      error: "Tool dispatch denied because permission policy could not be evaluated.",
+    });
+    expect(registry.getScopedTools).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(error).toHaveBeenCalledWith("Tool dispatch permission resolution failed");
+    expect(JSON.stringify(error.mock.calls)).not.toContain(secret);
+  });
+
+  it("fails closed when the enabled permission gateway is unavailable", async () => {
+    process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE = "1";
+    const { executor, registry, error } = executorWith({});
+
+    const result = await executor.execute({ tool: "safe.read", params: {} }, scope);
+
+    expect(result.status).toBe("failed");
+    expect(registry.getScopedTools).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("Tool dispatch permission gateway unavailable");
+  });
+
+  it("does not expose approval persistence failures", async () => {
+    process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE = "1";
+    const secret = "ciphertext=sentinel-ciphertext";
+    const { executor, registry, error } = executorWith({
+      permissionGateway: {
+        resolve: vi.fn().mockResolvedValue({
+          state: "require_approval",
+          tier: 1,
+          reason: "platform policy",
+        }),
+      },
+      approvalsService: {
+        createMcpApproval: vi.fn().mockRejectedValue(new Error(secret)),
+      },
+      redis: {},
+    });
+
+    const result = await executor.execute({ tool: "safe.write", params: {} }, scope);
+
+    expect(result.error).toBe("Tool approval could not be requested.");
+    expect(registry.getScopedTools).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(error).toHaveBeenCalledWith("Tool approval persistence failed");
+    expect(JSON.stringify(error.mock.calls)).not.toContain(secret);
+  });
+
+  it("does not expose approval wait failures", async () => {
+    process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE = "1";
+    const secret = "redis://:sentinel-password@redis.internal";
+    const blockClient = {
+      blpop: vi.fn().mockRejectedValue(new Error(secret)),
+      disconnect: vi.fn(),
+    };
+    const redis = {
+      publish: vi.fn().mockResolvedValue(1),
+      duplicate: vi.fn(() => blockClient),
+      del: vi.fn().mockResolvedValue(1),
+    };
+    const { executor, registry, error } = executorWith({
+      permissionGateway: {
+        resolve: vi.fn().mockResolvedValue({
+          state: "require_approval",
+          tier: 1,
+          reason: "platform policy",
+        }),
+      },
+      approvalsService: {
+        createMcpApproval: vi.fn().mockResolvedValue({ approvalId: "approval-1" }),
+      },
+      redis,
+    });
+
+    const result = await executor.execute({ tool: "safe.write", params: {} }, scope);
+
+    expect(result.error).toBe("Tool approval could not be completed.");
+    expect(registry.getScopedTools).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(error).toHaveBeenCalledWith("Tool approval wait failed");
+    expect(JSON.stringify(error.mock.calls)).not.toContain(secret);
+  });
+});

--- a/apps/agent/src/tool-gateway/tool-executor.service.ts
+++ b/apps/agent/src/tool-gateway/tool-executor.service.ts
@@ -227,8 +227,9 @@ export class ToolExecutorService {
    * so BLPOP doesn't queue every other ioredis op behind it, double-
    * write of the resolve transition for ledger consistency.
    *
-   * Fails open on any infrastructure error so the gate is strict
-   * defense-in-depth, never the failure point that loses a dispatch.
+   * Fails closed when the enabled gateway is unavailable or cannot resolve
+   * policy. Dispatch must not bypass an enabled authorization boundary merely
+   * because its persistence layer is unhealthy.
    *
    * The flag is off by default. Rollout: enable in staging, watch the
    * safety-event ledger for `dispatcher_permission_gate` entries,
@@ -245,7 +246,18 @@ export class ToolExecutorService {
     if (process.env.PLATOS_TOOL_DISPATCH_PERMISSION_GATE !== "1") {
       return { kind: "allow" };
     }
-    if (!this.permissionGateway) return { kind: "allow" };
+    if (!this.permissionGateway) {
+      this.logger.error("Tool dispatch permission gateway unavailable");
+      return {
+        kind: "deny",
+        result: {
+          tool: call.tool,
+          status: "failed",
+          error: "Tool dispatch denied because permission policy could not be evaluated.",
+          latencyMs: Date.now() - startTime,
+        },
+      };
+    }
     let resolved;
     try {
       resolved = await this.permissionGateway.resolve({
@@ -258,11 +270,17 @@ export class ToolExecutorService {
         userId: scope.userId ?? null,
         toolName: call.tool,
       });
-    } catch (err) {
-      // Fail-open on resolver errors — the gate is defense-in-depth,
-      // not the primary safety mechanism. Safety + rate-limit gates
-      // above still ran.
-      return { kind: "allow" };
+    } catch {
+      this.logger.error("Tool dispatch permission resolution failed");
+      return {
+        kind: "deny",
+        result: {
+          tool: call.tool,
+          status: "failed",
+          error: "Tool dispatch denied because permission policy could not be evaluated.",
+          latencyMs: Date.now() - startTime,
+        },
+      };
     }
     if (resolved.state === "auto_allow") return { kind: "allow" };
 
@@ -384,13 +402,14 @@ export class ToolExecutorService {
         timeoutSeconds,
         actionLabel: `Tool dispatch: ${call.tool}`,
       });
-    } catch (err: any) {
+    } catch {
+      this.logger.error("Tool approval persistence failed");
       return {
         kind: "deny",
         result: {
           tool: call.tool,
           status: "failed",
-          error: `Tool ${call.tool} requires approval; failed to persist approval row: ${err?.message ?? String(err)}`,
+          error: "Tool approval could not be requested.",
           latencyMs: Date.now() - startTime,
         },
       };
@@ -511,13 +530,14 @@ export class ToolExecutorService {
         kind: "allow",
         params: parsed.editedArgs ?? call.params,
       };
-    } catch (err: any) {
+    } catch {
+      this.logger.error("Tool approval wait failed");
       return {
         kind: "deny",
         result: {
           tool: call.tool,
           status: "failed",
-          error: `Tool ${call.tool} approval wait failed: ${err?.message ?? String(err)}`,
+          error: "Tool approval could not be completed.",
           latencyMs: Date.now() - startTime,
         },
       };

--- a/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
+++ b/internal-packages/tenancy-database/prisma/migrations/00000000000000_initial/migration.sql
@@ -3408,6 +3408,28 @@ CREATE TRIGGER "CredentialAudit_immutable_truncate"
   FOR EACH STATEMENT EXECUTE FUNCTION "public"."reject_credential_audit_mutation"();
 REVOKE UPDATE, DELETE, TRUNCATE ON TABLE "public"."CredentialAudit" FROM PUBLIC;
 
+-- Administrative audit evidence is append-only. Promotion and other control
+-- plane mutations may insert evidence transactionally, but no role can rewrite
+-- or remove an accepted event. Corrections must be represented by a new row.
+CREATE FUNCTION "public"."reject_admin_audit_mutation"() RETURNS trigger
+  LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'AdminAudit is immutable' USING ERRCODE = '23514';
+END;
+$$;
+
+CREATE TRIGGER "AdminAudit_immutable_update"
+  BEFORE UPDATE ON "public"."AdminAudit"
+  FOR EACH ROW EXECUTE FUNCTION "public"."reject_admin_audit_mutation"();
+CREATE TRIGGER "AdminAudit_immutable_delete"
+  BEFORE DELETE ON "public"."AdminAudit"
+  FOR EACH ROW EXECUTE FUNCTION "public"."reject_admin_audit_mutation"();
+CREATE TRIGGER "AdminAudit_immutable_truncate"
+  BEFORE TRUNCATE ON "public"."AdminAudit"
+  FOR EACH STATEMENT EXECUTE FUNCTION "public"."reject_admin_audit_mutation"();
+REVOKE UPDATE, DELETE, TRUNCATE ON TABLE "public"."AdminAudit" FROM PUBLIC;
+
 -- -----------------------------------------------------------------------------
 -- Memory feedback quarantine and thumbs-feedback constraints
 -- -----------------------------------------------------------------------------

--- a/internal-packages/tenancy-database/src/integration.test.ts
+++ b/internal-packages/tenancy-database/src/integration.test.ts
@@ -236,6 +236,83 @@ describe("domain schema integration", () => {
     })).rejects.toThrow(/immutable/);
   });
 
+  test("keeps AdminAudit append-only and rolls back a promotion when audit insertion fails", async () => {
+    const audit = await control.adminAudit.create({
+      data: {
+        environmentId: seeded.environment.id,
+        actorUserId: seeded.user.id,
+        action: "agent.canary.promote",
+        subjectType: "Agent",
+        subjectId: seeded.agent.id,
+        before: { previousCurrentVersionId: seeded.agentVersion.id },
+        after: { currentVersionId: seeded.agentVersion.id },
+        source: "integration-test",
+      },
+    });
+    await expect(control.adminAudit.update({
+      where: { id: audit.id },
+      data: { reason: "rewrite" },
+    })).rejects.toThrow(/immutable/);
+    await expect(control.adminAudit.delete({ where: { id: audit.id } })).rejects.toThrow(/immutable/);
+    await expect(control.$executeRawUnsafe('TRUNCATE TABLE "AdminAudit"')).rejects.toThrow(/immutable/);
+
+    const canary = await control.agentVersion.create({
+      data: {
+        agentId: seeded.agent.id,
+        versionNumber: 991,
+        model: "integration:canary",
+        createdBy: seeded.user.id,
+      },
+    });
+    await control.agentBinding.update({
+      where: { id: seeded.agentBinding.id },
+      data: { canaryAgentVersionId: canary.id, canaryPercent: 25 },
+    });
+    const before = await control.agentBinding.findUniqueOrThrow({
+      where: { id: seeded.agentBinding.id },
+      select: { activeAgentVersionId: true, canaryAgentVersionId: true, canaryPercent: true },
+    });
+    await control.$executeRawUnsafe(`CREATE FUNCTION "public"."block_admin_audit_insert_for_test"() RETURNS trigger
+      LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'audit unavailable'; END; $$`);
+    await control.$executeRawUnsafe(`CREATE TRIGGER "AdminAudit_block_insert_for_test"
+      BEFORE INSERT ON "public"."AdminAudit" FOR EACH ROW
+      EXECUTE FUNCTION "public"."block_admin_audit_insert_for_test"()`);
+    try {
+      await expect(control.$transaction(async (tx) => {
+        await tx.agentBinding.update({
+          where: { id: seeded.agentBinding.id },
+          data: {
+            activeAgentVersionId: canary.id,
+            canaryAgentVersionId: null,
+            canaryPercent: 0,
+          },
+        });
+        await tx.adminAudit.create({
+          data: {
+            environmentId: seeded.environment.id,
+            actorUserId: seeded.user.id,
+            action: "agent.canary.promote",
+            subjectType: "Agent",
+            subjectId: seeded.agent.id,
+            before,
+            after: { currentVersionId: canary.id },
+          },
+        });
+      })).rejects.toThrow(/audit unavailable/);
+    } finally {
+      await control.$executeRawUnsafe(
+        'DROP TRIGGER "AdminAudit_block_insert_for_test" ON "public"."AdminAudit"'
+      );
+      await control.$executeRawUnsafe(
+        'DROP FUNCTION "public"."block_admin_audit_insert_for_test"()'
+      );
+    }
+    await expect(control.agentBinding.findUniqueOrThrow({
+      where: { id: seeded.agentBinding.id },
+      select: { activeAgentVersionId: true, canaryAgentVersionId: true, canaryPercent: true },
+    })).resolves.toEqual(before);
+  });
+
   test("enforces one provider default under real concurrent PostgreSQL writes", async () => {
     const direct = await Promise.allSettled(
       Array.from({ length: 8 }, async (_, index) => {
@@ -1171,7 +1248,7 @@ async function seedEveryModel(control: PrismaClient) {
       createdBy: user.id,
     },
   }));
-  track("AgentBinding", await control.agentBinding.create({
+  const agentBinding = track("AgentBinding", await control.agentBinding.create({
     data: {
       environmentId: environment.id,
       agentId: agent.id,
@@ -1750,6 +1827,7 @@ async function seedEveryModel(control: PrismaClient) {
     endUserIdentity,
     agent,
     agentVersion,
+    agentBinding,
     credential,
     cluster,
     thread,

--- a/internal-packages/tenancy-database/src/schema.test.ts
+++ b/internal-packages/tenancy-database/src/schema.test.ts
@@ -290,6 +290,13 @@ describe("clean-slate domain schema", () => {
     expect(migration).toContain('CREATE FUNCTION "public"."revoke_operator_sessions_for_membership_change"()');
     expect(migration).toContain('CREATE FUNCTION "public"."reject_impersonation_audit_mutation"()');
     expect(migration).toContain('CREATE FUNCTION "public"."reject_credential_audit_mutation"()');
+    expect(migration).toContain('CREATE FUNCTION "public"."reject_admin_audit_mutation"()');
+    for (const operation of ["update", "delete", "truncate"]) {
+      expect(migration).toContain(`CREATE TRIGGER "AdminAudit_immutable_${operation}"`);
+    }
+    expect(migration).toContain(
+      'REVOKE UPDATE, DELETE, TRUNCATE ON TABLE "public"."AdminAudit" FROM PUBLIC'
+    );
     expect(migration).toContain('CREATE UNIQUE INDEX "AccessKey_one_active_per_environment"');
     expect(migration).toContain('WHERE "revokedAt" IS NULL AND "validUntil" IS NULL');
     expect(migration).toContain('CONSTRAINT "OperatorSession_tokenHash_check"');


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces stale legacy Prisma delegates in the agent with the clean tenancy client contract, restoring Platform MCP and agent runtime paths while failing closed where clean canonical semantics are not yet available.

## Changes

- Rewrites agent runtime, MCP, administration, monitoring, privacy, and provider paths onto canonical clean-schema models and tenancy boundaries.
- Resolves MCP permissions through organization policy and environment-scoped agent bindings, with tool dispatch failing closed when permission resolution or approval persistence fails.
- Returns stable unavailable responses for legacy surfaces that cannot be represented safely without prematurely implementing paused WIN-124 behavior.
- Establishes a verified canonical runtime external identity and aligns conversation ownership, monitoring, identity binding, and erasure around it.
- Makes erasure content-free and tenant-isolated, including complete tool-call audit payload redaction and exact-row negative verification.
- Makes binding promotion and immutable admin audit recording transactional, with database guards against audit update, delete, and truncate.
- Adds a TypeScript type-checker audit that inventories production Prisma delegate operations against the generated clean client.

## Testing

- `pnpm --filter @platos/tenancy-database test` — passed, 9 files / 69 tests.
- `pnpm --filter @platos/tenancy-database typecheck` — passed.
- `pnpm --filter @platos/tenancy-database build` — passed.
- Focused agent Vitest gates — passed, including permission routing, fail-closed dispatch, canonical runtime identity, ordinary erasure, cross-organization isolation, audit payload redaction, promotion rollback/immutability, monitoring projections, unavailable legacy surfaces, and the AST delegate inventory. Latest targeted erasure gate: 5 files / 29 tests; broader final gate: 17 files / 81 tests.
- `pnpm --filter platos-agent typecheck` — passed.
- `pnpm --filter platos-agent build:strict` — passed.
- `pnpm --filter platos-agent audit:production-dependencies` — passed.
- `node apps/agent/scripts/generate-control-plane.mjs --check` — passed, 206 MCP tools / 285 REST operations.
- `git diff --check` — passed.
- Full agent suite baseline comparison — 122 files / 996 tests passed; 10 failures across 7 files reproduced on base `9825764`, with no WIN-218-specific failure.

No UI or mobile surface changed, so visual testing does not apply.

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://8b698f41-8dfa-575e-a602-bcf25ef653cb.us1.vorflux.com/agent-sessions/e6232ca0-d647-4cc8-ab06-cda558c0b9a1)
- Requested by: tejas (tejas@winsenlabs.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
