### PR TITLE
fix(auth): unwrap the cutover's aggregate secret envelope before signing

### DIFF
--- a/apps/agent/src/auth/auth.service.test.ts
+++ b/apps/agent/src/auth/auth.service.test.ts
@@ -135,6 +135,35 @@ describe("AuthService — clean bearer-backed session tokens", () => {
     await expect(h.auth.validateSessionToken(token!)).resolves.toBeNull();
   });
 
+  it("unwraps the cutover's aggregate secret envelope, and leaves bare secrets alone", () => {
+    // The cutover stored {"serviceSecret":"…"} where the mint path stores the
+    // bare string, while Credential.secretHash kept the hash of the BARE
+    // secret. Hash-comparing readers (tool-sync) kept working; HMAC readers
+    // signed with the JSON envelope. Proven on test.platos: an 84-char JSON
+    // plaintext whose sha256 did not match secretHash, but whose nested
+    // serviceSecret value did.
+    const bare = "a".repeat(64);
+
+    expect(AuthService.unwrapEntitySecretMaterial(JSON.stringify({ serviceSecret: bare }))).toBe(bare);
+    expect(
+      AuthService.unwrapEntitySecretMaterial(
+        JSON.stringify({ "PlatosConnectedEntity.serviceSecret": bare, other: 1 }),
+      ),
+    ).toBe(bare);
+
+    // Freshly minted credentials must pass through untouched...
+    expect(AuthService.unwrapEntitySecretMaterial(bare)).toBe(bare);
+    // ...including a secret that merely looks JSON-ish, or an envelope with
+    // no recognised key — guessing would swap a valid secret for a wrong one.
+    expect(AuthService.unwrapEntitySecretMaterial("{not json")).toBe("{not json");
+    expect(AuthService.unwrapEntitySecretMaterial('{"somethingElse":"x"}')).toBe('{"somethingElse":"x"}');
+    expect(AuthService.unwrapEntitySecretMaterial('{"serviceSecret":42}')).toBe('{"serviceSecret":42}');
+    // Idempotent.
+    expect(
+      AuthService.unwrapEntitySecretMaterial(AuthService.unwrapEntitySecretMaterial(JSON.stringify({ serviceSecret: bare }))),
+    ).toBe(bare);
+  });
+
   it("accepts a token signed with the entity's own service secret and no iss", async () => {
     // This is exactly what @platosdev/token-mint emits. Before per-entity
     // verification the agent required SESSION_SECRET + iss=platos-platform,

--- a/apps/agent/src/auth/auth.service.ts
+++ b/apps/agent/src/auth/auth.service.ts
@@ -202,6 +202,43 @@ export class AuthService {
     return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signatureB64));
   }
 
+  /**
+   * Unwrap credential material the clean-schema cutover stored as an envelope.
+   *
+   * The live mint path stores an entity's service secret as a bare string. The
+   * cutover backfill wrote `{"serviceSecret":"…"}` into the same slot while
+   * `Credential.secretHash` kept the hash of the BARE secret — so the same
+   * credential has two disagreeing representations.
+   *
+   * Readers that compare hashes kept working (tool-sync connects fine).
+   * Readers that use the value as an HMAC key silently signed with the JSON
+   * envelope: every externally minted session token was rejected, and every
+   * signed outbound tool call to a migrated entity carried a signature
+   * derived from the wrong key.
+   *
+   * Bare secrets pass through untouched, so this is safe on freshly minted
+   * credentials and idempotent if it ever runs twice.
+   */
+  static unwrapEntitySecretMaterial(plaintext: string): string {
+    const trimmed = plaintext.trim();
+    if (!trimmed.startsWith("{")) return plaintext;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return plaintext;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return plaintext;
+    }
+    const record = parsed as Record<string, unknown>;
+    for (const key of ["serviceSecret", "PlatosConnectedEntity.serviceSecret"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.length > 0) return value;
+    }
+    return plaintext;
+  }
+
   async validateSessionToken(token: string): Promise<SessionPayload | null> {
     try {
       const parts = token.split(".");
@@ -1188,7 +1225,7 @@ export class AuthService {
         name: scope.entityId,
         kind: CredentialKind.ENTITY_SECRET,
       });
-      return material.reveal();
+      return AuthService.unwrapEntitySecretMaterial(material.reveal());
     } catch {
       return null;
     }


### PR DESCRIPTION
## Proven, not guessed

Decrypted the stored envelope on test.platos with the app's own crypto:

```
plaintext length: 84
plaintext is JSON object: true
sha256(plaintext) === Credential.secretHash:          false   <- signing uses this
sha256(value of "serviceSecret") === secretHash:      true    <- the real secret
```

## The bug

The clean-schema cutover stored the entity service secret as `{"serviceSecret":"…"}` in the secret store, while `Credential.secretHash` kept the hash of the **bare** secret. One credential, two disagreeing representations.

- **Hash-comparing readers kept working.** `tool-sync` verifies `sha256(presented) == secretHash` and connected happily the entire time.
- **HMAC readers signed with the JSON envelope.** Every externally minted session token was rejected, and every signed outbound tool call to a migrated entity (`signRequest`, `auth.service.ts:483`) carried a signature derived from the wrong key.

That split is why this presented as an auth bug for hours — the healthy path and the dead path were reading the *same credential*.

## Fix

Unwrap at the resolution boundary (`resolveEntityServiceSecret`) so every consumer receives the bare secret. Deliberately conservative:

- bare secrets pass through untouched (safe on freshly minted credentials)
- an envelope with no recognised key is returned **as-is** rather than guessed at — swapping a valid secret for a wrong one would be worse than failing
- idempotent

Same shape as the existing coerce-at-the-boundary fix for JSON columns: a value whose stored form drifted from what the reader assumes.

## Tests

Aggregate (both key spellings) unwraps; bare, non-JSON, unrecognised-envelope and non-string-value inputs all pass through unchanged; idempotency asserted. 97 auth tests pass.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>