### PR TITLE
fix(trigger): stop failing the task deploy on optional worker externals

### DIFF
--- a/apps/agent/scripts/trigger-worker-externals.test.ts
+++ b/apps/agent/scripts/trigger-worker-externals.test.ts
@@ -48,4 +48,37 @@ describe("generated Trigger worker externals", () => {
       unresolvedGeneratedWorkerExternals(metafileWithExternal("node:crypto"), agentDir)
     ).toEqual([]);
   });
+
+  it("tolerates optional externals the worker is designed to run without", () => {
+    // Trigger's build emits these as bare externals, but each is loaded inside
+    // a try/catch by a dependency with a working fallback. Failing the build
+    // over them blocked every task deploy: ws's two native addons are optional
+    // dependencies pnpm may not install, and pnpapi is a Yarn PnP module that
+    // is not a publishable package at all.
+    for (const optional of ["bufferutil", "utf-8-validate", "pnpapi"]) {
+      expect(
+        unresolvedGeneratedWorkerExternals(metafileWithExternal(optional), agentDir),
+        optional
+      ).toEqual([]);
+    }
+  });
+
+  it("still reports a genuinely missing external alongside optional ones", () => {
+    // The allowlist must narrow the check, not disable it.
+    expect(
+      unresolvedGeneratedWorkerExternals(
+        {
+          outputs: {
+            "worker.js": {
+              imports: [
+                { external: true, path: "bufferutil" },
+                { external: true, path: "not-a-real-trigger-worker-package" },
+              ],
+            },
+          },
+        },
+        agentDir
+      )
+    ).toEqual(["not-a-real-trigger-worker-package"]);
+  });
 });

--- a/apps/agent/scripts/trigger-worker-externals.ts
+++ b/apps/agent/scripts/trigger-worker-externals.ts
@@ -30,6 +30,36 @@ function isBareRuntimeImport(importPath: string): boolean {
 }
 
 /**
+ * Imports whose absence is the normal case, not a packaging mistake.
+ *
+ * The check below exists because a bare external that cannot resolve becomes a
+ * MODULE_NOT_FOUND once the generated worker runs. These three never do: each
+ * is loaded inside a try/catch by a dependency that has a working fallback, so
+ * requiring them to resolve would fail the build over a module the worker is
+ * designed to run without.
+ *
+ *   bufferutil, utf-8-validate  `ws` native performance addons. It requires
+ *                               them in a try/catch and falls back to its JS
+ *                               implementations. Both are optional
+ *                               dependencies, so pnpm may legitimately not
+ *                               install them.
+ *   pnpapi                      Yarn Plug'n'Play's runtime module, referenced
+ *                               by resolver code that first checks whether it
+ *                               is running under PnP. This repo uses pnpm, so
+ *                               it never exists — and declaring it a
+ *                               dependency is not possible, since no such
+ *                               package is published.
+ *
+ * Keep this list closed. Anything added here is a module the worker will run
+ * without, which is a claim worth making one import at a time.
+ */
+const optionalRuntimeExternals = new Set([
+  "bufferutil",
+  "utf-8-validate",
+  "pnpapi",
+]);
+
+/**
  * Trigger's worker bundle can leave packages external (including packages in
  * Trigger's own forced `alwaysExternal` list). Those imports execute from the
  * generated worker directory, so they must also resolve from this package's
@@ -44,7 +74,11 @@ export function unresolvedGeneratedWorkerExternals(
 
   for (const output of Object.values(metafile.outputs)) {
     for (const imported of output.imports ?? []) {
-      if (imported.external && isBareRuntimeImport(imported.path)) {
+      if (
+        imported.external &&
+        isBareRuntimeImport(imported.path) &&
+        !optionalRuntimeExternals.has(imported.path)
+      ) {
         externalImports.add(imported.path);
       }
     }


### PR DESCRIPTION
## Every Trigger task deploy from CI is failing

```
Generated Trigger worker external "bufferutil"      cannot resolve from apps/agent
Generated Trigger worker external "pnpapi"          cannot resolve from apps/agent
Generated Trigger worker external "utf-8-validate"  cannot resolve from apps/agent
```

**This predates the repository variables I set yesterday.** The workflow was aborting earlier, at `test -n "$TRIGGER_API_URL"`, and never reached the build — fixing the config revealed this rather than caused it. Task deploys have been silently not running.

## The guard is right; its premise doesn't cover these

A bare external that cannot resolve becomes a `MODULE_NOT_FOUND` once the generated worker runs, and turning that into a build failure is exactly what `generatedWorkerExternalsMustResolve` is for. That reasoning just doesn't apply to imports loaded inside a try/catch by a dependency with a working fallback.

| external | why it never resolves, and why that's fine |
|---|---|
| `bufferutil` | `ws` native performance addon, required in a try/catch with a JS fallback. An optional dependency pnpm may not install. |
| `utf-8-validate` | same |
| `pnpapi` | Yarn Plug'n'Play's runtime module, referenced by resolver code that first checks whether it's running under PnP. This repo uses pnpm, so it never exists — and it **cannot** be declared a dependency, because no such package is published. |

Declaring `pnpapi` a production dependency, which the error message suggests, is not possible.

## The change

A closed, documented allowlist — narrowing the check rather than widening or silencing it. Each entry states why the worker runs without it.

Two tests: the three optional externals are tolerated, and **a genuinely missing external is still reported when it appears alongside an allowlisted one** — so the allowlist cannot quietly become a bypass. Suite: 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)