### PR TITLE
fix(auth): name the stale scope id when a migrated deployment re-keys scopes

### DIFF
--- a/apps/agent/src/auth/auth.service.test.ts
+++ b/apps/agent/src/auth/auth.service.test.ts
@@ -155,6 +155,44 @@ describe("AuthService — clean bearer-backed session tokens", () => {
     });
   });
 
+  it("names the stale environment id when a migrated deployment re-keys its scopes", async () => {
+    // A cutover that re-keys Organization/Project/Environment (cuid -> uuid on
+    // test.platos) leaves every integrator minting tokens against ids that no
+    // longer exist. That failure is indistinguishable from a bad secret unless
+    // the log prints the id, so it must.
+    const h = makeSessionHarness();
+    h.prisma.environment.findUnique = vi.fn(async () => null);
+    const warn = vi
+      .spyOn((h.auth as any).logger, "warn")
+      .mockImplementation(() => undefined);
+
+    const stale = { ...SCOPE, environmentId: "cmrci97ty000dpb0jq01pbdac" };
+    await expect(
+      h.auth.validateSessionToken(entitySignedToken(stale, "any-secret-abcdefghijkl")),
+    ).resolves.toBeNull();
+
+    const reason = String(warn.mock.calls.at(-1)?.[0] ?? "");
+    expect(reason).toContain("cmrci97ty000dpb0jq01pbdac");
+    expect(reason).toMatch(/pre-migration ids/i);
+  });
+
+  it("names both sides when the claimed project/org do not own the environment", async () => {
+    const h = makeSessionHarness();
+    const warn = vi
+      .spyOn((h.auth as any).logger, "warn")
+      .mockImplementation(() => undefined);
+
+    await expect(
+      h.auth.validateSessionToken(
+        entitySignedToken({ ...SCOPE, organizationId: "org_someone_else" }, "any-secret-abcdefghijkl"),
+      ),
+    ).resolves.toBeNull();
+
+    const reason = String(warn.mock.calls.at(-1)?.[0] ?? "");
+    expect(reason).toContain("org_someone_else");
+    expect(reason).toContain(SCOPE.organizationId);
+  });
+
   it("refuses an entity-signed token for a scope that entity does not own", async () => {
     // resolveEntityServiceSecret re-derives organization/project from the
     // Environment and returns null when they disagree with the claims. That

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -272,6 +272,33 @@ export class AuthService {
               : "SESSION_SECRET is not set and the token carries no entityId — nothing can verify this token",
           );
         }
+        // Resolve the environment's real ancestry first, so a mismatch can
+        // name BOTH sides. Scope ids are identifiers, not secrets, and the
+        // difference between "something is wrong" and a one-line config fix
+        // is whether the log prints them: a database migration that re-keys
+        // Organization/Project/Environment leaves every integrator minting
+        // tokens against ids that no longer exist, and the failure is
+        // otherwise indistinguishable from a bad secret.
+        const environment = await this.prisma.environment.findUnique({
+          where: { id: claims.environmentId },
+          select: { id: true, project: { select: { id: true, organizationId: true } } },
+        });
+        if (!environment) {
+          return this.rejectSessionToken(
+            `token claims environmentId=${claims.environmentId}, which does not exist here — ` +
+              "if this deployment was migrated, the minting integrator is still using pre-migration ids",
+          );
+        }
+        if (
+          environment.project.id !== claims.projectId ||
+          environment.project.organizationId !== claims.organizationId
+        ) {
+          return this.rejectSessionToken(
+            `token scope does not match this database — claimed project=${claims.projectId} org=${claims.organizationId}, ` +
+              `but environment ${claims.environmentId} belongs to project=${environment.project.id} org=${environment.project.organizationId}`,
+          );
+        }
+
         const entitySecret = await this.resolveEntityServiceSecret({
           organizationId: claims.organizationId,
           projectId: claims.projectId,
@@ -280,7 +307,8 @@ export class AuthService {
         });
         if (!entitySecret) {
           return this.rejectSessionToken(
-            "no usable ENTITY_SECRET for this entity in the claimed environment, or the claimed organization/project does not own that environment",
+            `no resolvable ENTITY_SECRET for entity=${claims.entityId} in environment=${claims.environmentId} — ` +
+              "the credential is missing, revoked, or its secret version could not be decrypted",
           );
         }
         if (!this.signatureMatches(signingInput, signatureB64, entitySecret)) {


### PR DESCRIPTION
## What happened

The clean-schema cutover re-keyed every scope identifier:

| | legacy | clean |
|---|---|---|
| org | `cmrci93gg0009pb0jjcekjh6o` | `0e186325-6f76-56c6-8fd3-fdc5b398f239` |
| project | `cmrci97tt000cpb0jtcwm8h7s` | `8c4ca367-1042-531f-ae71-783945f488bd` |
| env (prod) | `cmrci97ty000dpb0jq01pbdac` | `478bc711-229c-544b-a346-254ada4bd84e` |

Walle still mints session tokens claiming the old cuids, so the environment in the token does not exist. Tool-sync kept working throughout because it authenticates by secret **hash**, not by scope ids — which made this look like an auth bug for hours.

The rejection read *"no usable ENTITY_SECRET for this entity in the claimed environment, or the claimed organization/project does not own that environment"* — a compound reason that points at the secret first, when the secret was never the problem.

## Change

Resolve the environment's real ancestry before touching the secret store, and report three distinct outcomes:

1. **environment does not exist** — names the id, and points at pre-migration ids as the likely cause
2. **claimed project/org do not own it** — names *both* sides
3. **secret could not be resolved** — missing, revoked, or undecryptable

Scope ids are identifiers, not secrets. Printing them is the difference between an afternoon of investigation and a one-line config fix.

## Tests

- names the stale environment id and flags pre-migration ids
- names both sides on a project/org mismatch
- 96 auth tests pass

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>