### PR TITLE
fix(scripts): stop the WS dev scripts pointing at a Winsen host

### DIFF
--- a/apps/webapp/scripts/ws-smoke-session.mjs
+++ b/apps/webapp/scripts/ws-smoke-session.mjs
@@ -28,7 +28,10 @@ const signingInput = `${b64({ alg: "HS256", typ: "JWT" })}.${b64(payload)}`;
 const sig = crypto.createHmac("sha256", secret).update(signingInput).digest("base64url");
 const token = `${signingInput}.${sig}`;
 
-const socket = io("wss://test.platos.dev/agent", {
+// Host comes from PLATOS_WS_URL so a self-hoster can point this at their own
+// deployment. Defaults to localhost rather than a Winsen box (WIN-155).
+const WS_URL = process.env.PLATOS_WS_URL ?? "ws://localhost:3100/agent";
+const socket = io(WS_URL, {
   path: "/agent-io/socket.io",
   transports: ["websocket"],
   auth: { token },

--- a/apps/webapp/scripts/ws-verify-memscope.mjs
+++ b/apps/webapp/scripts/ws-verify-memscope.mjs
@@ -12,7 +12,10 @@ const now = Math.floor(Date.now() / 1000);
 const b64 = (o) => Buffer.from(JSON.stringify(o)).toString("base64url");
 const si = `${b64({ alg: "HS256", typ: "JWT" })}.${b64({ ...scope, iss: "platos-platform", iat: now, exp: now + 3600 })}`;
 const token = `${si}.${crypto.createHmac("sha256", secret).update(si).digest("base64url")}`;
-const socket = io("wss://test.platos.dev/agent", { path: "/agent-io/socket.io", transports: ["websocket"], auth: { token } });
+// Host comes from PLATOS_WS_URL so a self-hoster can point this at their own
+// deployment. Defaults to localhost rather than a Winsen box (WIN-155).
+const WS_URL = process.env.PLATOS_WS_URL ?? "ws://localhost:3100/agent";
+const socket = io(WS_URL, { path: "/agent-io/socket.io", transports: ["websocket"], auth: { token } });
 let text = "";
 const bail = (m, c = 1) => { console.log(`\n[verify] ${m}`); socket.close(); process.exit(c); };
 setTimeout(() => bail("TIMEOUT"), 180_000);


### PR DESCRIPTION
WIN-155 item 4 — the last one open.

`ws-verify-memscope.mjs` and `ws-smoke-session.mjs` both hardcoded `wss://test.platos.dev/agent`, so a self-hoster running either smoke test exercised **our** deployment rather than theirs.

Both now read `PLATOS_WS_URL`, defaulting to `ws://localhost:3100/agent` — a local default rather than a Winsen resource, which is the rule WIN-155 asks for ("no fallback to a Winsen resource").

## The rest of WIN-155 is already closed

| item | state |
|---|---|
| 1. `trigger.config.ts` project-ref fallback | gone — now required, fails loudly |
| 2. `AGENT_API_URL = "https://test.platos.dev"` | route deleted by M4 |
| 3. `DocsLink.tsx` hardcoded docs base | deleted by M4 |
| 4. WS dev scripts | **this PR** |

The remaining `test.platos.dev` matches under `apps/` are prose comments and one `host-router.middleware.ts` allowlist entry — both of which are supposed to name it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)