### PR TITLE
fix(docker): exclude local pnpm store from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,8 @@
 
 **/dist
 **/node_modules
+.pnpm-store
+**/.pnpm-store
 
 # Theme BR deploy workaround — temporarily permit
 # packages/core/{dist,.tshy-build} so webapp Dockerfile's transitive


### PR DESCRIPTION
## Why

The test.platos source build copied the host-local `.pnpm-store` into the Docker build context because it was not ignored. Combined with stale BuildKit cache, this exhausted the 96 GB host filesystem before `COPY . .` completed.

## Change

Ignore both the root and nested `.pnpm-store` directories.

## Verification

- Before: build context attempted to include the 2.1 GB host store and failed with `no space left on device`.
- After: build context was 70.72 MB and the strict agent image built successfully.
- `git diff --check` passes.