### PR TITLE
fix(providers): a same-named env var no longer poisons provider resolution

### DIFF
--- a/apps/agent/src/agent-runtime/agent.service.ts
+++ b/apps/agent/src/agent-runtime/agent.service.ts
@@ -274,6 +274,13 @@ function resolveModel(
   // the agent passes its own rules, those win; else use sensible defaults.
   const retryFetch = makeRetryFetch(retryRules ?? DEFAULT_RETRY_RULES);
   if (!apiKey) {
+    // The client only ever sees the safe message, so name the model and
+    // provider here or an operator cannot tell WHICH provider was unresolved
+    // on an agent whose model routes span several of them.
+    new Logger("resolveModel").warn(
+      `no API key resolved for provider=${provider} model=${modelString} — ` +
+        "no default ProviderKey is registered for this provider in this environment",
+    );
     throw new ProviderRuntimeError("provider_configuration_unavailable");
   }
 

--- a/apps/agent/src/providers/scoped-env.service.test.ts
+++ b/apps/agent/src/providers/scoped-env.service.test.ts
@@ -219,6 +219,81 @@ describe("ScopedEnvService Platos credential resolution", () => {
     ).rejects.toMatchObject({ code: "provider_configuration_unavailable" });
   });
 
+  it("ignores a same-named credential that belongs to no provider", async () => {
+    // A migrated deployment holds BOTH a provider-owned SERVICE_CREDENTIAL for
+    // OPENAI_API_KEY and an operator environment variable of the same name
+    // (provider = null). Selecting "any credential with this name" and then
+    // throwing on a provider mismatch let the unrelated variable poison
+    // provider resolution — test.platos reported "Provider configuration is
+    // unavailable" for a provider that was correctly configured.
+    const rows = [
+      { id: "cred-envvar", name: "OPENAI_API_KEY", provider: null },
+      { id: "cred-provider", name: "OPENAI_API_KEY", provider: "openai" },
+    ];
+    const prisma = {
+      environment: {
+        findUnique: vi.fn(async () => ({
+          id: scope.environmentId,
+          archivedAt: null,
+          project: {
+            id: scope.projectId,
+            archivedAt: null,
+            organizationId: scope.organizationId,
+            organization: { archivedAt: null },
+          },
+        })),
+      },
+      credential: {
+        // Honour the provider filter the way Postgres would, and return the
+        // null-provider row first when no filter is applied — the ordering
+        // that produced the original failure.
+        findFirst: vi.fn(async (query: any) =>
+          rows.find(
+            (r) =>
+              r.name === query.where.name &&
+              (query.where.provider === undefined || r.provider === query.where.provider),
+          ) ?? null,
+        ),
+      },
+    };
+    const readForRuntime = vi.fn(async () => new SecretMaterial("sk-configured"));
+    const service = new ScopedEnvService(prisma as any, { readForRuntime } as any);
+
+    await expect(
+      service.getProviderConfiguration(scope, "OPENAI_API_KEY", "openai"),
+    ).resolves.toBe("sk-configured");
+    expect(prisma.credential.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ provider: "openai" }) }),
+    );
+  });
+
+  it("treats a name owned by no provider as unconfigured, not as an error", async () => {
+    const prisma = {
+      environment: {
+        findUnique: vi.fn(async () => ({
+          id: scope.environmentId,
+          archivedAt: null,
+          project: {
+            id: scope.projectId,
+            archivedAt: null,
+            organizationId: scope.organizationId,
+            organization: { archivedAt: null },
+          },
+        })),
+      },
+      credential: { findFirst: vi.fn(async () => null) },
+    };
+    const readForRuntime = vi.fn();
+    const service = new ScopedEnvService(prisma as any, { readForRuntime } as any);
+
+    // OPENAI_BASE_URL is genuinely absent on most deployments; callers fall
+    // back to the provider default, so this must not throw.
+    await expect(
+      service.getProviderConfiguration(scope, "OPENAI_BASE_URL", "openai"),
+    ).resolves.toBeUndefined();
+    expect(readForRuntime).not.toHaveBeenCalled();
+  });
+
   it("uses metadata-only same-provider readiness without decrypting", async () => {
     const { service, readForRuntime, prisma } = makeHarness();
 

--- a/apps/agent/src/providers/scoped-env.service.ts
+++ b/apps/agent/src/providers/scoped-env.service.ts
@@ -94,20 +94,28 @@ export class ScopedEnvService {
 
     let credential: { id: string; provider: string | null } | null;
     try {
+      // Match on provider in the QUERY, not after the fact. An Environment can
+      // legitimately hold several credentials under one name — a provider-owned
+      // SERVICE_CREDENTIAL for `OPENAI_API_KEY` and an operator's environment
+      // variable of the same name both exist on a migrated deployment. Fetching
+      // "any credential with this name" and then throwing on a provider
+      // mismatch made an unrelated same-named variable poison provider
+      // resolution: the runtime reported "Provider configuration is
+      // unavailable" for a provider that was correctly configured.
       credential = await this.prisma.credential.findFirst({
         where: {
           environmentId: authorization.environmentId,
           name,
+          provider,
         },
         select: { id: true, provider: true },
       });
     } catch {
       throw new ProviderRuntimeError("provider_configuration_unavailable");
     }
+    // Absent provider configuration is not an error — callers treat undefined
+    // as "not configured" and fall back to the provider's default.
     if (!credential) return undefined;
-    if (credential.provider !== provider) {
-      throw new ProviderRuntimeError("provider_configuration_unavailable");
-    }
 
     try {
       const material = await this.secretStore.readForRuntime({

--- a/apps/agent/src/providers/scoped-env.service.ts
+++ b/apps/agent/src/providers/scoped-env.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import {
   PROVIDER_KEY_SAFE_SELECT,
   PlatosSecretStore,
@@ -27,10 +27,40 @@ export type ScopeTuple = Pick<
  */
 @Injectable()
 export class ScopedEnvService {
+  private readonly logger = new Logger(ScopedEnvService.name);
+
   constructor(
     @Inject(PRISMA_TOKEN) private readonly prisma: PrismaClient,
     @Inject(PLATOS_SECRET_STORE_TOKEN) private readonly secretStore: PlatosSecretStore,
   ) {}
+
+  /**
+   * Raise a provider runtime error with the reason on the record.
+   *
+   * "Provider configuration is unavailable for this environment." is returned
+   * to callers deliberately — it must not leak credential, database or crypto
+   * detail. But it is raised from six different places, and with none of them
+   * logged an operator cannot tell a missing ProviderKey from a failed
+   * authorize from a decrypt error. The safe message still goes to the client;
+   * the reason goes to the server log.
+   *
+   * Never pass secret material, only identifiers already visible in config.
+   */
+  private failProvider(
+    code: "provider_configuration_unavailable" | "provider_credential_unavailable",
+    reason: string,
+    context: { provider?: string; name?: string; environmentId?: string },
+  ): never {
+    const where = [
+      context.provider ? `provider=${context.provider}` : null,
+      context.name ? `name=${context.name}` : null,
+      context.environmentId ? `env=${context.environmentId}` : null,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    this.logger.warn(`${code}: ${reason} (${where})`);
+    throw new ProviderRuntimeError(code);
+  }
 
   /** Resolve one same-Environment credential by its bare reference name. */
   async get(scope: ScopeTuple, name: string): Promise<string | undefined> {
@@ -88,8 +118,12 @@ export class ScopedEnvService {
     let authorization: EnvironmentRuntimeAuthorization;
     try {
       authorization = await this.authorize(scope);
-    } catch {
-      throw new ProviderRuntimeError("provider_configuration_unavailable");
+    } catch (err: any) {
+      this.failProvider(
+        "provider_configuration_unavailable",
+        `environment authorization failed while reading configuration (${err?.message ?? err})`,
+        { provider, name, environmentId: scope.environmentId },
+      );
     }
 
     let credential: { id: string; provider: string | null } | null;
@@ -110,8 +144,12 @@ export class ScopedEnvService {
         },
         select: { id: true, provider: true },
       });
-    } catch {
-      throw new ProviderRuntimeError("provider_configuration_unavailable");
+    } catch (err: any) {
+      this.failProvider(
+        "provider_configuration_unavailable",
+        `credential lookup failed (${err?.message ?? err})`,
+        { provider, name, environmentId: authorization.environmentId },
+      );
     }
     // Absent provider configuration is not an error — callers treat undefined
     // as "not configured" and fall back to the provider's default.
@@ -124,8 +162,12 @@ export class ScopedEnvService {
         provider,
       });
       return material.reveal();
-    } catch {
-      throw new ProviderRuntimeError("provider_configuration_unavailable");
+    } catch (err: any) {
+      this.failProvider(
+        "provider_configuration_unavailable",
+        `credential ${credential.id} found but could not be decrypted (${err?.message ?? err})`,
+        { provider, name, environmentId: authorization.environmentId },
+      );
     }
   }
 
@@ -211,8 +253,12 @@ export class ScopedEnvService {
     let authorization: EnvironmentRuntimeAuthorization;
     try {
       authorization = await this.authorize(scope);
-    } catch {
-      throw new ProviderRuntimeError("provider_configuration_unavailable");
+    } catch (err: any) {
+      this.failProvider(
+        "provider_configuration_unavailable",
+        `environment authorization failed (${err?.message ?? err}) — the scope's organization/project may not own this environment`,
+        { provider, environmentId: scope.environmentId },
+      );
     }
 
     let key: { id: string; credentialId: string } | null;
@@ -226,7 +272,13 @@ export class ScopedEnvService {
           },
           select: PROVIDER_KEY_SAFE_SELECT,
         });
-        if (!key) throw new ProviderRuntimeError("provider_configuration_unavailable");
+        if (!key) {
+          this.failProvider(
+            "provider_configuration_unavailable",
+            `no ProviderKey with the pinned id ${preferredKeyId} for this provider in this environment`,
+            { provider, environmentId: authorization.environmentId },
+          );
+        }
       } else {
         key = await this.prisma.providerKey.findFirst({
           where: {
@@ -243,11 +295,23 @@ export class ScopedEnvService {
         : new ProviderRuntimeError("provider_configuration_unavailable");
     }
 
-    if (!key) return undefined;
+    if (!key) {
+      // Not an error: callers treat undefined as "no key configured" and
+      // resolveModel reports it. Logged because on a migrated deployment this
+      // is the difference between "BYOK was never registered" and a bug.
+      this.logger.warn(
+        `no default ProviderKey for provider=${provider} env=${authorization.environmentId} — register one (BYOK) or pin providerKeyId on the model route`,
+      );
+      return undefined;
+    }
     try {
       return await this.readProviderKey(authorization, key.id, key.credentialId, provider);
-    } catch {
-      throw new ProviderRuntimeError("provider_credential_unavailable");
+    } catch (err: any) {
+      this.failProvider(
+        "provider_credential_unavailable",
+        `ProviderKey ${key.id} resolved but its credential could not be read (${err?.message ?? err})`,
+        { provider, environmentId: authorization.environmentId },
+      );
     }
   }
 


### PR DESCRIPTION
## The bug

`getProviderConfiguration` selected **any** credential with a given name in the Environment, then threw if its `provider` didn't match:

```ts
credential = await findFirst({ where: { environmentId, name } });   // no provider filter
if (!credential) return undefined;
if (credential.provider !== provider) throw provider_configuration_unavailable;
```

An Environment can legitimately hold two credentials under one name:

| name | kind | provider |
|---|---|---|
| `OPENAI_API_KEY` | `SERVICE_CREDENTIAL` | `openai` |
| `OPENAI_API_KEY` | `SECRET_REFERENCE` | `NULL` (operator env var) |

When both exist, the null-provider row can win the `findFirst` — and the runtime then reports **"Provider configuration is unavailable for this environment."** for a provider that is correctly configured. Another error naming the one thing that is *not* wrong.

Confirmed on test.platos, where migrating the legacy environment variables into the clean schema created this collision for all five model providers:

```
OPENAI_API_KEY  findFirst({environmentId, name})
  -> provider=NULL -> THROWS provider_configuration_unavailable
```

## Fix

Match on `provider` in the query, so only provider-owned credentials are considered. An absent row now returns `undefined` — "not configured" — which is what every caller already assumes when it falls back to the provider default.

## Tests

- a same-named `provider = null` credential is ignored; the provider-owned one resolves
- a name owned by no provider (`OPENAI_BASE_URL`, absent on most deployments) returns `undefined` without decrypting or throwing
- 14 tests pass, including the existing "credential read failure stays fail-loud" case

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>