### PR TITLE
fix(platools): decode the platform acks the client was calling malformed

### DIFF
--- a/packages/platools-js/src/transport/client.ts
+++ b/packages/platools-js/src/transport/client.ts
@@ -319,7 +319,30 @@ export class PlatoolsClient {
         return;
       case "welcome":
       case "heartbeat_ack":
+      case "tools_registered":
         // informational — no action required
+        return;
+      case "register_throttled":
+        // The platform refused the batch; the reconnect/re-register path will
+        // try again. Surface it so a persistent throttle is visible rather
+        // than looking like silent registration success.
+        this.logger.warn(
+          `platools registration throttled: ${message.error}${
+            message.retry_after_ms === undefined
+              ? ""
+              : ` (retry in ${Math.ceil(message.retry_after_ms / 1000)}s)`
+          }`,
+        );
+        return;
+      case "tool_health_alert":
+        this.logger.warn(
+          `platools tool health: ${message.tool} is ${message.status}`,
+        );
+        return;
+      case "error":
+        // Terminal: the platform closes the socket after sending this, so the
+        // reason has to be logged here or it is lost to a bare close event.
+        this.logger.error(`platools platform error: ${message.error}`);
         return;
     }
   }

--- a/packages/platools-js/src/transport/protocol.ts
+++ b/packages/platools-js/src/transport/protocol.ts
@@ -92,7 +92,48 @@ export interface WelcomeMessage {
   readonly project_id?: string;
 }
 
-export type PlatformToSdk = ToolCallMessage | HeartbeatAckMessage | WelcomeMessage;
+/**
+ * Acknowledgement for a `tool_register` batch. The platform sends this on every
+ * successful registration, which means it lands immediately after connect — a
+ * decoder that does not know it warns "malformed message" on every session.
+ */
+export interface ToolsRegisteredMessage {
+  readonly type: "tools_registered";
+  readonly entity_id?: string;
+  readonly environment_id?: string;
+  readonly count?: number;
+  readonly new_tools?: readonly string[];
+}
+
+/** Registration rate limit hit; retry after the supplied delay. */
+export interface RegisterThrottledMessage {
+  readonly type: "register_throttled";
+  readonly error: string;
+  readonly retry_after_ms?: number;
+}
+
+/** Health transition for a registered tool, pushed by the platform. */
+export interface ToolHealthAlertMessage {
+  readonly type: "tool_health_alert";
+  readonly tool: string;
+  readonly status: string;
+  readonly details?: unknown;
+}
+
+/** Terminal protocol error — the platform closes the socket after sending it. */
+export interface PlatformErrorMessage {
+  readonly type: "error";
+  readonly error: string;
+}
+
+export type PlatformToSdk =
+  | ToolCallMessage
+  | HeartbeatAckMessage
+  | WelcomeMessage
+  | ToolsRegisteredMessage
+  | RegisterThrottledMessage
+  | ToolHealthAlertMessage
+  | PlatformErrorMessage;
 
 /**
  * Decode a raw JSON string into a `PlatformToSdk` message.
@@ -157,6 +198,38 @@ export function decodePlatformMessage(raw: string): PlatformToSdk | null {
       };
       return welcome;
     }
+    case "tools_registered":
+      return {
+        type: "tools_registered",
+        ...(typeof record.entity_id === "string" ? { entity_id: record.entity_id } : {}),
+        ...(typeof record.environment_id === "string"
+          ? { environment_id: record.environment_id }
+          : {}),
+        ...(typeof record.count === "number" ? { count: record.count } : {}),
+        ...(Array.isArray(record.new_tools)
+          ? { new_tools: record.new_tools.filter((t): t is string => typeof t === "string") }
+          : {}),
+      };
+    case "register_throttled":
+      if (typeof record.error !== "string") return null;
+      return {
+        type: "register_throttled",
+        error: record.error,
+        ...(typeof record.retry_after_ms === "number"
+          ? { retry_after_ms: record.retry_after_ms }
+          : {}),
+      };
+    case "tool_health_alert":
+      if (typeof record.tool !== "string" || typeof record.status !== "string") return null;
+      return {
+        type: "tool_health_alert",
+        tool: record.tool,
+        status: record.status,
+        ...(record.details !== undefined ? { details: record.details } : {}),
+      };
+    case "error":
+      if (typeof record.error !== "string") return null;
+      return { type: "error", error: record.error };
     default:
       return null;
   }

--- a/packages/platools-js/tests/protocol-decode.test.ts
+++ b/packages/platools-js/tests/protocol-decode.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression: the platform sends message types the decoder did not know, and
+ * every one of them logged "platools received malformed message".
+ *
+ * `tools_registered` is the one that bit us — the platform acknowledges every
+ * successful `tool_register` batch, so it arrives immediately after connect.
+ * Walle logged the warning on every single session while the connection was
+ * in fact healthy, which made a working socket look broken.
+ */
+import { describe, expect, test } from "vitest";
+import { decodePlatformMessage } from "../src/transport/protocol";
+
+const decode = (value: unknown) => decodePlatformMessage(JSON.stringify(value));
+
+describe("decodePlatformMessage — platform acknowledgements", () => {
+  test("decodes tools_registered, the ack sent on every connect", () => {
+    expect(
+      decode({
+        type: "tools_registered",
+        entity_id: "walle-mcp-service",
+        environment_id: "478bc711-229c-544b-a346-254ada4bd84e",
+        count: 12,
+        new_tools: ["search_book", "draft_outreach"],
+      }),
+    ).toEqual({
+      type: "tools_registered",
+      entity_id: "walle-mcp-service",
+      environment_id: "478bc711-229c-544b-a346-254ada4bd84e",
+      count: 12,
+      new_tools: ["search_book", "draft_outreach"],
+    });
+  });
+
+  test("tolerates a tools_registered carrying only its discriminator", () => {
+    expect(decode({ type: "tools_registered" })).toEqual({ type: "tools_registered" });
+  });
+
+  test("drops non-string entries from new_tools rather than failing the frame", () => {
+    const decoded = decode({ type: "tools_registered", new_tools: ["ok", 7, null] });
+    expect(decoded).toEqual({ type: "tools_registered", new_tools: ["ok"] });
+  });
+
+  test("decodes register_throttled with its retry hint", () => {
+    expect(decode({ type: "register_throttled", error: "60/min exceeded", retry_after_ms: 30_000 }))
+      .toEqual({ type: "register_throttled", error: "60/min exceeded", retry_after_ms: 30_000 });
+  });
+
+  test("decodes tool_health_alert", () => {
+    expect(decode({ type: "tool_health_alert", tool: "search_book", status: "degraded" }))
+      .toEqual({ type: "tool_health_alert", tool: "search_book", status: "degraded" });
+  });
+
+  test("decodes a terminal platform error so the reason is not lost to a bare close", () => {
+    expect(decode({ type: "error", error: "Invalid service secret or entity not found" }))
+      .toEqual({ type: "error", error: "Invalid service secret or entity not found" });
+  });
+
+  test("still rejects frames missing their required fields", () => {
+    // Widening the decoder must not turn it into a pass-through.
+    expect(decode({ type: "register_throttled" })).toBeNull();
+    expect(decode({ type: "tool_health_alert", tool: "x" })).toBeNull();
+    expect(decode({ type: "error" })).toBeNull();
+    expect(decode({ type: "genuinely_unknown" })).toBeNull();
+    expect(decodePlatformMessage("not json")).toBeNull();
+  });
+
+  test("existing platform messages are unaffected", () => {
+    expect(decode({ type: "heartbeat_ack" })).toEqual({ type: "heartbeat_ack" });
+    expect(
+      decode({ type: "tool_call", call_id: "c1", tool_name: "search_book", params: {} }),
+    ).toEqual({ type: "tool_call", call_id: "c1", tool_name: "search_book", params: {} });
+  });
+});


### PR DESCRIPTION
## Symptom

```
[Nest] [ConnectorService] [bridge-connector] connected (entity=walle-mcp-service env=prod)
[platools] platools received malformed message
```

Reported from Walle: the socket connects successfully, then immediately warns.

## Cause

`decodePlatformMessage` handled only `tool_call`, `heartbeat_ack` and `welcome`. The platform also sends four other types — `tools_registered`, `register_throttled`, `tool_health_alert`, `error` — and every one of them fell through to `default: return null`, which the client logs as malformed.

**`tools_registered` is the one that bit us.** The platform acknowledges every successful `tool_register` batch (`tool-sync-ws.service.ts:501`), so it arrives immediately after connect. Walle logged the warning on *every session* while the connection was in fact perfectly healthy — a working socket that looked broken.

## Change

Decode all four, and handle them rather than swallowing:

| type | handling |
|---|---|
| `tools_registered` | informational, alongside `welcome`/`heartbeat_ack` |
| `register_throttled` | **warn** with the retry hint — a persistent throttle previously looked like silent registration success |
| `tool_health_alert` | warn |
| `error` | **error** — the platform closes the socket straight after, so the reason is otherwise lost to a bare close event |

## Not a pass-through

Widening the decoder must not weaken it. Frames missing required fields (`register_throttled` with no `error`, `tool_health_alert` with no `status`) and genuinely unknown discriminators still decode to `null`. Non-string entries in `new_tools` are dropped rather than failing the whole frame.

## Tests

8 new cases in `tests/protocol-decode.test.ts` covering each new type, the partial-frame tolerance, the rejection cases, and that existing messages are unaffected. Full suite: **105/105**, typecheck clean.

Note the 502s in the same report were my agent restarts during deploy — the socket has been stable and heartbeating cleanly for 2 hours since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)