### PR TITLE
fix(auth): say why a session token was rejected; stop the docs bridge reconnect loop

### DIFF
--- a/apps/agent/src/auth/auth.service.test.ts
+++ b/apps/agent/src/auth/auth.service.test.ts
@@ -117,6 +117,40 @@ describe("AuthService — clean bearer-backed session tokens", () => {
     await expect(h.auth.validateSessionToken(token!)).resolves.toBeNull();
   });
 
+  it("records a distinct reason for each rejection, and never the token itself", async () => {
+    // validateSessionToken had sixteen silent `return null` paths, so a Slack
+    // turn failing on test.platos surfaced as "Invalid or expired session
+    // token." with nothing in the agent log to say which of the sixteen fired.
+    const h = makeSessionHarness();
+    const warn = vi
+      .spyOn((h.auth as any).logger, "warn")
+      .mockImplementation(() => undefined);
+    const lastReason = () => String(warn.mock.calls.at(-1)?.[0] ?? "");
+
+    const expired = await h.auth.createEntitySessionToken(entityClaims(), "bearer_1", -1);
+    await expect(h.auth.validateSessionToken(expired!)).resolves.toBeNull();
+    const expiredReason = lastReason();
+    expect(expiredReason).toMatch(/expired/i);
+
+    const valid = (await h.auth.createEntitySessionToken(entityClaims(), "bearer_1", 60))!;
+    const [header, payload] = valid.split(".");
+    const forged = `${header}.${payload}.${"A".repeat(43)}`;
+    await expect(h.auth.validateSessionToken(forged)).resolves.toBeNull();
+    const forgedReason = lastReason();
+    expect(forgedReason).toMatch(/signature does not verify/i);
+
+    // An expiry and a bad signature are different operator problems and must
+    // not be reported with the same words.
+    expect(expiredReason).not.toBe(forgedReason);
+
+    // A reason is for the log, so it must never carry token material.
+    for (const call of warn.mock.calls) {
+      const line = String(call[0] ?? "");
+      expect(line).not.toContain(header);
+      expect(line).not.toContain(payload);
+    }
+  });
+
   it("immediately rejects bearer expiry and revocation", async () => {
     const h = makeSessionHarness();
     const token = (await h.auth.createEntitySessionToken(entityClaims(), "bearer_1", 60))!;

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -166,12 +166,33 @@ export class AuthService {
    * exactly matches the signed claims. This single method is shared by the
    * HTTP ScopeGuard and WebSocket gateway.
    */
+  /**
+   * Reject a session token with a reason on the record.
+   *
+   * validateSessionToken has sixteen ways to fail and used to return null from
+   * every one of them in silence, so an operator saw only the client-side
+   * "Invalid or expired session token." and had no way to tell an expired
+   * token from a signature mismatch from a revoked authorization.
+   *
+   * Reason strings are fixed vocabulary. Never pass token material, claim
+   * values, secrets, or anything caller-controlled through here — the reason
+   * is for whoever is reading agent logs, and it must stay safe to read.
+   */
+  private rejectSessionToken(reason: string): null {
+    this.logger.warn(`validateSessionToken rejected: ${reason}`);
+    return null;
+  }
+
   async validateSessionToken(token: string): Promise<SessionPayload | null> {
     try {
       const parts = token.split(".");
-      if (parts.length !== 3) return null;
+      if (parts.length !== 3) {
+        return this.rejectSessionToken("malformed token — expected three segments");
+      }
       const [headerB64, payloadB64, signatureB64] = parts;
-      if (!headerB64 || !payloadB64 || !signatureB64) return null;
+      if (!headerB64 || !payloadB64 || !signatureB64) {
+        return this.rejectSessionToken("malformed token — empty segment");
+      }
 
       let header: unknown;
       let claims: SessionPayload;
@@ -179,7 +200,7 @@ export class AuthService {
         header = JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8"));
         claims = JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8"));
       } catch {
-        return null;
+        return this.rejectSessionToken("header or claims are not base64url JSON");
       }
       if (
         !header ||
@@ -196,33 +217,48 @@ export class AuthService {
         typeof claims.exp !== "number" ||
         !Number.isFinite(claims.exp)
       ) {
-        return null;
+        return this.rejectSessionToken(
+          "missing or malformed required claims (iss/organizationId/projectId/environmentId/userId/iat/exp) or alg is not HS256",
+        );
       }
 
       const signingSecret = this.platformSigningSecret;
       if (!signingSecret) {
-        this.logger.warn(
-          "validateSessionToken: SESSION_SECRET not set — rejecting scoped token.",
+        return this.rejectSessionToken(
+          "SESSION_SECRET is not set on this deployment — no scoped token can validate",
         );
-        return null;
       }
       const signingInput = `${headerB64}.${payloadB64}`;
       const expected = crypto
         .createHmac("sha256", signingSecret)
         .update(signingInput)
         .digest("base64url");
-      if (expected.length !== signatureB64.length) return null;
+      if (expected.length !== signatureB64.length) {
+        return this.rejectSessionToken(
+          "signature does not verify — token was signed with a different SESSION_SECRET",
+        );
+      }
       if (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signatureB64))) {
-        return null;
+        return this.rejectSessionToken(
+          "signature does not verify — token was signed with a different SESSION_SECRET",
+        );
       }
 
       const now = new Date();
-      if (claims.exp * 1000 <= now.getTime()) return null;
-      if (claims.iat > Math.floor(now.getTime() / 1000) + 60) return null;
+      if (claims.exp * 1000 <= now.getTime()) {
+        return this.rejectSessionToken("token expired — mint a fresh one");
+      }
+      if (claims.iat > Math.floor(now.getTime() / 1000) + 60) {
+        return this.rejectSessionToken(
+          "token issued more than 60s in the future — check clock skew on the minting host",
+        );
+      }
 
       if (claims.authorizationId !== undefined) {
         if (typeof claims.authorizationId !== "string" || typeof claims.entityId !== "string") {
-          return null;
+          return this.rejectSessionToken(
+            "authorizationId present but authorizationId/entityId claims are malformed",
+          );
         }
         const authorization = await this.prisma.mcpBearerToken.findUnique({
           where: { id: claims.authorizationId },
@@ -248,7 +284,11 @@ export class AuthService {
           authorization.entity.project.id !== claims.projectId ||
           authorization.entity.project.organizationId !== claims.organizationId
         ) {
-          return null;
+          return this.rejectSessionToken(
+            !authorization
+              ? "no McpBearerToken row for this authorizationId — the end-user authorization does not exist in this database"
+              : "McpBearerToken is revoked, expired, or its entity/project/environment does not match the token's claims",
+          );
         }
 
         const environment = await this.prisma.environment.findUnique({
@@ -260,7 +300,9 @@ export class AuthService {
           environment.project.id !== authorization.entity.project.id ||
           environment.project.organizationId !== authorization.entity.project.organizationId
         ) {
-          return null;
+          return this.rejectSessionToken(
+            "the token's environment does not belong to the authorization's project/organization",
+          );
         }
 
         // Close the lookup→use revocation race. A revoke/expiry that wins here
@@ -274,7 +316,11 @@ export class AuthService {
           },
           data: { lastUsedAt: now },
         });
-        if (active.count !== 1) return null;
+        if (active.count !== 1) {
+          return this.rejectSessionToken(
+            "authorization was revoked or expired between lookup and use",
+          );
+        }
       }
 
       return claims;

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -677,7 +677,11 @@ services:
       # Internal docker network: connect agent on the compose hostname,
       # not test.platos.dev. Skips Caddy + TLS for the WS hop and is
       # immune to DNS / cert weirdness during local dev.
-      PLATOS_URL: "${PLATOS_DOCS_MCP_BRIDGE_PLATOS_URL:-ws://agent:3100/tools/sync}"
+      # The ?entity= slug is REQUIRED — without it the gateway cannot know
+      # which registered entity is connecting and rejects every attempt, which
+      # on test.platos meant a 1s reconnect loop logging ~23 rejections a
+      # minute. It must match the entity's externalId in the dashboard.
+      PLATOS_URL: "${PLATOS_DOCS_MCP_BRIDGE_PLATOS_URL:-ws://agent:3100/tools/sync?entity=platos-docs-mcp}"
       # Service secret minted when you registered the entity in the
       # dashboard (default entity name: platos-docs-mcp). REGENERATE
       # the secret on the entity detail page if you do not have it;


### PR DESCRIPTION
## Why

Two problems found chasing a live error on test.platos.

**1. `validateSessionToken` fails silently, sixteen ways.**

A Slack turn failed with `Platos WS error: message=Invalid or expired session token.` The agent logged *nothing* — the gateway `emit`s that string to the client and `validateSessionToken` returns `null` from sixteen distinct places without a word. Expired token, signature mismatch, clock skew, revoked authorization, missing `McpBearerToken` row, and *"SESSION_SECRET is not set on this deployment"* were all indistinguishable from each other.

That last one matters: a deployment with no signing secret rejects **every** token, and said so nowhere.

**2. The docs-mcp-bridge could never connect.**

Its compose default pointed at `ws://agent:3100/tools/sync` with no `?entity=` slug — while the comment three lines below names the entity `platos-docs-mcp`. The gateway rejected every attempt and the bridge retried at 1s, forever: **~23 rejections a minute**, 2,066 in ninety minutes. That noise is what made a perfectly healthy Walle connection look broken.

## Change

- Each rejection records a fixed-vocabulary reason via `rejectSessionToken()`.
- Reasons are for whoever reads agent logs, so they never carry token material, claims, or secrets — asserted in the test.
- The compose default now carries the entity slug it always needed.

## Test

`records a distinct reason for each rejection, and never the token itself` — proves an expired token and a bad signature produce *different* reasons (the entire point), and that no logged line contains the token's header or payload segment.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>