### PR TITLE
fix(webapp): modernize operator login

### DIFF
--- a/apps/webapp/app/routes/login._index/route.tsx
+++ b/apps/webapp/app/routes/login._index/route.tsx
@@ -94,7 +94,7 @@ export default function Login() {
             <span className="text-indigo-400">.</span>
           </h2>
           <p className="mt-8 max-w-xl text-xl leading-8 text-text-dimmed">
-            Ship dependable agents with deployment, observability, memory, tools, and governance built into one coherent platform.
+            Ship dependable agents with versioning, observability, memory, tools, and governance built into one coherent platform.
           </p>
         </div>
 

--- a/apps/webapp/app/routes/login._index/route.tsx
+++ b/apps/webapp/app/routes/login._index/route.tsx
@@ -27,26 +27,90 @@ export default function Login() {
   const result = useActionData<typeof action>();
 
   return (
-    <main className="grid min-h-screen place-items-center bg-background-dimmed p-6 text-text-bright">
-      <div className="w-full max-w-sm rounded-xl border border-grid-bright bg-background-bright p-6">
-        <img
-          src="/images/platos-logotype.png"
-          alt="Platos"
-          width={280}
-          height={80}
-          className="h-auto w-48"
-        />
-        <h1 className="mt-6 text-2xl font-semibold">Sign in to Platos</h1>
-        <p className="mt-2 text-sm text-text-dimmed">Canonical operator accounts use short-lived magic links.</p>
-        <Form method="post" className="mt-6">
-          <label className="text-sm">
-            Email
-            <input name="email" type="email" required className="mt-2 w-full rounded border border-grid-bright bg-charcoal-900 px-3 py-2" />
-          </label>
-          <button className="mt-4 w-full rounded bg-indigo-500 px-4 py-2 text-sm text-white">Send sign-in link</button>
-        </Form>
-        {result && <p className="mt-4 text-sm text-text-dimmed">{result.message}</p>}
-      </div>
+    <main className="grid min-h-screen bg-background-bright text-text-bright lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+      <section className="relative flex min-h-screen flex-col border-grid-bright px-6 py-8 sm:px-10 lg:border-r lg:px-14 lg:py-10">
+        <header className="flex justify-center lg:justify-start">
+          <a href="/" aria-label="Platos home" className="inline-flex">
+            <img
+              src="/images/platos-logotype.png"
+              alt="Platos"
+              width={320}
+              height={156}
+              className="h-auto w-40"
+            />
+          </a>
+        </header>
+
+        <div className="flex flex-1 items-center justify-center py-12">
+          <div className="w-full max-w-sm">
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">Operator console</p>
+            <h1 className="mt-4 text-4xl font-semibold tracking-[-0.035em]">Sign in to Platos</h1>
+            <p className="mt-4 text-base leading-7 text-text-dimmed">
+              No password to remember. We&apos;ll email you a secure link that expires automatically.
+            </p>
+
+            <Form method="post" className="mt-10">
+              <label htmlFor="operator-email" className="text-sm font-medium">Work email</label>
+              <input
+                id="operator-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                inputMode="email"
+                required
+                placeholder="name@company.com"
+                className="mt-3 w-full border-0 border-b border-grid-bright bg-transparent px-0 py-3 text-lg text-text-bright outline-none transition placeholder:text-text-dimmed focus:border-indigo-400 focus:ring-0"
+              />
+              <button className="mt-8 w-full rounded-md bg-indigo-500 px-4 py-3.5 text-sm font-semibold text-white transition hover:bg-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-300 focus:ring-offset-2 focus:ring-offset-background-bright">
+                Continue with email
+              </button>
+            </Form>
+
+            {result && (
+              <p role="status" className={`mt-5 border-l-2 px-4 py-2 text-sm leading-6 ${result.ok ? "border-emerald-400 text-emerald-200" : "border-rose-400 text-rose-200"}`}>
+                {result.message}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <footer className="text-center text-xs text-text-dimmed lg:text-left">
+          Secure passwordless access for Platos operators.
+        </footer>
+      </section>
+
+      <section className="relative hidden min-h-screen overflow-hidden bg-charcoal-950 lg:flex lg:flex-col lg:justify-between lg:p-14 xl:p-20">
+        <div aria-hidden="true" className="absolute inset-0 [background-image:radial-gradient(circle_at_72%_24%,rgba(99,102,241,0.28),transparent_34%),radial-gradient(circle_at_20%_85%,rgba(56,189,248,0.12),transparent_30%)]" />
+        <div aria-hidden="true" className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(rgba(255,255,255,0.6)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.6)_1px,transparent_1px)] [background-size:56px_56px]" />
+
+        <div className="relative flex items-center gap-3 text-xs font-medium uppercase tracking-[0.2em] text-text-dimmed">
+          <span className="h-2 w-2 rounded-full bg-emerald-400 shadow-[0_0_16px_rgba(52,211,153,0.8)]" />
+          Production agent infrastructure
+        </div>
+
+        <div className="relative max-w-2xl py-16">
+          <h2 className="text-6xl font-semibold leading-[1.03] tracking-[-0.05em] text-white xl:text-7xl">
+            The only runtime<br />you will ever need
+            <span className="text-indigo-400">.</span>
+          </h2>
+          <p className="mt-8 max-w-xl text-xl leading-8 text-text-dimmed">
+            Ship dependable agents with deployment, observability, memory, tools, and governance built into one coherent platform.
+          </p>
+        </div>
+
+        <div className="relative grid grid-cols-3 border-t border-white/10 pt-6 text-sm">
+          {[
+            ["01", "Build"],
+            ["02", "Deploy"],
+            ["03", "Operate"],
+          ].map(([number, label]) => (
+            <div key={number}>
+              <span className="mr-3 font-mono text-xs text-indigo-300">{number}</span>
+              <span className="text-text-dimmed">{label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
     </main>
   );
 }

--- a/apps/webapp/test/loginBranding.test.ts
+++ b/apps/webapp/test/loginBranding.test.ts
@@ -10,5 +10,11 @@ describe("operator login branding", () => {
     expect(existsSync(logo)).toBe(true);
     expect(route).toContain('src="/images/platos-logotype.png"');
     expect(route).toContain('alt="Platos"');
+    expect(route).toContain("width={320}");
+    expect(route).toContain("height={156}");
+    expect(route).toContain("The only runtime");
+    expect(route).toContain("you will ever need");
+    expect(route).toContain("lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]");
+    expect(route).toContain("Continue with email");
   });
 });


### PR DESCRIPTION
## Summary
- restore the v1-inspired split login composition
- center the passwordless operator flow in a clean left pane
- add the product statement: The only runtime you will ever need
- use the canonical Platos asset with correct intrinsic dimensions

## Verification
- pnpm --filter webapp exec vitest run test/loginBranding.test.ts
- git diff --check

This PR is intended for immediate test.platos.dev deployment after CI passes.