### PR TITLE
fix(tool-gateway): stop reporting a missing entity id as a bad secret

### DIFF
--- a/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
+++ b/apps/agent/src/tool-gateway/tool-sync-ws.service.ts
@@ -171,9 +171,12 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
       ? auth.slice(7).trim()
       : "";
 
-    // entity=<slug> selects which registered entity is connecting (defaults
-    // to "main" for backwards compat with earlier platools clients that used
-    // ?source=main). Also accept X-Platos-Entity-Id header.
+    // entity=<slug> selects which registered entity is connecting. ?source=
+    // is the older platools spelling and is still accepted, as are the
+    // X-Platos-Entity-Id / X-Platos-Source headers. There is deliberately NO
+    // default: guessing an entity would bind an unidentified client to
+    // whichever entity happened to be named that, so a missing id is a
+    // rejection with its own distinct reason (see below).
     const entityIdFromUrl = (
       parsed.searchParams.get("entity") ||
       parsed.searchParams.get("source") ||
@@ -199,13 +202,32 @@ export class ToolSyncWsService implements OnApplicationBootstrap, OnApplicationS
       return;
     }
 
+    // A connection with no entity id can never match a credential, and it is
+    // NOT a secret problem — reporting it as one sends operators hunting a
+    // hash mismatch that does not exist. Reject it on its own terms, before
+    // the lookup, so the client is told the one thing it can act on.
+    if (!entityIdFromUrl) {
+      this.logger.warn(
+        "reject: no entity id supplied (pass ?entity=<slug>, ?source=<slug>, or X-Platos-Entity-Id) — secret was not checked",
+      );
+      ws.off("message", earlyListener);
+      ws.send(
+        JSON.stringify({
+          type: "error",
+          error:
+            "Missing entity id. Connect with ?entity=<slug> (or the X-Platos-Entity-Id header). Your service secret was not the problem.",
+        }),
+      );
+      ws.close(1008, "missing entity id");
+      return;
+    }
+
     // Resolve the clean Environment + Entity first, then verify the
     // Environment-owned ENTITY_SECRET credential by hash. Raw secret material
     // is never persisted on Entity.
     let entityRow: any = null;
     let environmentId = "";
     try {
-      if (!entityIdFromUrl) throw new Error("entity id is required");
       const digest = createHash("sha256").update(secret).digest("hex");
       const credentials = await this.prisma.credential.findMany({
         where: {

--- a/apps/agent/src/tool-gateway/tool-sync-ws.test.ts
+++ b/apps/agent/src/tool-gateway/tool-sync-ws.test.ts
@@ -135,6 +135,51 @@ describe("ToolSyncWsService clean credential handshake", () => {
     expect(code).toBe(1008);
   });
 
+  it("rejects a missing entity id on its own terms, without blaming the secret", async () => {
+    // Regression: a client connecting without ?entity= was told "Invalid
+    // service secret or entity not found", which sent operators hunting a
+    // hash mismatch that did not exist. test.platos logged 590 of these in
+    // ten minutes from a client whose secret was perfectly valid.
+    const database = makeDatabase({ secret: "correct-secret" });
+    let lookups = 0;
+    const findMany = database.credential.findMany;
+    database.credential.findMany = async (args: any) => {
+      lookups += 1;
+      return findMany(args);
+    };
+    const service = new ToolSyncWsService(
+      database,
+      makeRegistry() as any,
+      {} as any,
+    );
+    const server = await startRawServer(service);
+    closeServer = server.close;
+
+    const { code, error } = await new Promise<{
+      code: number;
+      error?: string;
+    }>((resolve) => {
+      // Valid secret, but no ?entity=, no ?source=, no header.
+      const ws = new WebSocket(
+        `ws://127.0.0.1:${server.port}/tools/sync?env=env-1`,
+        { headers: { authorization: "Bearer correct-secret" } },
+      );
+      let seen: string | undefined;
+      ws.on("message", (raw) => {
+        const message = JSON.parse(raw.toString());
+        if (message.type === "error") seen = message.error;
+      });
+      ws.on("close", (closeCode) => resolve({ code: closeCode, error: seen }));
+      ws.on("error", () => undefined);
+    });
+
+    expect(code).toBe(1008);
+    expect(error).toMatch(/entity id/i);
+    expect(error).not.toMatch(/invalid service secret/i);
+    // The secret was never checked — a missing id is not a hash failure.
+    expect(lookups).toBe(0);
+  });
+
   it("verifies the Environment ENTITY_SECRET hash and emits canonical scope", async () => {
     const service = new ToolSyncWsService(
       makeDatabase({ secret: "correct-secret" }),


### PR DESCRIPTION
## What

A tool-sync client connecting without `?entity=` (or `?source=` / `X-Platos-Entity-Id`) was rejected with **"Invalid service secret or entity not found"**. The secret was never checked — the handler threw `entity id is required` before the credential lookup — so the error named the one thing that was *not* wrong.

## Why it matters

Found on test.platos: **590 rejections in ten minutes** from a client holding a perfectly valid secret. Diagnosing it meant first ruling out

- a `secretHash` format mismatch,
- four duplicate `ENTITY_SECRET` rows across four environments (`candidates.length !== 1`),
- a suspected cutover backfill writing an unqueryable `Credential.name`,

before the cause turned out to be a missing query parameter. The misleading message cost the entire investigation.

## Change

- Reject a missing entity id **before** the lookup, with its own reason and close code, telling the client exactly what to pass.
- Drop the comment claiming the id "defaults to `main` for backwards compat". It never did — and a silent default would bind an unidentified client to whichever entity happened to carry that slug, so the absence of a default is deliberate and now says so.

## Test

`rejects a missing entity id on its own terms, without blaming the secret` — asserts the close code, that the reason names the entity id, that it does **not** say "invalid service secret", and that `credential.findMany` was never called. Fails against the old behaviour on the message assertion.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>