### PR TITLE
fix(pricing): coerce catalogue token counts at the JSON boundary

### DIFF
--- a/internal-packages/tenancy-database/src/model-pricing.test.ts
+++ b/internal-packages/tenancy-database/src/model-pricing.test.ts
@@ -4,6 +4,7 @@ import {
   calculateCanonicalModelCost,
   ModelPricingUnavailableError,
   modelPricingLookupKeys,
+  tokenCountOrNull,
   type CanonicalModelPriceSnapshot,
 } from "./model-pricing";
 
@@ -117,5 +118,35 @@ describe("canonical model pricing math", () => {
         cacheWriteInputTokens: 10,
       })
     ).toThrow(ModelPricingUnavailableError);
+  });
+});
+
+describe("tokenCountOrNull", () => {
+  // The agent crash-looped on boot with `Argument contextWindow: Invalid value
+  // provided. Expected Int or Null, provided String`. LiteLlmEntry declares
+  // these as `number`, but the catalogue is parsed JSON and some upstream rows
+  // carry them as strings, so the annotation is an assertion rather than a
+  // guarantee.
+  test("passes through safe integers", () => {
+    expect(tokenCountOrNull(128000)).toBe(128000);
+    expect(tokenCountOrNull(0)).toBe(0);
+  });
+
+  test("parses the numeric strings that crashed the bootstrap", () => {
+    expect(tokenCountOrNull("128000")).toBe(128000);
+    expect(tokenCountOrNull("  9000  ")).toBe(9000);
+  });
+
+  test("treats anything it cannot represent as absent rather than guessing", () => {
+    for (const value of [undefined, null, "", "   ", "unlimited", "12k", {}, [], NaN, Infinity]) {
+      expect(tokenCountOrNull(value)).toBeNull();
+    }
+  });
+
+  test("rejects non-integers rather than silently truncating", () => {
+    // Prisma's Int column would reject these anyway; failing here keeps the
+    // rejection at the boundary instead of at the write.
+    expect(tokenCountOrNull(1024.5)).toBeNull();
+    expect(tokenCountOrNull("1024.5")).toBeNull();
   });
 });

--- a/internal-packages/tenancy-database/src/model-pricing.ts
+++ b/internal-packages/tenancy-database/src/model-pricing.ts
@@ -217,6 +217,26 @@ function dateOrNull(value: string | undefined): Date | null {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+/**
+ * Token counts arrive from parsed JSON, so the declared `number` on
+ * LiteLlmEntry is an assertion rather than a guarantee — some upstream entries
+ * carry these as strings. Prisma then rejects the write with `Expected Int or
+ * Null, provided String`, which crashes the bootstrap and takes the whole agent
+ * down on boot.
+ *
+ * Coerce at the boundary: accept a number or a numeric string, and treat
+ * anything else — a float, an empty string, "unlimited" — as absent rather than
+ * guessing.
+ */
+export function tokenCountOrNull(value: unknown): number | null {
+  if (typeof value === "number") return Number.isSafeInteger(value) ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
 function verifiedObservedAt(value: string): Date {
   return new Date(`${value}T00:00:00.000Z`);
 }
@@ -583,8 +603,8 @@ export class PlatosModelPricing {
               name: key,
               displayName: entry.model_name ?? null,
               description: entry.description ?? null,
-              contextWindow: entry.max_input_tokens ?? entry.max_tokens ?? null,
-              maxOutputTokens: entry.max_output_tokens ?? null,
+              contextWindow: tokenCountOrNull(entry.max_input_tokens) ?? tokenCountOrNull(entry.max_tokens),
+              maxOutputTokens: tokenCountOrNull(entry.max_output_tokens),
               capabilities: capabilitiesFor(entry),
               releaseDate: dateOrNull(entry.release_date),
               deprecationDate: dateOrNull(entry.deprecation_date),
@@ -594,8 +614,8 @@ export class PlatosModelPricing {
               provider,
               displayName: entry.model_name ?? null,
               description: entry.description ?? null,
-              contextWindow: entry.max_input_tokens ?? entry.max_tokens ?? null,
-              maxOutputTokens: entry.max_output_tokens ?? null,
+              contextWindow: tokenCountOrNull(entry.max_input_tokens) ?? tokenCountOrNull(entry.max_tokens),
+              maxOutputTokens: tokenCountOrNull(entry.max_output_tokens),
               capabilities: capabilitiesFor(entry),
               releaseDate: dateOrNull(entry.release_date),
               deprecationDate: dateOrNull(entry.deprecation_date),


### PR DESCRIPTION
## The agent cannot boot

Deploying `main` (`d45077f`) to test.platos crash-loops:

```
Invalid `prisma.model.upsert()` invocation:
Argument `contextWindow`: Invalid value provided. Expected Int or Null, provided String.
  at ModelPricingBootstrapService.bootstrapIfEmpty
  at ModelPricingBootstrapService.onApplicationBootstrap
```

It runs in `onApplicationBootstrap`, so the failure takes the **entire process** down — not just pricing.

## Cause

`LiteLLMModelEntry` declares `max_input_tokens`, `max_tokens` and `max_output_tokens` as `number`. The catalogue is parsed JSON and nothing validates it, so that annotation is an assertion rather than a guarantee — some upstream rows carry these as strings. The value travels unchecked to Prisma, which rejects it against an `Int?` column.

## Fix

Coerce at the boundary. `tokenCountOrNull` accepts a number or a numeric string and returns `null` for anything it cannot represent as an `Int` — floats, empty strings, `"unlimited"` — rather than guessing or truncating. Applied to all four write sites across the `create` and `update` branches.

This is the same failure shape as the earlier `modelRoutes` and `dynamicBlocks` coercions: a JSON-sourced field whose declared type isn't enforced at the edge.

## Tests

Four cases in `model-pricing.test.ts` covering safe integers, the numeric strings that caused the crash, unrepresentable values, and non-integers. Suite passes 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)