### PR TITLE
Audit and harden MCP and backend route boundaries

### DIFF
--- a/apps/agent/src/auth/scope.guard.test.ts
+++ b/apps/agent/src/auth/scope.guard.test.ts
@@ -12,7 +12,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UnauthorizedException } from "@nestjs/common";
 import { mintSessionToken } from "@platosdev/token-mint";
-import { isPublicMcpTransport, ScopeGuard } from "./scope.guard";
+import {
+  isPublicDocsMcpTransport,
+  isPublicChannelCallback,
+  isPublicMcpTransport,
+  isPublicOAuthRoute,
+  isPublicTokenMintRoute,
+  ScopeGuard,
+} from "./scope.guard";
 import { AuthService } from "./auth.service";
 import { AgentController } from "../agent-runtime/agent.controller";
 import type { ExecutionContext } from "@nestjs/common";
@@ -23,7 +30,7 @@ function mockExecutionContext(
   headers: HeaderMap = {},
   url = "/api/v1/agent/threads",
   preScoped?: Record<string, unknown>,
-  method = "GET",
+  method = "GET"
 ): ExecutionContext {
   const request: Record<string, unknown> = { headers, url, method };
   if (preScoped) request.scope = preScoped;
@@ -123,15 +130,17 @@ describe("ScopeGuard — pre-scoped short-circuit", () => {
   });
 });
 
-describe("ScopeGuard — health/test allowlist", () => {
+describe("ScopeGuard — health allowlist", () => {
   it("allows /api/health without auth", async () => {
     const guard = new ScopeGuard();
     await expect(guard.canActivate(mockExecutionContext({}, "/api/health"))).resolves.toBe(true);
   });
 
-  it("allows /test/* without auth", async () => {
+  it("does not reserve a public /test/* prefix in the global guard", async () => {
     const guard = new ScopeGuard();
-    await expect(guard.canActivate(mockExecutionContext({}, "/test/ping"))).resolves.toBe(true);
+    await expect(guard.canActivate(mockExecutionContext({}, "/test/ping"))).rejects.toBeInstanceOf(
+      UnauthorizedException,
+    );
   });
 });
 
@@ -156,6 +165,99 @@ describe("ScopeGuard — exact MCP protocol isolation", () => {
   });
 });
 
+describe("ScopeGuard — exact public self-auth route isolation", () => {
+  it.each([
+    ["GET", "/mcp"],
+    ["POST", "/mcp?client=inspector"],
+    ["GET", "/mcp/docs"],
+    ["GET", "/mcp/docs/sse?sessionId=one"],
+    ["POST", "/mcp/messages?sessionId=one"],
+    ["POST", "/mcp/docs/messages?sessionId=one"],
+  ])("recognizes public Docs MCP %s %s", (method, url) => {
+    expect(isPublicDocsMcpTransport(method, url)).toBe(true);
+  });
+
+  it.each([
+    ["DELETE", "/mcp"],
+    ["POST", "/mcp/sse"],
+    ["GET", "/mcp/messages"],
+    ["GET", "/mcp/docs-admin"],
+    ["POST", "/mcp/docs/tokens"],
+    ["POST", "/mcp/docs/messages/extra"],
+  ])("keeps Docs MCP near-miss %s %s behind normal scope auth", (method, url) => {
+    expect(isPublicDocsMcpTransport(method, url)).toBe(false);
+  });
+
+  it.each([
+    ["POST", "/api/v1/public/guest-token"],
+    ["POST", "/api/v1/entities/walle-mcp/session-tokens?ttl=300"],
+  ])("recognizes public token mint %s %s", (method, url) => {
+    expect(isPublicTokenMintRoute(method, url)).toBe(true);
+  });
+
+  it.each([
+    ["GET", "/api/v1/public/guest-token"],
+    ["POST", "/api/v1/public/guest-token/rotate"],
+    ["POST", "/api/v1/publicity/guest-token"],
+    ["GET", "/api/v1/entities/walle-mcp/session-tokens"],
+    ["POST", "/api/v1/entities/walle-mcp/session-tokens/rotate"],
+    ["POST", "/api/v1/entities/walle-mcp/not-session-tokens"],
+  ])("keeps token-mint near-miss %s %s behind normal scope auth", (method, url) => {
+    expect(isPublicTokenMintRoute(method, url)).toBe(false);
+  });
+});
+
+describe("ScopeGuard — exact channel callback isolation", () => {
+  it.each([
+    ["POST", "/api/v1/channels/inbound/connection_1/secret_1"],
+    ["GET", "/api/v1/channels/inbound/connection_1/secret_1"],
+    ["GET", "/api/v1/channels/oauth/app_1/install"],
+    ["GET", "/api/v1/channels/oauth/app_1/callback?code=one"],
+    ["POST", "/api/v1/channels/apps/app_1/events"],
+    ["GET", "/api/v1/channels/link/callback?code=one"],
+    ["GET", "/api/v1/channels/link/nonce_1"],
+  ])("recognizes provider callback %s %s", (method, url) => {
+    expect(isPublicChannelCallback(method, url)).toBe(true);
+  });
+
+  it.each([
+    ["GET", "/api/v1/channels/apps/app_1"],
+    ["POST", "/api/v1/channels/oauth/app_1/install"],
+    ["GET", "/api/v1/channels/oauth/app_1/callback/admin"],
+    ["POST", "/api/v1/channels/apps/app_1/events/replay"],
+    ["POST", "/api/v1/channels/link/callback"],
+    ["GET", "/api/v1/channels/inbound/connection_1"],
+  ])("keeps non-callback sibling %s %s scoped", (method, url) => {
+    expect(isPublicChannelCallback(method, url)).toBe(false);
+  });
+});
+
+describe("ScopeGuard — exact OAuth protocol isolation", () => {
+  it.each([
+    ["GET", "/.well-known/oauth-authorization-server"],
+    ["POST", "/oauth/token"],
+    ["GET", "/oauth/authorize?client_id=one"],
+    ["POST", "/oauth/entity/entity_1/register"],
+    ["GET", "/oauth/entity/entity_1/authorize"],
+    ["POST", "/oauth/entity/entity_1/authorize/anonymous"],
+    ["GET", "/oauth/entity/entity_1/oidc-callback?code=one"],
+  ])("recognizes OAuth endpoint %s %s", (method, url) => {
+    expect(isPublicOAuthRoute(method, url)).toBe(true);
+  });
+
+  it.each([
+    ["GET", "/oauth"],
+    ["GET", "/oauth/token"],
+    ["POST", "/oauth/entity/entity_1/authorize"],
+    ["GET", "/oauth/entity/entity_1/token"],
+    ["POST", "/oauth/entity/entity_1/oidc-callback"],
+    ["GET", "/oauth/admin/tokens"],
+    ["GET", "/.well-known/private-config"],
+  ])("keeps OAuth near-miss %s %s scoped", (method, url) => {
+    expect(isPublicOAuthRoute(method, url)).toBe(false);
+  });
+});
+
 describe("ScopeGuard — Path 2 direct headers", () => {
   it("accepts 4-header scope from trusted internal origin (no X-Forwarded-For)", async () => {
     const guard = new ScopeGuard();
@@ -166,7 +268,7 @@ describe("ScopeGuard — Path 2 direct headers", () => {
       "x-platos-user-id": "user_1",
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    const req = (ctx.switchToHttp().getRequest() as any);
+    const req = ctx.switchToHttp().getRequest() as any;
     expect(req.scope.organizationId).toBe("org_1");
     expect(req.scope.projectId).toBe("proj_1");
     expect(req.scope.environmentId).toBe("env_1");
@@ -207,7 +309,7 @@ describe("ScopeGuard — Path 2 direct headers", () => {
       "x-platos-user-token": "opaque.user.jwt",
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    const req = (ctx.switchToHttp().getRequest() as any);
+    const req = ctx.switchToHttp().getRequest() as any;
     expect(req.scope.entityId).toBe("fandesk-main");
     expect(req.scope.userToken).toBe("opaque.user.jwt");
   });
@@ -231,13 +333,13 @@ describe("ScopeGuard — Path 2 direct headers", () => {
         },
         url,
         undefined,
-        method,
+        method
       );
 
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(authService.verifyAccessKey).not.toHaveBeenCalled();
       expect((ctx.switchToHttp().getRequest() as any).scope.principal).toBe("operator");
-    },
+    }
   );
 
   it.each([
@@ -247,39 +349,42 @@ describe("ScopeGuard — Path 2 direct headers", () => {
     ["POST", "/api/v1/agent/access-key/"],
     ["POST", "/api/v1/agent/access-key/rotate"],
     ["POST", "/api/v1/agent/access-key/origins/extra?from=dashboard"],
-  ])("rejects trusted direct-header %s %s when the AccessKey is missing or invalid", async (method, url) => {
-    const authService = { verifyAccessKey: vi.fn().mockResolvedValue(false) };
-    const guard = new ScopeGuard(authService as any);
-    const ctx = mockExecutionContext(
-      {
-        "x-platos-organization-id": "org_1",
-        "x-platos-project-id": "proj_1",
-        "x-platos-environment-id": "env_1",
-        "x-platos-user-id": "user_1",
-      },
-      url,
-      undefined,
-      method,
-    );
+  ])(
+    "rejects trusted direct-header %s %s when the AccessKey is missing or invalid",
+    async (method, url) => {
+      const authService = { verifyAccessKey: vi.fn().mockResolvedValue(false) };
+      const guard = new ScopeGuard(authService as any);
+      const ctx = mockExecutionContext(
+        {
+          "x-platos-organization-id": "org_1",
+          "x-platos-project-id": "proj_1",
+          "x-platos-environment-id": "env_1",
+          "x-platos-user-id": "user_1",
+        },
+        url,
+        undefined,
+        method
+      );
 
-    await expect(guard.canActivate(ctx)).resolves.toBe(false);
-    expect(authService.verifyAccessKey).toHaveBeenCalledWith(
-      {
-        organizationId: "org_1",
-        projectId: "proj_1",
-        environmentId: "env_1",
-        userId: "user_1",
-      },
-      undefined,
-      undefined,
-    );
-    const response = ctx.switchToHttp().getResponse() as any;
-    expect(response.status).toHaveBeenCalledWith(401);
-    expect(response.json).toHaveBeenCalledWith({
-      error: "INVALID_ACCESS_KEY",
-      message: "X-Platos-Api-Key is missing or invalid for this scope.",
-    });
-  });
+      await expect(guard.canActivate(ctx)).resolves.toBe(false);
+      expect(authService.verifyAccessKey).toHaveBeenCalledWith(
+        {
+          organizationId: "org_1",
+          projectId: "proj_1",
+          environmentId: "env_1",
+          userId: "user_1",
+        },
+        undefined,
+        undefined
+      );
+      const response = ctx.switchToHttp().getResponse() as any;
+      expect(response.status).toHaveBeenCalledWith(401);
+      expect(response.json).toHaveBeenCalledWith({
+        error: "INVALID_ACCESS_KEY",
+        message: "X-Platos-Api-Key is missing or invalid for this scope.",
+      });
+    }
+  );
 
   it("allows an arbitrary trusted direct-header route with a valid AccessKey", async () => {
     const authService = { verifyAccessKey: vi.fn().mockResolvedValue(true) };
@@ -295,7 +400,7 @@ describe("ScopeGuard — Path 2 direct headers", () => {
       },
       "/api/v1/agent/threads?agentId=agent_1",
       undefined,
-      "POST",
+      "POST"
     );
 
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
@@ -307,7 +412,7 @@ describe("ScopeGuard — Path 2 direct headers", () => {
         userId: "user_1",
       },
       "platos_live_valid",
-      "https://app.example",
+      "https://app.example"
     );
   });
 
@@ -317,13 +422,16 @@ describe("ScopeGuard — Path 2 direct headers", () => {
     try {
       const authService = { verifyAccessKey: vi.fn().mockResolvedValue(false) };
       const guard = new ScopeGuard(authService as any);
-      const ctx = mockExecutionContext({
-        "x-platos-organization-id": "org_1",
-        "x-platos-project-id": "proj_1",
-        "x-platos-environment-id": "env_1",
-        "x-platos-user-id": "user_1",
-        "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
-      }, "/api/v1/agent/entities/entity_1");
+      const ctx = mockExecutionContext(
+        {
+          "x-platos-organization-id": "org_1",
+          "x-platos-project-id": "proj_1",
+          "x-platos-environment-id": "env_1",
+          "x-platos-user-id": "user_1",
+          "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
+        },
+        "/api/v1/agent/entities/entity_1"
+      );
 
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
       expect(authService.verifyAccessKey).not.toHaveBeenCalled();
@@ -338,23 +446,31 @@ describe("ScopeGuard — Path 2 direct headers", () => {
     process.env.PLATOS_INTERNAL_AUTH_TOKEN = "dashboard-control-plane-token-32chars";
     try {
       const h = makeAuthHarness();
-      const ctx = mockExecutionContext({
-        "x-platos-organization-id": h.scope.organizationId,
-        "x-platos-project-id": h.scope.projectId,
-        "x-platos-environment-id": h.scope.environmentId,
-        "x-platos-user-id": h.scope.userId,
-        "x-platos-agent-id": "agent_A",
-        "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
-      }, "/api/v1/memory");
+      const ctx = mockExecutionContext(
+        {
+          "x-platos-organization-id": h.scope.organizationId,
+          "x-platos-project-id": h.scope.projectId,
+          "x-platos-environment-id": h.scope.environmentId,
+          "x-platos-user-id": h.scope.userId,
+          "x-platos-agent-id": "agent_A",
+          "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
+        },
+        "/api/v1/memory"
+      );
 
       await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(true);
       expect((ctx.switchToHttp().getRequest() as any).scope).toMatchObject({
         principal: "operator",
         agentId: "agent_A",
       });
-      expect(h.prisma.agentBinding.findFirst).toHaveBeenCalledWith(expect.objectContaining({
-        where: expect.objectContaining({ agentId: "agent_A", environmentId: h.scope.environmentId }),
-      }));
+      expect(h.prisma.agentBinding.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            agentId: "agent_A",
+            environmentId: h.scope.environmentId,
+          }),
+        })
+      );
     } finally {
       if (previous === undefined) delete process.env.PLATOS_INTERNAL_AUTH_TOKEN;
       else process.env.PLATOS_INTERNAL_AUTH_TOKEN = previous;
@@ -366,19 +482,24 @@ describe("ScopeGuard — Path 2 direct headers", () => {
     process.env.PLATOS_INTERNAL_AUTH_TOKEN = "dashboard-control-plane-token-32chars";
     try {
       const h = makeAuthHarness();
-      const ctx = mockExecutionContext({
-        "x-platos-organization-id": h.scope.organizationId,
-        "x-platos-project-id": h.scope.projectId,
-        "x-platos-environment-id": h.scope.environmentId,
-        "x-platos-user-id": h.scope.userId,
-        "x-platos-agent-id": "agent_foreign",
-        "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
-      }, "/api/v1/memory");
+      const ctx = mockExecutionContext(
+        {
+          "x-platos-organization-id": h.scope.organizationId,
+          "x-platos-project-id": h.scope.projectId,
+          "x-platos-environment-id": h.scope.environmentId,
+          "x-platos-user-id": h.scope.userId,
+          "x-platos-agent-id": "agent_foreign",
+          "x-platos-internal-auth": "dashboard-control-plane-token-32chars",
+        },
+        "/api/v1/memory"
+      );
 
       await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(false);
       const response = ctx.switchToHttp().getResponse() as any;
       expect(response.status).toHaveBeenCalledWith(403);
-      expect(response.json).toHaveBeenCalledWith(expect.objectContaining({ error: "INVALID_AGENT_SCOPE" }));
+      expect(response.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: "INVALID_AGENT_SCOPE" })
+      );
       expect((ctx.switchToHttp().getRequest() as any).scope).toBeUndefined();
     } finally {
       if (previous === undefined) delete process.env.PLATOS_INTERNAL_AUTH_TOKEN;
@@ -388,13 +509,16 @@ describe("ScopeGuard — Path 2 direct headers", () => {
 
   it("rejects an otherwise valid Agent pin without server control-plane authentication", async () => {
     const h = makeAuthHarness();
-    const ctx = mockExecutionContext({
-      "x-platos-organization-id": h.scope.organizationId,
-      "x-platos-project-id": h.scope.projectId,
-      "x-platos-environment-id": h.scope.environmentId,
-      "x-platos-user-id": h.scope.userId,
-      "x-platos-agent-id": "agent_A",
-    }, "/api/v1/memory");
+    const ctx = mockExecutionContext(
+      {
+        "x-platos-organization-id": h.scope.organizationId,
+        "x-platos-project-id": h.scope.projectId,
+        "x-platos-environment-id": h.scope.environmentId,
+        "x-platos-user-id": h.scope.userId,
+        "x-platos-agent-id": "agent_A",
+      },
+      "/api/v1/memory"
+    );
 
     await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(false);
     expect(h.prisma.agentBinding.findFirst).not.toHaveBeenCalled();
@@ -420,7 +544,7 @@ describe("ScopeGuard — Path 1 session token", () => {
       "x-platos-session-token": token!,
     });
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
-    const req = (ctx.switchToHttp().getRequest() as any);
+    const req = ctx.switchToHttp().getRequest() as any;
     expect(req.scope).toMatchObject({
       organizationId: h.scope.organizationId,
       entityId: h.scope.entityId,
@@ -464,10 +588,7 @@ describe("ScopeGuard — Path 1 session token", () => {
       claims: h.scope,
       ttlSeconds: 300,
     });
-    const ctx = mockExecutionContext(
-      { "x-platos-session-token": token },
-      "/api/v1/agent/budgets",
-    );
+    const ctx = mockExecutionContext({ "x-platos-session-token": token }, "/api/v1/agent/budgets");
 
     await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(true);
     const req = ctx.switchToHttp().getRequest() as any;
@@ -486,11 +607,12 @@ describe("ScopeGuard — Path 1 session token", () => {
     const calls = [
       () => controller.listBudgets(req),
       () => controller.budgetStatus(req),
-      () => controller.upsertBudget(req, {
-        scopeType: "environment",
-        period: "monthly",
-        limitCents: 10_000,
-      }),
+      () =>
+        controller.upsertBudget(req, {
+          scopeType: "environment",
+          period: "monthly",
+          limitCents: 10_000,
+        }),
       () => controller.deleteBudget(req, "cap-1"),
       () => controller.overrideBudget(req, "cap-1", { minutes: 60 }),
     ];
@@ -518,10 +640,7 @@ describe("ScopeGuard — Path 1 session token", () => {
       userId: h.scope.userId,
       extraClaims: { isGuest: true },
     });
-    const ctx = mockExecutionContext(
-      { "x-platos-session-token": token! },
-      "/api/v1/agent/budgets",
-    );
+    const ctx = mockExecutionContext({ "x-platos-session-token": token! }, "/api/v1/agent/budgets");
 
     await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(true);
     const req = ctx.switchToHttp().getRequest() as any;
@@ -540,11 +659,12 @@ describe("ScopeGuard — Path 1 session token", () => {
     const calls = [
       () => controller.listBudgets(req),
       () => controller.budgetStatus(req),
-      () => controller.upsertBudget(req, {
-        scopeType: "environment",
-        period: "monthly",
-        limitCents: 10_000,
-      }),
+      () =>
+        controller.upsertBudget(req, {
+          scopeType: "environment",
+          period: "monthly",
+          limitCents: 10_000,
+        }),
       () => controller.deleteBudget(req, "cap-1"),
       () => controller.overrideBudget(req, "cap-1", { minutes: 60 }),
     ];
@@ -578,9 +698,9 @@ describe("ScopeGuard — Path 1 session token", () => {
 
       const ctx = mockExecutionContext({ "x-platos-session-token": token! });
       await expect(new ScopeGuard(h.auth).canActivate(ctx)).rejects.toBeInstanceOf(
-        UnauthorizedException,
+        UnauthorizedException
       );
-    },
+    }
   );
 
   it("runs the AccessKey check only after session validation succeeds", async () => {
@@ -597,7 +717,7 @@ describe("ScopeGuard — Path 1 session token", () => {
     const h = makeAuthHarness();
     const ctx = mockExecutionContext({ "x-platos-session-token": "payload.signature" });
     await expect(new ScopeGuard(h.auth).canActivate(ctx)).rejects.toBeInstanceOf(
-      UnauthorizedException,
+      UnauthorizedException
     );
   });
 });
@@ -617,6 +737,8 @@ describe("ScopeGuard — admin token path", () => {
       const ctx = mockExecutionContext(
         { "x-platos-internal-auth": "admin-secret-for-test" },
         "/api/v1/agent/monitoring/cost/catalog",
+        undefined,
+        "POST"
       );
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
     } finally {
@@ -632,11 +754,59 @@ describe("ScopeGuard — admin token path", () => {
       const ctx = mockExecutionContext(
         { "x-platos-internal-auth": "WRONG" },
         "/api/v1/agent/monitoring/cost/catalog",
+        undefined,
+        "POST"
       );
       await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
     } finally {
       process.env.PLATOS_INTERNAL_AUTH_TOKEN = prevToken;
     }
+  });
+
+  it("allows only the registered verb for internal callbacks and observability status", async () => {
+    const prevToken = process.env.PLATOS_INTERNAL_AUTH_TOKEN;
+    process.env.PLATOS_INTERNAL_AUTH_TOKEN = "admin-secret-for-test";
+    const headers = { "x-platos-internal-auth": "admin-secret-for-test" };
+    try {
+      const guard = new ScopeGuard();
+      await expect(
+        guard.canActivate(
+          mockExecutionContext(
+            headers,
+            "/api/v1/agent/monitoring/observability/status",
+            undefined,
+            "GET"
+          )
+        )
+      ).resolves.toBe(true);
+      await expect(
+        guard.canActivate(
+          mockExecutionContext(
+            headers,
+            "/api/v1/agent/monitoring/observability/status",
+            undefined,
+            "POST"
+          )
+        )
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+      await expect(
+        guard.canActivate(
+          mockExecutionContext(headers, "/api/v1/agent/internal/compaction/extra", undefined, "POST")
+        )
+      ).rejects.toBeInstanceOf(UnauthorizedException);
+    } finally {
+      process.env.PLATOS_INTERNAL_AUTH_TOKEN = prevToken;
+    }
+  });
+
+  it("lets the HMAC-authenticated env invalidation callback reach its controller", async () => {
+    const guard = new ScopeGuard();
+    await expect(
+      guard.canActivate(mockExecutionContext({}, "/internal/env/invalidate", undefined, "POST"))
+    ).resolves.toBe(true);
+    await expect(
+      guard.canActivate(mockExecutionContext({}, "/internal/env/invalidate/extra", undefined, "POST"))
+    ).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
   // LAUNCH-11 — durable compaction callback.
@@ -648,6 +818,8 @@ describe("ScopeGuard — admin token path", () => {
       const ctx = mockExecutionContext(
         { "x-platos-internal-auth": "admin-secret-for-test" },
         "/api/v1/agent/internal/compaction",
+        undefined,
+        "POST"
       );
       await expect(guard.canActivate(ctx)).resolves.toBe(true);
     } finally {
@@ -663,6 +835,8 @@ describe("ScopeGuard — admin token path", () => {
       const ctx = mockExecutionContext(
         { "x-platos-internal-auth": "WRONG" },
         "/api/v1/agent/internal/compaction",
+        undefined,
+        "POST"
       );
       await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
     } finally {
@@ -675,7 +849,7 @@ describe("ScopeGuard — admin token path", () => {
     process.env.PLATOS_INTERNAL_AUTH_TOKEN = "admin-secret-for-test";
     try {
       const guard = new ScopeGuard();
-      const ctx = mockExecutionContext({}, "/api/v1/agent/internal/compaction");
+      const ctx = mockExecutionContext({}, "/api/v1/agent/internal/compaction", undefined, "POST");
       await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
     } finally {
       process.env.PLATOS_INTERNAL_AUTH_TOKEN = prevToken;
@@ -698,6 +872,8 @@ describe("ScopeGuard — admin token path", () => {
         const ctx = mockExecutionContext(
           { "x-platos-internal-auth": "admin-secret-for-test" },
           path,
+          undefined,
+          "POST"
         );
         await expect(guard.canActivate(ctx)).resolves.toBe(true);
       } finally {
@@ -710,7 +886,12 @@ describe("ScopeGuard — admin token path", () => {
       process.env.PLATOS_INTERNAL_AUTH_TOKEN = "admin-secret-for-test";
       try {
         const guard = new ScopeGuard();
-        const ctx = mockExecutionContext({ "x-platos-internal-auth": "WRONG" }, path);
+        const ctx = mockExecutionContext(
+          { "x-platos-internal-auth": "WRONG" },
+          path,
+          undefined,
+          "POST"
+        );
         await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
       } finally {
         process.env.PLATOS_INTERNAL_AUTH_TOKEN = prevToken;
@@ -722,7 +903,7 @@ describe("ScopeGuard — admin token path", () => {
       process.env.PLATOS_INTERNAL_AUTH_TOKEN = "admin-secret-for-test";
       try {
         const guard = new ScopeGuard();
-        const ctx = mockExecutionContext({}, path);
+        const ctx = mockExecutionContext({}, path, undefined, "POST");
         await expect(guard.canActivate(ctx)).rejects.toBeInstanceOf(UnauthorizedException);
       } finally {
         process.env.PLATOS_INTERNAL_AUTH_TOKEN = prevToken;

--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -1,4 +1,12 @@
-import { Injectable, CanActivate, ExecutionContext, UnauthorizedException, ForbiddenException, Inject, Optional } from "@nestjs/common";
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  ForbiddenException,
+  Inject,
+  Optional,
+} from "@nestjs/common";
 import * as crypto from "node:crypto";
 import { AuthService } from "./auth.service";
 import { env } from "../shared/env";
@@ -37,7 +45,7 @@ export function isPublicMcpTransport(methodValue: unknown, urlValue: unknown): b
     return true;
   }
   const entityProtocol = pathname.match(
-    /^\/mcp\/entity\/[^/]+(?:\/(sse|messages|events\/subscribe))?$/,
+    /^\/mcp\/entity\/[^/]+(?:\/(sse|messages|events\/subscribe))?$/
   );
   if (!entityProtocol) return false;
   const suffix = entityProtocol[1];
@@ -47,6 +55,82 @@ export function isPublicMcpTransport(methodValue: unknown, urlValue: unknown): b
     (suffix === "messages" && method === "POST") ||
     (suffix === "events/subscribe" && method === "GET")
   );
+}
+
+/** Public, read-only Docs MCP transports. Keep this separate from the
+ * authenticated Platform/Entity MCP matcher: `/mcp` and `/mcp/docs` expose
+ * only the docs controller, while every sibling route remains deny-by-default.
+ */
+export function isPublicDocsMcpTransport(methodValue: unknown, urlValue: unknown): boolean {
+  const method = typeof methodValue === "string" ? methodValue.toUpperCase() : "";
+  const url = typeof urlValue === "string" ? urlValue : "";
+  const pathname = url.split("?", 1)[0];
+  return (
+    ((pathname === "/mcp" || pathname === "/mcp/docs") &&
+      (method === "GET" || method === "POST")) ||
+    ((pathname === "/mcp/sse" || pathname === "/mcp/docs/sse") && method === "GET") ||
+    ((pathname === "/mcp/messages" || pathname === "/mcp/docs/messages") && method === "POST")
+  );
+}
+
+/** Public session-mint and guest-token endpoints authenticate in-controller.
+ * Match the registered verb and complete pathname so a future sibling under
+ * either prefix cannot accidentally inherit the bypass.
+ */
+export function isPublicTokenMintRoute(methodValue: unknown, urlValue: unknown): boolean {
+  const method = typeof methodValue === "string" ? methodValue.toUpperCase() : "";
+  const url = typeof urlValue === "string" ? urlValue : "";
+  const pathname = url.split("?", 1)[0];
+  return (
+    method === "POST" &&
+    (pathname === "/api/v1/public/guest-token" ||
+      /^\/api\/v1\/entities\/[^/]+\/session-tokens$/.test(pathname))
+  );
+}
+
+/** Provider callbacks authenticate inside their controllers. Match only the
+ * currently registered public verbs and shapes; management siblings stay
+ * behind normal scoped authentication. */
+export function isPublicChannelCallback(methodValue: unknown, urlValue: unknown): boolean {
+  const method = typeof methodValue === "string" ? methodValue.toUpperCase() : "";
+  const url = typeof urlValue === "string" ? urlValue : "";
+  const pathname = url.split("?", 1)[0];
+  return (
+    ((method === "GET" || method === "POST") &&
+      /^\/api\/v1\/channels\/inbound\/[^/]+\/[^/]+$/.test(pathname)) ||
+    (method === "GET" &&
+      /^\/api\/v1\/channels\/oauth\/[^/]+\/(install|callback)$/.test(pathname)) ||
+    (method === "POST" && /^\/api\/v1\/channels\/apps\/[^/]+\/events$/.test(pathname)) ||
+    (method === "GET" &&
+      (pathname === "/api/v1/channels/link/callback" ||
+        /^\/api\/v1\/channels\/link\/[^/]+$/.test(pathname)))
+  );
+}
+
+/** OAuth protocol entry points self-authenticate through client credentials,
+ * PKCE, signed consent state, or bearer revocation. Keep the allowlist in sync
+ * with OAuthController rather than granting its entire namespace. */
+export function isPublicOAuthRoute(methodValue: unknown, urlValue: unknown): boolean {
+  const method = typeof methodValue === "string" ? methodValue.toUpperCase() : "";
+  const url = typeof urlValue === "string" ? urlValue : "";
+  const pathname = url.split("?", 1)[0];
+  if (
+    method === "GET" &&
+    (pathname === "/.well-known/oauth-authorization-server" ||
+      /^\/.well-known\/oauth-authorization-server\/entity\/[^/]+$/.test(pathname))
+  ) return true;
+  if (
+    (method === "GET" && (pathname === "/oauth/authorize" || pathname === "/oauth/consent")) ||
+    (method === "POST" &&
+      ["/oauth/register", "/oauth/authorize/callback", "/oauth/token", "/oauth/introspect", "/oauth/revoke"].includes(pathname))
+  ) return true;
+  const entityRoute = pathname.match(
+    /^\/oauth\/entity\/[^/]+\/(register|authorize|authorize\/anonymous|token|revoke|oidc-redirect|oidc-callback)$/,
+  );
+  if (!entityRoute) return false;
+  return entityRoute[1] === "authorize" || entityRoute[1]?.startsWith("oidc-")
+    ? method === "GET"
+    : method === "POST";
 }
 
 /**
@@ -60,7 +144,7 @@ export function isPublicMcpTransport(methodValue: unknown, urlValue: unknown): b
  * Format:  `00-<32-char-hex-trace-id>-<16-char-hex-span-id>-<2-char-hex-flags>`
  */
 function parseTraceparent(
-  header: string | string[] | undefined,
+  header: string | string[] | undefined
 ): { traceId: string; parentSpanId: string } | null {
   const raw = Array.isArray(header) ? header[0] : header;
   if (!raw || typeof raw !== "string") return null;
@@ -218,8 +302,8 @@ export class ScopeGuard implements CanActivate {
       typeof request.originalUrl === "string"
         ? request.originalUrl
         : typeof request.url === "string"
-          ? request.url
-          : "";
+        ? request.url
+        : "";
     const pathname = url.split("?", 1)[0];
 
     return (
@@ -260,24 +344,26 @@ export class ScopeGuard implements CanActivate {
 
     const url: string = request.url || "";
 
-    // Allow health and test endpoints without auth
-    if (url.startsWith("/api/health") || url.startsWith("/test/")) return true;
+    // The production graph intentionally excludes TestModule. Do not add a
+    // global `/test/*` bypass here: doing so would silently expose any future
+    // route mounted at that prefix if the module graph regressed.
+    const pathname = url.split("?", 1)[0];
+    if (request.method?.toUpperCase() === "GET" && pathname === "/api/health")
+      return true;
 
     // EOBD.41 — Prometheus scrape endpoint. Unauthenticated by design;
     // the operator fronts /metrics with a network-level ACL (Caddy,
     // firewall rule) rather than per-scope auth. Matches the pattern
     // used by the rate-limit guard which also exempts /metrics.
-    if (url.startsWith("/metrics")) return true;
+    if (request.method?.toUpperCase() === "GET" && pathname === "/metrics") return true;
 
     // Entity session-token mint endpoint. The controller validates the clean
     // `plt_ent_` McpBearerToken and canonical Entity ancestry itself.
-    if (url.startsWith("/api/v1/entities/") && url.includes("/session-tokens")) return true;
+    if (isPublicTokenMintRoute(request.method, url)) return true;
 
     // EOBD.89 — public guest-token mint. Unauthenticated by design;
     // the controller gates access by agent.visibility + per-IP +
     // per-agent rate limits.
-    if (url.startsWith("/api/v1/public/")) return true;
-
     // Connect reimagining — inbound channel webhooks (Slack / Telegram /
     // WhatsApp / Discord). No per-scope session context: the caller is the
     // provider, not a Platos user. Auth is TWO-FACTOR and happens IN the
@@ -286,7 +372,7 @@ export class ScopeGuard implements CanActivate {
     // adapter verifies the provider signature (Slack HMAC / WhatsApp
     // X-Hub-Signature-256 / Discord Ed25519 / Telegram secret_token) using the
     // decrypted connection credentials. ScopeGuard just lets the request land.
-    if (url.startsWith("/api/v1/channels/inbound/")) return true;
+    if (isPublicChannelCallback(request.method, url)) return true;
 
     // Connect v3 — marketplace channel apps (Slack-first). Two PUBLIC
     // surfaces, each self-authenticating IN the controller (never here):
@@ -310,14 +396,6 @@ export class ScopeGuard implements CanActivate {
     // land. (The operator-only MANAGEMENT surface lives at
     // /api/v1/agent/channel-apps and is NOT bypassed — it runs under normal
     // scope extraction below.)
-    if (
-      url.startsWith("/api/v1/channels/oauth/") ||
-      url.startsWith("/api/v1/channels/apps/") ||
-      url.startsWith("/api/v1/channels/link/")
-    ) {
-      return true;
-    }
-
     // Theme K — Platform MCP. Authed by `Authorization: Bearer
     // <PLATOS_MCP_TOKEN>` on every request; token verification + scope
     // pin happens inside McpPlatformController. Token CRUD sub-routes
@@ -336,17 +414,7 @@ export class ScopeGuard implements CanActivate {
     // `/mcp` (the user-facing install URL — `claude mcp add platos
     // https://mcp.platos.dev/mcp`). Bypass scope auth for both forms +
     // their sub-routes (`/sse`, `/messages?sessionId=...`).
-    if (url.startsWith("/mcp/docs")) return true;
-    if (
-      url === "/mcp" ||
-      url.startsWith("/mcp?") ||
-      url === "/mcp/sse" ||
-      url.startsWith("/mcp/sse?") ||
-      url === "/mcp/messages" ||
-      url.startsWith("/mcp/messages?")
-    ) {
-      return true;
-    }
+    if (isPublicDocsMcpTransport(request.method, url)) return true;
 
     // PIFSP-21 — per-entity MCP Gateway. Self-auths via OAuth 2.1 bearer
     // tokens minted at `/oauth/entity/:entityId/*`. Routes validate the
@@ -371,36 +439,51 @@ export class ScopeGuard implements CanActivate {
     // PIFSP-21 — per-entity OAuth endpoints (`/oauth/entity/:entityId/*`)
     // and their metadata (`/.well-known/oauth-authorization-server/entity/*`)
     // fall through the same bypass — every route self-auths.
-    if (url.startsWith("/oauth/") || url === "/oauth" || url.startsWith("/.well-known/")) {
+    if (isPublicOAuthRoute(request.method, url)) {
       return true;
     }
 
     // Theme I.10 — OpenAPI spec + Swagger UI are intentionally public so
     // the docs site / agent-connect page can render without auth. The
     // spec is static (no scope-dependent data).
-    if (url.startsWith("/api/v1/agent/openapi.json") || url === "/openapi" || url.startsWith("/openapi?")) return true;
+    if (
+      request.method?.toUpperCase() === "GET" &&
+      (pathname === "/api/v1/agent/openapi.json" ||
+        pathname === "/openapi" ||
+        pathname.startsWith("/openapi/"))
+    )
+      return true;
 
     // PPR-25 — `/internal/execute-tool` is called by trigger.dev tasks
     // running inside the worker sandbox. It carries no per-scope context
     // of its own; the HMAC signature + scope-in-body + ToolExecutorService
     // registry lookup is the scope gate. ScopeGuard just lets the call
     // land on the controller, which verifies the HMAC before dispatching.
-    if (url.startsWith("/internal/execute-tool")) return true;
+    if (
+      request.method?.toUpperCase() === "POST" &&
+      (pathname === "/internal/execute-tool" || pathname === "/internal/env/invalidate")
+    )
+      return true;
     // W.1 — `/internal/batch-turn` follows the same pattern: HMAC-signed
     // callback from the `platos-agent-batch` trigger.dev task so it can
     // invoke AgentTaskService.executeNonStreamingTurn once per batch item.
-    if (url.startsWith("/internal/batch-turn")) return true;
+    if (request.method?.toUpperCase() === "POST" && pathname === "/internal/batch-turn")
+      return true;
     // Subagent spawning — `/internal/subagent-turn` is the per-turn callback
     // from the `platos.agent.subrun` trigger.dev task. Same HMAC-signed,
     // scope-in-body pattern as batch-turn, but it threads the CHILD thread id
     // through so multi-turn history accumulates on one thread. The controller
     // verifies the HMAC before running the turn.
-    if (url.startsWith("/internal/subagent-turn")) return true;
+    if (request.method?.toUpperCase() === "POST" && pathname === "/internal/subagent-turn")
+      return true;
 
     // WIN-132 — callback-only custom task execution. This route has no user
     // session; its controller performs the timing-safe internal-token check and
     // rejects every other auth path before parsing or executing the body.
-    if (url.split("?", 1)[0] === "/api/v1/agent/internal/jobs/execute") {
+    if (
+      request.method?.toUpperCase() === "POST" &&
+      pathname === "/api/v1/agent/internal/jobs/execute"
+    ) {
       return true;
     }
 
@@ -412,24 +495,23 @@ export class ScopeGuard implements CanActivate {
     // admin-tier `plt_mcp_` credential in ErasureController. ScopeGuard must let
     // the request reach that controller, but it must not accept any deployment
     // secret as authorization for irreversible erasure.
-    if (url.startsWith("/api/v1/agent/admin/privacy")) return true;
-
-    if (url.startsWith("/api/v1/agent/monitoring/cost/catalog")) {
-      const expected = env.PLATOS_INTERNAL_AUTH_TOKEN;
-      const provided = request.headers["x-platos-internal-auth"];
-      // BUG-6: timing-safe comparison to prevent timing oracle attacks.
-      if (expected && typeof provided === "string" && provided.length === expected.length) {
-        try {
-          if (crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return true;
-        } catch { /* length mismatch handled above */ }
-      }
-    }
-    // Theme M.5 / O.1 — scheduled memory-extraction sweep admin endpoint.
-    // Cross-scope by design (scans every thread in the monorepo). The
-    // controller re-verifies the token with a timing-safe compare.
+    const privacyRoute = pathname.match(
+      /^\/api\/v1\/agent\/admin\/privacy\/(subjects\/[^/]+\/inventory|erasures|erasures\/[^/]+|erasures\/[^/]+\/retry|erasures\/resume-due)$/,
+    );
     if (
-      url.startsWith("/api/v1/memory/admin/extraction-sweep") ||
-      url.startsWith("/api/v1/platos/memory/admin/extraction-sweep")
+      privacyRoute &&
+      ((request.method?.toUpperCase() === "GET" &&
+        (privacyRoute[1]?.startsWith("subjects/") ||
+          /^erasures\/[^/]+$/.test(privacyRoute[1] ?? ""))) ||
+        (request.method?.toUpperCase() === "POST" &&
+          (privacyRoute[1] === "erasures" ||
+            privacyRoute[1] === "erasures/resume-due" ||
+            privacyRoute[1]?.endsWith("/retry"))))
+    ) return true;
+
+    if (
+      request.method?.toUpperCase() === "POST" &&
+      pathname === "/api/v1/agent/monitoring/cost/catalog"
     ) {
       const expected = env.PLATOS_INTERNAL_AUTH_TOKEN;
       const provided = request.headers["x-platos-internal-auth"];
@@ -437,7 +519,28 @@ export class ScopeGuard implements CanActivate {
       if (expected && typeof provided === "string" && provided.length === expected.length) {
         try {
           if (crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return true;
-        } catch { /* length mismatch handled above */ }
+        } catch {
+          /* length mismatch handled above */
+        }
+      }
+    }
+    // Theme M.5 / O.1 — scheduled memory-extraction sweep admin endpoint.
+    // Cross-scope by design (scans every thread in the monorepo). The
+    // controller re-verifies the token with a timing-safe compare.
+    if (
+      request.method?.toUpperCase() === "POST" &&
+      (pathname === "/api/v1/memory/admin/extraction-sweep" ||
+        pathname === "/api/v1/platos/memory/admin/extraction-sweep")
+    ) {
+      const expected = env.PLATOS_INTERNAL_AUTH_TOKEN;
+      const provided = request.headers["x-platos-internal-auth"];
+      // BUG-6: timing-safe comparison to prevent timing oracle attacks.
+      if (expected && typeof provided === "string" && provided.length === expected.length) {
+        try {
+          if (crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return true;
+        } catch {
+          /* length mismatch handled above */
+        }
       }
     }
     // LAUNCH-11 — durable compaction callback. Trigger.dev worker POSTs
@@ -450,41 +553,43 @@ export class ScopeGuard implements CanActivate {
     // callbacks (durable-turn / employee-run / skill-run) use the same
     // admin-token gate + scope-in-body pattern as compaction.
     if (
-      url.startsWith("/api/v1/agent/internal/compaction") ||
-      url.startsWith("/api/v1/agent/internal/durable-turn") ||
-      url.startsWith("/api/v1/agent/internal/chat/stream-turn") ||
-      url.startsWith("/api/v1/agent/internal/chat/reap-sessions") ||
-      url.startsWith("/api/v1/agent/internal/employee-run") ||
-      url.startsWith("/api/v1/agent/internal/skill-run") ||
-      url.startsWith("/api/v1/agent/internal/budget-alert") ||
+      (request.method?.toUpperCase() === "POST" &&
+      (pathname === "/api/v1/agent/internal/compaction" ||
+      pathname === "/api/v1/agent/internal/durable-turn" ||
+      pathname === "/api/v1/agent/internal/chat/stream-turn" ||
+      pathname === "/api/v1/agent/internal/chat/reap-sessions" ||
+      pathname === "/api/v1/agent/internal/employee-run" ||
+      pathname === "/api/v1/agent/internal/skill-run" ||
+      pathname === "/api/v1/agent/internal/budget-alert" ||
       // Subagent report-back — the `platos.agent.subrun` task POSTs the child's
       // result here (admin-token gated + scope-in-body); the controller
       // re-verifies the token AND that the body's scope owns the parent
       // agent/thread before waking a durable parent turn.
-      url.startsWith("/api/v1/agent/internal/subagent-report") ||
+      pathname === "/api/v1/agent/internal/subagent-report" ||
       // Managed-cloud maintenance-task callbacks — same admin-token gate +
       // scope-in-body. These run as scheduled trigger.dev tasks on Trigger
       // Cloud and reach the agent through the public proxy; each controller
       // re-verifies the token with a timing-safe compare.
-      url.startsWith("/api/v1/agent/monitoring/dlq/drain") ||
-      url.startsWith("/api/v1/agent/monitoring/cost/reconcile") ||
-      url.startsWith("/api/v1/agent/monitoring/budget/email") ||
-      url.startsWith("/api/v1/agent/monitoring/approvals/expiry-sweep") ||
-      url.startsWith("/api/v1/agent/evals/sample") ||
-      url.startsWith("/api/v1/agent/evals/dispatch") ||
-      url.startsWith("/api/v1/agent/attachments/retention") ||
+      pathname === "/api/v1/agent/monitoring/dlq/drain" ||
+      pathname === "/api/v1/agent/monitoring/cost/reconcile" ||
+      pathname === "/api/v1/agent/monitoring/budget/email" ||
+      pathname === "/api/v1/agent/monitoring/approvals/expiry-sweep" ||
       // memory-extraction sweep callback (platos.memory.extract task). Note
       // the non-/agent prefix — served by the memory module's own controller;
       // needs its own Caddy route (/api/v1/memory/* → agent) or it lands on
       // the webapp and 401s with the callback-style problem+json.
-      url.startsWith("/api/v1/memory/admin/extraction-sweep")
+      pathname === "/api/v1/memory/admin/extraction-sweep")) ||
+      (request.method?.toUpperCase() === "GET" &&
+        pathname === "/api/v1/agent/monitoring/observability/status")
     ) {
       const expected = env.PLATOS_INTERNAL_AUTH_TOKEN;
       const provided = request.headers["x-platos-internal-auth"];
       if (expected && typeof provided === "string" && provided.length === expected.length) {
         try {
           if (crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected))) return true;
-        } catch { /* length mismatch handled above */ }
+        } catch {
+          /* length mismatch handled above */
+        }
       }
     }
 
@@ -529,7 +634,9 @@ export class ScopeGuard implements CanActivate {
                 ...(userMeta.email ? { email: userMeta.email } : {}),
               }
             : undefined;
-        const sessionContextFromToken = signedUserMeta ? { user: { ...signedUserMeta } } : undefined;
+        const sessionContextFromToken = signedUserMeta
+          ? { user: { ...signedUserMeta } }
+          : undefined;
 
         // Carry verified-identity claims onto the scope so downstream
         // ConversationService.resolveEndUser can link this turn to a canonical
@@ -564,9 +671,7 @@ export class ScopeGuard implements CanActivate {
               : "end-user",
           ...(tokenAgentId ? { agentId: tokenAgentId } : {}),
           ...(tokenUserIdentities ? { userIdentities: tokenUserIdentities } : {}),
-          ...(sessionContextFromToken
-            ? { sessionContext: sessionContextFromToken }
-            : {}),
+          ...(sessionContextFromToken ? { sessionContext: sessionContextFromToken } : {}),
           // WIN-133 — the same values, kept apart from the prompt bag so the
           // analytical projection can tell a signature from a merge. See
           // RequestScope.signedUserMeta.
@@ -576,17 +681,28 @@ export class ScopeGuard implements CanActivate {
         // Access key check (if configured for this scope)
         if (this.authService) {
           const providedKey = request.headers["x-platos-api-key"] as string | undefined;
-          const origin = (request.headers["origin"] || request.headers["referer"]) as string | undefined;
+          const origin = (request.headers["origin"] || request.headers["referer"]) as
+            | string
+            | undefined;
           const scopeForCheck = {
             organizationId: request.scope.organizationId,
             projectId: request.scope.projectId,
             environmentId: request.scope.environmentId,
             userId: request.scope.userId,
           };
-          const keyResult = await this.authService.verifyAccessKey(scopeForCheck, providedKey, origin);
+          const keyResult = await this.authService.verifyAccessKey(
+            scopeForCheck,
+            providedKey,
+            origin
+          );
           if (keyResult === false) {
             const resp = context.switchToHttp().getResponse();
-            resp.status(401).json({ error: "INVALID_ACCESS_KEY", message: "X-Platos-Api-Key is missing or invalid for this scope." });
+            resp
+              .status(401)
+              .json({
+                error: "INVALID_ACCESS_KEY",
+                message: "X-Platos-Api-Key is missing or invalid for this scope.",
+              });
             return false;
           }
         }
@@ -617,14 +733,14 @@ export class ScopeGuard implements CanActivate {
         const validPin =
           controlPlaneAuthenticated &&
           this.authService &&
-          await this.authService.validateOperatorAgentPin(
+          (await this.authService.validateOperatorAgentPin(
             {
               organizationId: String(organizationId),
               projectId: String(projectId),
               environmentId: String(environmentId),
             },
-            String(requestedAgentId),
-          );
+            String(requestedAgentId)
+          ));
         if (!validPin) {
           const resp = context.switchToHttp().getResponse();
           resp.status(403).json({
@@ -661,17 +777,28 @@ export class ScopeGuard implements CanActivate {
         !this.hasValidControlPlaneAuth(request)
       ) {
         const providedKey = request.headers["x-platos-api-key"] as string | undefined;
-        const origin = (request.headers["origin"] || request.headers["referer"]) as string | undefined;
+        const origin = (request.headers["origin"] || request.headers["referer"]) as
+          | string
+          | undefined;
         const scopeForCheck = {
           organizationId: request.scope.organizationId,
           projectId: request.scope.projectId,
           environmentId: request.scope.environmentId,
           userId: request.scope.userId,
         };
-        const keyResult = await this.authService.verifyAccessKey(scopeForCheck, providedKey, origin);
+        const keyResult = await this.authService.verifyAccessKey(
+          scopeForCheck,
+          providedKey,
+          origin
+        );
         if (keyResult === false) {
           const resp = context.switchToHttp().getResponse();
-          resp.status(401).json({ error: "INVALID_ACCESS_KEY", message: "X-Platos-Api-Key is missing or invalid for this scope." });
+          resp
+            .status(401)
+            .json({
+              error: "INVALID_ACCESS_KEY",
+              message: "X-Platos-Api-Key is missing or invalid for this scope.",
+            });
           return false;
         }
       }

--- a/apps/agent/src/mcp-platform/mcp-platform-management.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform-management.test.ts
@@ -14,15 +14,33 @@ function harness() {
   controller.tokenService = {
     revoke: vi.fn(),
     list: vi.fn(),
+    verifyById: vi.fn(),
   };
+  controller.oauth = { verifyAccessTokenHash: vi.fn() };
+  controller.redis = {
+    get: vi.fn(),
+    del: vi.fn().mockResolvedValue(1),
+    publish: vi.fn().mockResolvedValue(1),
+  };
+  controller.router = { handle: vi.fn() };
   return controller;
+}
+
+function responseHarness() {
+  const response: any = {
+    status: vi.fn(),
+    send: vi.fn(),
+  };
+  response.status.mockReturnValue(response);
+  return response;
 }
 
 describe("McpPlatformController management", () => {
   it("rejects end-user token inventory access", async () => {
     const controller = harness();
-    await expect(controller.listTokens({ scope: { ...operatorScope, principal: "end-user" } }))
-      .rejects.toMatchObject({ status: 403 });
+    await expect(
+      controller.listTokens({ scope: { ...operatorScope, principal: "end-user" } })
+    ).rejects.toMatchObject({ status: 403 });
     expect(controller.tokenService.list).not.toHaveBeenCalled();
   });
 
@@ -30,10 +48,70 @@ describe("McpPlatformController management", () => {
     const controller = harness();
     controller.tokenService.revoke.mockResolvedValue(false);
 
-    await expect(controller.revokeToken({ scope: operatorScope }, "foreign-token", undefined))
-      .rejects.toMatchObject({
-        status: 404,
-        response: { code: "MCP_TOKEN_NOT_FOUND", message: "MCP token not found" },
-      });
+    await expect(
+      controller.revokeToken({ scope: operatorScope }, "foreign-token", undefined)
+    ).rejects.toMatchObject({
+      status: 404,
+      response: { code: "MCP_TOKEN_NOT_FOUND", message: "MCP token not found" },
+    });
+  });
+
+  it("rejects a revoked Platform token before dispatching an SSE message", async () => {
+    const controller = harness();
+    const response = responseHarness();
+    controller.redis.get.mockResolvedValue(
+      JSON.stringify({
+        credential: { kind: "platform", tokenId: "token_1" },
+      })
+    );
+    controller.tokenService.verifyById.mockResolvedValue(null);
+
+    await controller.messages(
+      "session_1",
+      undefined,
+      { jsonrpc: "2.0", id: 1, method: "tools/list" },
+      response
+    );
+
+    expect(controller.tokenService.verifyById).toHaveBeenCalledWith("token_1");
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(controller.router.handle).not.toHaveBeenCalled();
+    expect(controller.redis.del).toHaveBeenCalledWith("platos:mcp:platform:session:session_1");
+  });
+
+  it("routes an SSE response through Redis using freshly revalidated authority", async () => {
+    const controller = harness();
+    const response = responseHarness();
+    const freshToken = {
+      id: "token_1",
+      scope: operatorScope,
+      permissions: ["*"],
+      mintedByUserId: operatorScope.userId,
+      expiresAt: null,
+      tier: "scope",
+      credential: { kind: "platform", tokenId: "token_1" },
+    };
+    const request = { jsonrpc: "2.0", id: 1, method: "tools/list" };
+    const rpcResponse = { jsonrpc: "2.0", id: 1, result: { tools: [] } };
+    controller.redis.get.mockResolvedValue(
+      JSON.stringify({
+        credential: freshToken.credential,
+      })
+    );
+    controller.tokenService.verifyById.mockResolvedValue(freshToken);
+    controller.router.handle.mockResolvedValue(rpcResponse);
+
+    await controller.messages("session_1", undefined, request, response);
+
+    expect(response.status).toHaveBeenCalledWith(202);
+    expect(controller.router.handle).toHaveBeenCalledWith(
+      request,
+      freshToken,
+      expect.objectContaining({ approvalId: null })
+    );
+    expect(controller.redis.publish).toHaveBeenCalledWith(
+      "platos:mcp:platform:sse:session_1",
+      JSON.stringify(rpcResponse)
+    );
   });
 });

--- a/apps/agent/src/mcp-platform/mcp-platform.controller.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform.controller.ts
@@ -14,20 +14,13 @@ import {
   Res,
 } from "@nestjs/common";
 import { ModuleRef } from "@nestjs/core";
-import {
-  PLATOS_SECRET_STORE_TOKEN,
-  PRISMA_TOKEN,
-} from "../shared/database.provider";
+import { PLATOS_SECRET_STORE_TOKEN, PRISMA_TOKEN } from "../shared/database.provider";
 import type { PlatosSecretStore } from "@platos/tenancy-database";
 import type { Request, Response } from "express";
 import * as crypto from "node:crypto";
 import { PlatosMCPTokenService, AdminMintForbiddenError } from "./token.service";
 import type { VerifiedToken, PlatosMCPTokenTier } from "./token.service";
-import {
-  McpRouter,
-  type JsonRpcRequest,
-  type McpApprovalGate,
-} from "./mcp-router";
+import { McpRouter, type JsonRpcRequest, type McpApprovalGate } from "./mcp-router";
 import { MCPPermissionGatewayService } from "./permission-gateway.service";
 import { buildPlatformToolHandlers } from "./tools";
 import { MacroRecordingState } from "./tools/macros";
@@ -99,7 +92,6 @@ import type { McpStdioSession } from "./stdio-transport";
 @Controller("mcp/platform")
 export class McpPlatformController {
   private router: McpRouter | null = null;
-  private readonly sessions = new Map<string, SseSession>();
   /**
    * K.17 — in-memory macro recording state. Lives on the controller
    * singleton so the MCP router's record-hook + the `macros.*` tool
@@ -162,7 +154,7 @@ export class McpPlatformController {
     @Inject(PLATOS_SECRET_STORE_TOKEN) private readonly secretStore: PlatosSecretStore,
     @Inject(REDIS_TOKEN) private readonly redis: Redis,
     // Lazy resolution of ChannelRuntimeService (see invalidateChannelRuntime).
-    private readonly moduleRef: ModuleRef,
+    private readonly moduleRef: ModuleRef
   ) {}
 
   private getRouter(): McpRouter {
@@ -177,7 +169,7 @@ export class McpPlatformController {
           principal: "operator",
         }),
       },
-      this.permissionGateway,
+      this.permissionGateway
     );
     router.registerAll(
       buildPlatformToolHandlers({
@@ -239,9 +231,7 @@ export class McpPlatformController {
         // resolution failure must never fail the tool call.
         invalidateChannelRuntime: (connectionId: string) => {
           try {
-            this.moduleRef
-              .get(ChannelRuntimeService, { strict: false })
-              ?.invalidate(connectionId);
+            this.moduleRef.get(ChannelRuntimeService, { strict: false })?.invalidate(connectionId);
           } catch {
             // ChannelsModule absent — the runtime TTL bounds staleness.
           }
@@ -252,14 +242,12 @@ export class McpPlatformController {
         // Same lazy ModuleRef pattern; best-effort.
         invalidateChannelApp: (appId: string) => {
           try {
-            this.moduleRef
-              .get(ChannelRuntimeService, { strict: false })
-              ?.invalidateApp(appId);
+            this.moduleRef.get(ChannelRuntimeService, { strict: false })?.invalidateApp(appId);
           } catch {
             // ChannelsModule absent — the runtime TTL bounds staleness.
           }
         },
-      }),
+      })
     );
     // K.17 — attach recorder so the router captures successful tool
     // calls into any in-progress recording for the token.
@@ -275,7 +263,7 @@ export class McpPlatformController {
     if (approvalsEnabled) {
       const ttlSeconds = Math.max(
         60,
-        Number.parseInt(process.env["MCP_APPROVAL_TTL_SECONDS"] ?? "3600", 10) || 3600,
+        Number.parseInt(process.env["MCP_APPROVAL_TTL_SECONDS"] ?? "3600", 10) || 3600
       );
       const approvals = this.approvals;
       const gate: McpApprovalGate = {
@@ -286,7 +274,7 @@ export class McpPlatformController {
               projectId: scope.projectId,
               environmentId: scope.environmentId,
             },
-            approvalId,
+            approvalId
           ),
         create: (input) =>
           approvals.createMcpApproval({
@@ -310,7 +298,7 @@ export class McpPlatformController {
               environmentId: scope.environmentId,
             },
             approvalId,
-            resolution,
+            resolution
           ),
         hash: (scope, toolName, args) =>
           MonitoringApprovalsService.computeRequestHash(
@@ -320,7 +308,7 @@ export class McpPlatformController {
               environmentId: scope.environmentId,
             },
             toolName,
-            args,
+            args
           ),
       };
       router.setApprovalGate(gate, ttlSeconds);
@@ -374,9 +362,49 @@ export class McpPlatformController {
         mintedByUserId: oa.userId,
         expiresAt: oa.expiresAt,
         tier: "scope",
+        credential: { kind: "oauth", tokenHash: oa.tokenHash },
       };
     }
     return this.tokenService.verify(raw);
+  }
+
+  /** Revalidate the non-secret credential reference persisted for an SSE session. */
+  private async verifySseCredential(
+    credential: VerifiedToken["credential"]
+  ): Promise<VerifiedToken | null> {
+    if (!credential) return null;
+    if (credential.kind === "platform") {
+      return this.tokenService.verifyById(credential.tokenId);
+    }
+    const oa = await this.oauth.verifyAccessTokenHash(credential.tokenHash);
+    if (!oa || oa.entityPk) return null;
+    return {
+      id: oa.tokenHash.slice(0, 16),
+      scope: {
+        organizationId: oa.scope.organizationId,
+        projectId: oa.scope.projectId,
+        environmentId: oa.scope.environmentId,
+      },
+      permissions: oa.scopes.includes("mcp:write")
+        ? ["*"]
+        : ["*.list", "*.get", "platos_whoami", "platos_list_accessible_scopes"],
+      mintedByUserId: oa.userId,
+      expiresAt: oa.expiresAt,
+      tier: "scope",
+      credential,
+    };
+  }
+
+  private parseSseCredential(value: unknown): VerifiedToken["credential"] {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+    const candidate = value as Record<string, unknown>;
+    if (candidate["kind"] === "platform" && typeof candidate["tokenId"] === "string") {
+      return { kind: "platform", tokenId: candidate["tokenId"] };
+    }
+    if (candidate["kind"] === "oauth" && typeof candidate["tokenHash"] === "string") {
+      return { kind: "oauth", tokenHash: candidate["tokenHash"] };
+    }
+    return undefined;
   }
 
   /**
@@ -422,7 +450,7 @@ export class McpPlatformController {
             approvalId: typeof approvalId === "string" ? approvalId : null,
             dashboardOrigin:
               process.env["APP_ORIGIN"] ?? process.env["PLATOS_WEBAPP_ORIGIN"] ?? null,
-          },
+          }
         );
       },
     };
@@ -432,13 +460,13 @@ export class McpPlatformController {
   async jsonRpc(
     @Headers("authorization") authorization: string | undefined,
     @Headers("x-platos-approval-id") approvalIdHeader: string | undefined,
-    @Body() body: JsonRpcRequest,
+    @Body() body: JsonRpcRequest
   ): Promise<any> {
     const bearer = this.extractBearer(authorization);
     if (!bearer) {
       throw new HttpException(
         "Authorization: Bearer <PLATOS_MCP_TOKEN> required",
-        HttpStatus.UNAUTHORIZED,
+        HttpStatus.UNAUTHORIZED
       );
     }
     const token = await this.verifyAnyBearer(bearer);
@@ -448,7 +476,7 @@ export class McpPlatformController {
     if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
       throw new HttpException(
         "body must be a JSON-RPC 2.0 request with `method`",
-        HttpStatus.BAD_REQUEST,
+        HttpStatus.BAD_REQUEST
       );
     }
     return this.getRouter().handle(body, token, {
@@ -461,7 +489,7 @@ export class McpPlatformController {
   async sse(
     @Req() req: Request,
     @Res() res: Response,
-    @Headers("authorization") authorization: string | undefined,
+    @Headers("authorization") authorization: string | undefined
   ): Promise<void> {
     const bearer = this.extractBearer(authorization);
     if (!bearer) {
@@ -485,6 +513,47 @@ export class McpPlatformController {
     // the client should send JSON-RPC requests to; we tag the URL
     // with `sessionId` so we can route responses back on this stream.
     const sessionId = crypto.randomBytes(16).toString("hex");
+    if (!token.credential) {
+      res.write('event: error\ndata: {"message":"session credential unavailable"}\n\n');
+      res.end();
+      return;
+    }
+    const sessionKey = `platos:mcp:platform:session:${sessionId}`;
+    const sseChannel = `platos:mcp:platform:sse:${sessionId}`;
+    try {
+      await this.redis.set(
+        sessionKey,
+        JSON.stringify({ credential: token.credential }),
+        "EX",
+        3600
+      );
+    } catch {
+      res.write('event: error\ndata: {"message":"session store unavailable"}\n\n');
+      res.end();
+      return;
+    }
+
+    const sub = this.redis.duplicate();
+    try {
+      await sub.subscribe(sseChannel);
+    } catch {
+      await this.redis.del(sessionKey).catch(() => undefined);
+      await sub.quit().catch(() => undefined);
+      res.write('event: error\ndata: {"message":"session transport unavailable"}\n\n');
+      res.end();
+      return;
+    }
+    const onMessage = (_channel: string, message: string) => {
+      try {
+        res.write(`event: message\ndata: ${message}\n\n`);
+      } catch {
+        /* socket closed — cleanup fires */
+      }
+    };
+    sub.on("message", onMessage);
+
+    // Advertise the POST endpoint only after the shared session record and
+    // subscriber are ready; otherwise a fast client can race the Redis write.
     const endpointUrl = `/mcp/platform/messages?sessionId=${sessionId}`;
     res.write(`event: endpoint\ndata: ${endpointUrl}\n\n`);
 
@@ -500,16 +569,15 @@ export class McpPlatformController {
       }
     }, 30_000);
 
-    // BUG-18: sessions are stored in-memory on this controller instance.
-    // On agent restart all SSE sessions are lost and MCP clients must
-    // reconnect. TODO(redis-sessions): migrate to Redis-backed session
-    // store (same pattern as McpEntityController) for multi-replica safety.
-    // For now, ensure cleanup fires on disconnect so memory doesn't leak.
-    this.sessions.set(sessionId, { token, res, pingInterval });
-
+    let cleanedUp = false;
     const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
       clearInterval(pingInterval);
-      this.sessions.delete(sessionId);
+      sub.off("message", onMessage);
+      sub.unsubscribe(sseChannel).catch(() => undefined);
+      sub.quit().catch(() => undefined);
+      this.redis.del(sessionKey).catch(() => undefined);
       try {
         res.end();
       } catch {
@@ -525,15 +593,36 @@ export class McpPlatformController {
     @Query("sessionId") sessionId: string | undefined,
     @Headers("x-platos-approval-id") approvalIdHeader: string | undefined,
     @Body() body: JsonRpcRequest,
-    @Res() res: Response,
+    @Res() res: Response
   ): Promise<void> {
     if (!sessionId) {
       res.status(400).send("missing sessionId query param");
       return;
     }
-    const session = this.sessions.get(sessionId);
-    if (!session) {
+    const sessionKey = `platos:mcp:platform:session:${sessionId}`;
+    const rawSession = await this.redis.get(sessionKey).catch(() => null);
+    if (!rawSession) {
       res.status(404).send("unknown or expired sessionId");
+      return;
+    }
+    let credential: VerifiedToken["credential"];
+    try {
+      credential = this.parseSseCredential(
+        (JSON.parse(rawSession) as { credential?: unknown }).credential
+      );
+    } catch {
+      res.status(500).send("corrupt session record");
+      return;
+    }
+    if (!credential) {
+      await this.redis.del(sessionKey).catch(() => undefined);
+      res.status(500).send("corrupt session record");
+      return;
+    }
+    const token = await this.verifySseCredential(credential);
+    if (!token) {
+      await this.redis.del(sessionKey).catch(() => undefined);
+      res.status(401).send("session token revoked or expired");
       return;
     }
     if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
@@ -546,13 +635,11 @@ export class McpPlatformController {
     res.status(202).send();
 
     try {
-      const response = await this.getRouter().handle(body, session.token, {
+      const response = await this.getRouter().handle(body, token, {
         approvalId: approvalIdHeader ?? null,
-        dashboardOrigin:
-          process.env["APP_ORIGIN"] ?? process.env["PLATOS_WEBAPP_ORIGIN"] ?? null,
+        dashboardOrigin: process.env["APP_ORIGIN"] ?? process.env["PLATOS_WEBAPP_ORIGIN"] ?? null,
       });
-      const frame = `event: message\ndata: ${JSON.stringify(response)}\n\n`;
-      session.res.write(frame);
+      await this.redis.publish(`platos:mcp:platform:sse:${sessionId}`, JSON.stringify(response));
     } catch (err) {
       const rpcError = {
         jsonrpc: "2.0" as const,
@@ -562,7 +649,7 @@ export class McpPlatformController {
           message: err instanceof Error ? err.message : "internal error",
         },
       };
-      session.res.write(`event: message\ndata: ${JSON.stringify(rpcError)}\n\n`);
+      await this.redis.publish(`platos:mcp:platform:sse:${sessionId}`, JSON.stringify(rpcError));
     }
   }
 
@@ -582,7 +669,7 @@ export class McpPlatformController {
     @Req() req: Request,
     @Res() res: Response,
     @Query("token") tokenParam: string | undefined,
-    @Query("filters") filtersParam: string | undefined,
+    @Query("filters") filtersParam: string | undefined
   ): Promise<void> {
     if (!tokenParam) {
       res.status(401).send("token query param required");
@@ -635,7 +722,7 @@ export class McpPlatformController {
         scope: verified.scope,
         filters,
         channel: scopeChannel,
-      })}\n\n`,
+      })}\n\n`
     );
 
     const matchesType = (eventType: string) => {
@@ -662,7 +749,7 @@ export class McpPlatformController {
       res.write(
         `event: error\ndata: ${JSON.stringify({
           message: err instanceof Error ? err.message : String(err),
-        })}\n\n`,
+        })}\n\n`
       );
       try {
         await sub.quit();
@@ -729,7 +816,8 @@ export class McpPlatformController {
   @Post("tokens")
   async mintToken(
     @Req() req: Request,
-    @Body() body: {
+    @Body()
+    body: {
       name: string;
       permissions: string[];
       ttlSeconds?: number;
@@ -738,7 +826,7 @@ export class McpPlatformController {
        * caller to be an org ADMIN (enforced in TokenService.mint()).
        */
       tier?: PlatosMCPTokenTier;
-    },
+    }
   ) {
     const scope = (req as any).scope as RequestScope | undefined;
     if (!scope) throw new HttpException("unauthenticated", HttpStatus.UNAUTHORIZED);
@@ -767,7 +855,7 @@ export class McpPlatformController {
   async listTokens(
     @Req() req: Request,
     @Query("limit") limit?: string,
-    @Query("offset") offset?: string,
+    @Query("offset") offset?: string
   ) {
     const scope = (req as any).scope as RequestScope | undefined;
     if (!scope) throw new HttpException("unauthenticated", HttpStatus.UNAUTHORIZED);
@@ -782,11 +870,7 @@ export class McpPlatformController {
   }
 
   @Post("tokens/:id/revoke")
-  async revokeToken(
-    @Req() req: Request,
-    @Param("id") id: string,
-    @Body() _body: unknown,
-  ) {
+  async revokeToken(@Req() req: Request, @Param("id") id: string, @Body() _body: unknown) {
     const scope = (req as any).scope as RequestScope | undefined;
     if (!scope) throw new HttpException("unauthenticated", HttpStatus.UNAUTHORIZED);
     // SECURITY (audit authz-2026-07-22 F5) — token revocation is an operator
@@ -835,9 +919,7 @@ export class McpPlatformController {
       // ("platos.platform"), too broad for the picker, so the name
       // prefix wins; the stamped category is only a fallback for an
       // (unexpected) dotless name.
-      const category = h.name.includes(".")
-        ? h.name.split(".")[0]!
-        : h.category ?? "other";
+      const category = h.name.includes(".") ? h.name.split(".")[0]! : h.category ?? "other";
       const list = byCategory.get(category) ?? [];
       list.push({
         name: h.name,
@@ -868,10 +950,4 @@ export class McpPlatformController {
       categories,
     };
   }
-}
-
-interface SseSession {
-  token: VerifiedToken;
-  res: Response;
-  pingInterval: NodeJS.Timeout;
 }

--- a/apps/agent/src/mcp-platform/token.service.test.ts
+++ b/apps/agent/src/mcp-platform/token.service.test.ts
@@ -67,7 +67,7 @@ describe("PlatosMCPTokenService clean-tenancy lifecycle", () => {
         scope: { ...scope, organizationId: "forged_org" },
         name: "automation",
         permissions: ["agents.read"],
-      }),
+      })
     ).rejects.toThrow("Environment not found in scope");
     expect(prisma.mcpToken.create).not.toHaveBeenCalled();
   });
@@ -113,11 +113,32 @@ describe("PlatosMCPTokenService clean-tenancy lifecycle", () => {
     await expect(service.verify("plt_mcp_valid")).resolves.toBeNull();
   });
 
+  it("revalidates an established transport by opaque row id without a raw bearer", async () => {
+    prisma.mcpToken.findUnique.mockResolvedValue({
+      id: "token_1",
+      tokenHash: tokenHash("plt_mcp_valid"),
+      permissions: ["agents.read"],
+      mintedByUserId: "user_1",
+      expiresAt: new Date(Date.now() + 60_000),
+      revokedAt: null,
+      tier: "scope",
+      environment: { id: "env_1", project: { id: "proj_1", organizationId: "org_1" } },
+    });
+
+    await expect(service.verifyById("token_1")).resolves.toMatchObject({
+      id: "token_1",
+      credential: { kind: "platform", tokenId: "token_1" },
+    });
+    expect(prisma.mcpToken.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: "token_1" } })
+    );
+  });
+
   it("uses canonical organization ancestry for the admin-tier role gate", async () => {
     prisma.organizationMembership.findFirst.mockResolvedValue(null);
 
     await expect(
-      service.mint({ ...({ scope, name: "admin", permissions: ["*"] }), tier: "admin" }),
+      service.mint({ ...{ scope, name: "admin", permissions: ["*"] }, tier: "admin" })
     ).rejects.toBeInstanceOf(AdminMintForbiddenError);
     expect(prisma.organizationMembership.findFirst).toHaveBeenCalledWith({
       where: {
@@ -134,11 +155,33 @@ describe("PlatosMCPTokenService clean-tenancy lifecycle", () => {
     const createdAt = new Date("2026-08-14T00:00:00.000Z");
     prisma.mcpToken.count.mockResolvedValue(3);
     prisma.mcpToken.findMany.mockResolvedValue([
-      { id: "token_2", name: "two", permissions: ["agents.read"], tier: "scope", mintedByUserId: "user_1", expiresAt: null, lastUsedAt: null, revokedAt: null, createdAt },
+      {
+        id: "token_2",
+        name: "two",
+        permissions: ["agents.read"],
+        tier: "scope",
+        mintedByUserId: "user_1",
+        expiresAt: null,
+        lastUsedAt: null,
+        revokedAt: null,
+        createdAt,
+      },
     ]);
 
     await expect(service.list(scope, { limit: 1, offset: 1 })).resolves.toEqual({
-      tokens: [{ id: "token_2", name: "two", permissions: ["agents.read"], tier: "scope", mintedByUserId: "user_1", expiresAt: null, lastUsedAt: null, revokedAt: null, createdAt }],
+      tokens: [
+        {
+          id: "token_2",
+          name: "two",
+          permissions: ["agents.read"],
+          tier: "scope",
+          mintedByUserId: "user_1",
+          expiresAt: null,
+          lastUsedAt: null,
+          revokedAt: null,
+          createdAt,
+        },
+      ],
       total: 3,
       limit: 1,
       offset: 1,
@@ -149,9 +192,11 @@ describe("PlatosMCPTokenService clean-tenancy lifecycle", () => {
         orderBy: [{ createdAt: "desc" }, { id: "desc" }],
         skip: 1,
         take: 1,
-      }),
+      })
     );
-    await expect(service.list(scope, { limit: Number.NaN, offset: Number.NaN })).resolves.toMatchObject({
+    await expect(
+      service.list(scope, { limit: Number.NaN, offset: Number.NaN })
+    ).resolves.toMatchObject({
       total: 3,
       limit: 50,
       offset: 0,
@@ -179,10 +224,9 @@ describe("PlatosMCPTokenService clean-tenancy lifecycle", () => {
       return { count: 1 };
     });
 
-    await expect(Promise.all([
-      service.revoke("token_1", scope),
-      service.revoke("token_1", scope),
-    ])).resolves.toEqual([true, true]);
+    await expect(
+      Promise.all([service.revoke("token_1", scope), service.revoke("token_1", scope)])
+    ).resolves.toEqual([true, true]);
     await expect(service.revoke("token_1", scope)).resolves.toBe(true);
 
     expect(row).toMatchObject({ revokedAt: expect.any(Date), revokedBy: "user_1" });

--- a/apps/agent/src/mcp-platform/token.service.ts
+++ b/apps/agent/src/mcp-platform/token.service.ts
@@ -40,14 +40,20 @@ export interface VerifiedToken {
   mintedByUserId: string;
   expiresAt: Date | null;
   tier: PlatosMCPTokenTier;
+  /** Opaque persisted credential reference used to revalidate long-lived
+   * transports without retaining the raw bearer in memory. */
+  credential?: { kind: "platform"; tokenId: string } | { kind: "oauth"; tokenHash: string };
 }
 
 const DEFAULT_TTL_SECONDS = 90 * 24 * 3600;
 
-function boundedInteger(value: number | undefined, fallback: number, minimum: number, maximum: number): number {
-  return Number.isInteger(value)
-    ? Math.max(minimum, Math.min(maximum, value as number))
-    : fallback;
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number
+): number {
+  return Number.isInteger(value) ? Math.max(minimum, Math.min(maximum, value as number)) : fallback;
 }
 const TOKEN_PREFIX = "plt_mcp_";
 
@@ -56,7 +62,7 @@ type ScopeTuple = Pick<RequestScope, "organizationId" | "projectId" | "environme
 export class AdminMintForbiddenError extends Error {
   constructor(userId: string, organizationId: string) {
     super(
-      `user ${userId} is not an owner or admin of organization ${organizationId} — admin-tier MCP tokens are reserved for organization administrators`,
+      `user ${userId} is not an owner or admin of organization ${organizationId} — admin-tier MCP tokens are reserved for organization administrators`
     );
     this.name = "AdminMintForbiddenError";
   }
@@ -182,8 +188,21 @@ export class PlatosMCPTokenService {
       return null;
     }
     const tokenHash = this.hashToken(raw);
+    return this.verifyPersisted({ tokenHash }, tokenHash);
+  }
+
+  /** Revalidate an established SSE session without storing its raw bearer. */
+  async verifyById(id: string): Promise<VerifiedToken | null> {
+    if (!id) return null;
+    return this.verifyPersisted({ id });
+  }
+
+  private async verifyPersisted(
+    where: { id: string } | { tokenHash: string },
+    expectedHash?: string
+  ): Promise<VerifiedToken | null> {
     const row = await this.prisma.mcpToken.findUnique({
-      where: { tokenHash },
+      where,
       select: {
         id: true,
         tokenHash: true,
@@ -200,7 +219,12 @@ export class PlatosMCPTokenService {
         },
       },
     });
-    if (!row || !constantTimeHexEqual(row.tokenHash, tokenHash) || row.revokedAt) return null;
+    if (
+      !row ||
+      (expectedHash && !constantTimeHexEqual(row.tokenHash, expectedHash)) ||
+      row.revokedAt
+    )
+      return null;
     if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return null;
 
     const updated = await this.prisma.mcpToken.updateMany({
@@ -224,16 +248,16 @@ export class PlatosMCPTokenService {
       mintedByUserId: row.mintedByUserId,
       expiresAt: row.expiresAt,
       tier: normalizeTier(row.tier),
+      credential: { kind: "platform", tokenId: row.id },
     };
   }
 
   /** List redacted token metadata for a canonically resolved Environment. */
   async list(
     scope: ScopeTuple,
-    options: { limit?: number; offset?: number } = {},
-  ): Promise<
-    {
-      tokens: Array<{
+    options: { limit?: number; offset?: number } = {}
+  ): Promise<{
+    tokens: Array<{
       id: string;
       name: string;
       permissions: string[];
@@ -243,12 +267,11 @@ export class PlatosMCPTokenService {
       lastUsedAt: Date | null;
       revokedAt: Date | null;
       createdAt: Date;
-      }>;
-      total: number;
-      limit: number;
-      offset: number;
-    }
-  > {
+    }>;
+    total: number;
+    limit: number;
+    offset: number;
+  }> {
     const canonical = await this.resolveScope(scope);
     const limit = boundedInteger(options.limit, 50, 1, 100);
     const offset = boundedInteger(options.offset, 0, 0, Number.MAX_SAFE_INTEGER);
@@ -291,7 +314,7 @@ export class PlatosMCPTokenService {
   /** Idempotently revoke a token in the caller's canonical Environment. */
   async revoke(
     id: string,
-    scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId" | "userId">,
+    scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId" | "userId">
   ): Promise<boolean> {
     const canonical = await this.resolveScope(scope);
     if (!canonical) return false;

--- a/apps/agent/src/oauth/oauth.controller.test.ts
+++ b/apps/agent/src/oauth/oauth.controller.test.ts
@@ -23,11 +23,13 @@ const environment = {
   project: {
     id: "project_1",
     organizationId: "org_1",
-    entities: [{
-      id: "entity_1",
-      displayName: "Acme",
-      mcpConfig: { enabled: true, redirectUriAllowlist: [] },
-    }],
+    entities: [
+      {
+        id: "entity_1",
+        displayName: "Acme",
+        mcpConfig: { enabled: true, redirectUriAllowlist: [] },
+      },
+    ],
   },
 };
 
@@ -108,7 +110,7 @@ describe("OAuthController entity environment contract", () => {
     expect(h.prisma.environment.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({ id: "env_1", archivedAt: null }),
-      }),
+      })
     );
   });
 
@@ -127,7 +129,7 @@ describe("OAuthController entity environment contract", () => {
       "state_1",
       "challenge_1",
       "S256",
-      "env_1",
+      "env_1"
     );
 
     const consent = new URL(res.redirect.mock.calls[0]![1]);
@@ -144,6 +146,7 @@ describe("OAuthController entity environment contract", () => {
         type: "oauth2_pkce",
         authorizationUrl: "https://identity.example/authorize",
         tokenUrl: "https://identity.example/token",
+        userInfoUrl: "https://identity.example/userinfo",
         clientId: "entity-client",
         clientSecret: "entity-client-secret",
         scopes: ["openid", "email"],
@@ -153,14 +156,16 @@ describe("OAuthController entity environment contract", () => {
       ...environment,
       project: {
         ...environment.project,
-        entities: [{
-          ...environment.project.entities[0],
-          mcpConfig: {
-            enabled: true,
-            identityMode: "bearer+oidc+anonymous",
-            identityProviders,
+        entities: [
+          {
+            ...environment.project.entities[0],
+            mcpConfig: {
+              enabled: true,
+              identityMode: "bearer+oidc+anonymous",
+              identityProviders,
+            },
           },
-        }],
+        ],
       },
     });
     const consent = {
@@ -185,12 +190,12 @@ describe("OAuthController entity environment contract", () => {
       "acme",
       {} as any,
       redirectRes as any,
-      "consent_transaction_1",
+      "consent_transaction_1"
     );
 
     const providerRedirect = new URL(redirectRes.redirect.mock.calls[0]![1]);
     expect(providerRedirect.origin + providerRedirect.pathname).toBe(
-      "https://identity.example/authorize",
+      "https://identity.example/authorize"
     );
     expect(providerRedirect.searchParams.get("client_id")).toBe("entity-client");
     expect(providerRedirect.searchParams.get("scope")).toBe("openid email");
@@ -198,21 +203,31 @@ describe("OAuthController entity environment contract", () => {
     const signedState = providerRedirect.searchParams.get("state");
     expect(signedState).toBeTruthy();
 
-    const idToken = [
-      Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
-      Buffer.from(JSON.stringify({ sub: "user_1", email: "user@example.com" })).toString("base64url"),
-      "signature",
-    ].join(".");
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        access_token: "provider_access_token",
-        refresh_token: "provider_refresh_token",
-        expires_in: 3600,
-        id_token: idToken,
-      }),
-      text: vi.fn(),
-    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          access_token: "provider_access_token",
+          refresh_token: "provider_refresh_token",
+          expires_in: 3600,
+          // Deliberately unsigned and contradictory: identity must come from
+          // the authenticated userinfo response, never this token's payload.
+          id_token: `${Buffer.from('{"alg":"none"}').toString("base64url")}.${Buffer.from(
+            '{"sub":"forged"}'
+          ).toString("base64url")}.signature`,
+        }),
+        text: vi.fn(),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          sub: "user_1",
+          email: "user@example.com",
+          email_verified: true,
+          name: "Test User",
+        }),
+      });
     vi.stubGlobal("fetch", fetchMock);
     const callbackRes = {
       status: vi.fn().mockReturnThis(),
@@ -225,12 +240,20 @@ describe("OAuthController entity environment contract", () => {
       callbackRes as any,
       "entity_authorization_code",
       signedState!,
-      undefined,
+      undefined
     );
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://identity.example/token",
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "https://identity.example/userinfo",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer provider_access_token" }),
+      })
     );
     const tokenRequest = new URLSearchParams(fetchMock.mock.calls[0]![1].body);
     expect(tokenRequest.get("client_id")).toBe("entity-client");
@@ -239,12 +262,21 @@ describe("OAuthController entity environment contract", () => {
     expect(tokenRequest.get("redirect_uri")).toContain("/oauth/entity/acme/oidc-callback");
     expect(h.secretStore.createInTransaction).toHaveBeenCalledWith(
       h.tx,
-      expect.objectContaining({ plaintext: expect.stringContaining("provider_access_token") }),
+      expect.objectContaining({ plaintext: expect.stringContaining("provider_access_token") })
     );
     expect(h.tx.mcpOidcSession.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        create: expect.objectContaining({ environmentId: "env_1", provider: "oauth2_pkce" }),
-      }),
+        where: expect.objectContaining({
+          environmentId_entityId_provider_externalSubject: expect.objectContaining({
+            externalSubject: "user_1",
+          }),
+        }),
+        create: expect.objectContaining({
+          environmentId: "env_1",
+          provider: "oauth2_pkce",
+          emailVerified: true,
+        }),
+      })
     );
     expect(h.oauth.issueAuthCode).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -254,11 +286,11 @@ describe("OAuthController entity environment contract", () => {
           environmentId: "env_1",
         },
         mcpIdentity: { kind: "oidc", sessionId: "oidc_session_1" },
-      }),
+      })
     );
     expect(callbackRes.redirect).toHaveBeenCalledWith(
       302,
-      "https://client.example/callback?code=plt_oauth_code&state=client_state",
+      "https://client.example/callback?code=plt_oauth_code&state=client_state"
     );
   });
 
@@ -275,43 +307,51 @@ describe("OAuthController entity environment contract", () => {
       ...environment,
       project: {
         ...environment.project,
-        entities: [{
-          ...environment.project.entities[0],
-          mcpConfig: {
-            enabled: true,
-            identityMode: "bearer+oidc",
-            identityProviders: {
-              type: "oauth2_pkce",
-              authorizationUrl: "https://identity.example/authorize",
-              tokenUrl: "https://identity.example/token",
-              clientId: "legacy-client",
+        entities: [
+          {
+            ...environment.project.entities[0],
+            mcpConfig: {
+              enabled: true,
+              identityMode: "bearer+oidc",
+              identityProviders: {
+                type: "oauth2_pkce",
+                authorizationUrl: "https://identity.example/authorize",
+                tokenUrl: "https://identity.example/token",
+                clientId: "legacy-client",
+              },
             },
           },
-        }],
+        ],
       },
     });
 
     await h.controller.entityOidcRedirect("acme", {} as any, res as any, "transaction_1");
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "oidc_not_configured" }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "oidc_not_configured" })
+    );
     expect(res.redirect).not.toHaveBeenCalled();
 
     h.prisma.environment.findFirst.mockResolvedValue({
       ...environment,
       project: {
         ...environment.project,
-        entities: [{
-          ...environment.project.entities[0],
-          mcpConfig: {
-            enabled: true,
-            identityMode: "bearer+oidc",
-            identityProviders: [{
-              type: "oidc",
-              authorizationUrl: "https://identity.example/authorize",
-              tokenUrl: "https://identity.example/token",
-            }],
+        entities: [
+          {
+            ...environment.project.entities[0],
+            mcpConfig: {
+              enabled: true,
+              identityMode: "bearer+oidc",
+              identityProviders: [
+                {
+                  type: "oidc",
+                  authorizationUrl: "https://identity.example/authorize",
+                  tokenUrl: "https://identity.example/token",
+                },
+              ],
+            },
           },
-        }],
+        ],
       },
     });
     res.status.mockClear();
@@ -319,7 +359,9 @@ describe("OAuthController entity environment contract", () => {
 
     await h.controller.entityOidcRedirect("acme", {} as any, res as any, "transaction_1");
     expect(res.status).toHaveBeenCalledWith(400);
-    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ error: "oidc_not_configured" }));
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "oidc_not_configured" })
+    );
     expect(res.redirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/agent/src/oauth/oauth.controller.ts
+++ b/apps/agent/src/oauth/oauth.controller.ts
@@ -55,7 +55,7 @@ export class OAuthController {
   constructor(
     private readonly oauth: OAuthService,
     @Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient,
-    @Inject(PLATOS_SECRET_STORE_TOKEN) private readonly secretStore: PlatosSecretStore,
+    @Inject(PLATOS_SECRET_STORE_TOKEN) private readonly secretStore: PlatosSecretStore
   ) {}
 
   private get issuerUrl(): string {
@@ -72,18 +72,15 @@ export class OAuthController {
    */
   private async resolveEntityForMcp(
     entityIdSlug: string,
-    environmentId?: string,
-  ): Promise<
-    | {
-        entityPk: string;
-        organizationId: string;
-        projectId: string;
-        environmentId: string;
-        displayName: string;
-        config: any;
-      }
-    | null
-  > {
+    environmentId?: string
+  ): Promise<{
+    entityPk: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    displayName: string;
+    config: any;
+  } | null> {
     if (!entityIdSlug || typeof entityIdSlug !== "string" || !environmentId) return null;
     const environment = await this.prisma.environment.findFirst({
       where: {
@@ -137,11 +134,7 @@ export class OAuthController {
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
-      token_endpoint_auth_methods_supported: [
-        "client_secret_basic",
-        "client_secret_post",
-        "none",
-      ],
+      token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
       scopes_supported: [...PLATFORM_MCP_SCOPES],
     };
   }
@@ -162,7 +155,7 @@ export class OAuthController {
       scope?: string;
       organization_id?: string;
       registered_by_user_id?: string;
-    },
+    }
   ) {
     try {
       const result = await this.oauth.register({
@@ -174,9 +167,7 @@ export class OAuthController {
         ...(body?.grant_types ? { grantTypes: body.grant_types } : {}),
         scope: body?.scope,
         ...(body?.organization_id ? { organizationId: body.organization_id } : {}),
-        ...(body?.registered_by_user_id
-          ? { registeredByUserId: body.registered_by_user_id }
-          : {}),
+        ...(body?.registered_by_user_id ? { registeredByUserId: body.registered_by_user_id } : {}),
       });
       return result;
     } catch (err) {
@@ -210,7 +201,7 @@ export class OAuthController {
     @Query("state") state: string | undefined,
     @Query("code_challenge") codeChallenge: string | undefined,
     @Query("code_challenge_method") codeChallengeMethod: string | undefined,
-    @Query("environment_id") environmentId: string | undefined,
+    @Query("environment_id") environmentId: string | undefined
   ): Promise<void> {
     // Parameter validation — per RFC 6749 §4.1.2.1 errors that apply to
     // redirect_uri itself MUST NOT redirect; other errors redirect back.
@@ -303,10 +294,7 @@ export class OAuthController {
     // Bounce to the webapp consent screen. The loader reads these query
     // params + requireUserId, renders the approval card, then POSTs back
     // to `/oauth/authorize/callback` on this controller.
-    const webappBase =
-      env.APP_ORIGIN ??
-      env.PLATOS_WEBAPP_ADMIN_URL ??
-      "http://localhost:3030";
+    const webappBase = env.APP_ORIGIN ?? env.PLATOS_WEBAPP_ADMIN_URL ?? "http://localhost:3030";
     const consentUrl = new URL("/oauth/consent", webappBase);
     consentUrl.searchParams.set("transaction", transaction);
     res.redirect(302, consentUrl.toString());
@@ -323,20 +311,23 @@ export class OAuthController {
         ? row.entity?.mcpConfig?.identityMode?.split("+").includes("oidc")
           ? "entity_oidc"
           : row.entity?.mcpConfig?.identityMode?.split("+").includes("anonymous")
-            ? "entity_anonymous"
-            : "entity_bearer"
+          ? "entity_anonymous"
+          : "entity_bearer"
         : "platform",
       client: {
         clientId: row.client.clientId,
         clientName: row.client.clientName,
         redirectUri: row.redirectUri,
       },
-      entity: row.entityId && row.entity ? {
-        entityPk: row.entityId,
-        entityId: row.entity.externalId,
-        displayName: row.entity.displayName,
-        branding: row.entity.mcpConfig?.branding ?? null,
-      } : null,
+      entity:
+        row.entityId && row.entity
+          ? {
+              entityPk: row.entityId,
+              entityId: row.entity.externalId,
+              displayName: row.entity.displayName,
+              branding: row.entity.mcpConfig?.branding ?? null,
+            }
+          : null,
       environment: row.environment,
       effectiveScopes: row.scopes,
     };
@@ -358,12 +349,12 @@ export class OAuthController {
       transaction: string;
       userId: string;
       action?: "approve" | "deny";
-    },
+    }
   ): Promise<{ redirectTo: string }> {
     if (!env.PLATOS_INTERNAL_AUTH_TOKEN) {
       throw new HttpException(
         "internal consent authentication not configured",
-        HttpStatus.SERVICE_UNAVAILABLE,
+        HttpStatus.SERVICE_UNAVAILABLE
       );
     }
     const provided = Buffer.from(internalToken ?? "");
@@ -423,7 +414,7 @@ export class OAuthController {
       client_id?: string;
       client_secret?: string;
       refresh_token?: string;
-    },
+    }
   ) {
     const { clientId, clientSecret } = this.extractClientCredentials(authorization, body);
     if (!clientId) {
@@ -438,18 +429,14 @@ export class OAuthController {
     // Authenticate confidential clients.
     if (client.tokenEndpointAuthMethod !== "none") {
       if (!clientSecret) {
-        throw this.oauthHttp(
-          "invalid_client",
-          "client_secret required",
-          HttpStatus.UNAUTHORIZED,
-        );
+        throw this.oauthHttp("invalid_client", "client_secret required", HttpStatus.UNAUTHORIZED);
       }
       const ok = await this.oauth.verifyClientSecret(clientId, clientSecret);
       if (!ok) {
         throw this.oauthHttp(
           "invalid_client",
           "client authentication failed",
-          HttpStatus.UNAUTHORIZED,
+          HttpStatus.UNAUTHORIZED
         );
       }
     }
@@ -457,10 +444,7 @@ export class OAuthController {
     try {
       if (body.grant_type === "authorization_code") {
         if (!body.code || !body.code_verifier || !body.redirect_uri) {
-          throw new OAuthError(
-            "invalid_request",
-            "code, redirect_uri, code_verifier required",
-          );
+          throw new OAuthError("invalid_request", "code, redirect_uri, code_verifier required");
         }
         const result = await this.oauth.exchangeAuthCode({
           clientId,
@@ -503,7 +487,7 @@ export class OAuthController {
 
   private extractClientCredentials(
     authorization: string | undefined,
-    body: { client_id?: string; client_secret?: string },
+    body: { client_id?: string; client_secret?: string }
   ): { clientId: string | undefined; clientSecret: string | undefined } {
     if (authorization && authorization.toLowerCase().startsWith("basic ")) {
       try {
@@ -523,10 +507,7 @@ export class OAuthController {
   }
 
   private oauthHttp(code: string, description: string, status: number) {
-    return new HttpException(
-      { error: code, error_description: description },
-      status,
-    );
+    return new HttpException({ error: code, error_description: description }, status);
   }
 
   // ─────────────────────────────────────────────────────────────
@@ -536,18 +517,14 @@ export class OAuthController {
   @Post("oauth/introspect")
   async introspect(
     @Headers("authorization") authorization: string | undefined,
-    @Body() body: { token?: string; client_id?: string; client_secret?: string },
+    @Body() body: { token?: string; client_id?: string; client_secret?: string }
   ) {
     // Authenticate the introspecting client — only registered clients may
     // introspect (prevents strangers probing token liveness). Public
     // clients are allowed to introspect their own tokens (no secret needed).
     const { clientId, clientSecret } = this.extractClientCredentials(authorization, body);
     if (!clientId) {
-      throw this.oauthHttp(
-        "invalid_client",
-        "client_id required",
-        HttpStatus.UNAUTHORIZED,
-      );
+      throw this.oauthHttp("invalid_client", "client_id required", HttpStatus.UNAUTHORIZED);
     }
     const client = await this.oauth.findClient(clientId);
     if (!client) {
@@ -555,18 +532,14 @@ export class OAuthController {
     }
     if (client.tokenEndpointAuthMethod !== "none") {
       if (!clientSecret) {
-        throw this.oauthHttp(
-          "invalid_client",
-          "client_secret required",
-          HttpStatus.UNAUTHORIZED,
-        );
+        throw this.oauthHttp("invalid_client", "client_secret required", HttpStatus.UNAUTHORIZED);
       }
       const ok = await this.oauth.verifyClientSecret(clientId, clientSecret);
       if (!ok) {
         throw this.oauthHttp(
           "invalid_client",
           "client authentication failed",
-          HttpStatus.UNAUTHORIZED,
+          HttpStatus.UNAUTHORIZED
         );
       }
     }
@@ -604,15 +577,11 @@ export class OAuthController {
       token_type_hint?: "access_token" | "refresh_token";
       client_id?: string;
       client_secret?: string;
-    },
+    }
   ) {
     const { clientId, clientSecret } = this.extractClientCredentials(authorization, body);
     if (!clientId) {
-      throw this.oauthHttp(
-        "invalid_client",
-        "client_id required",
-        HttpStatus.UNAUTHORIZED,
-      );
+      throw this.oauthHttp("invalid_client", "client_id required", HttpStatus.UNAUTHORIZED);
     }
     const client = await this.oauth.findClient(clientId);
     if (!client) {
@@ -620,18 +589,14 @@ export class OAuthController {
     }
     if (client.tokenEndpointAuthMethod !== "none") {
       if (!clientSecret) {
-        throw this.oauthHttp(
-          "invalid_client",
-          "client_secret required",
-          HttpStatus.UNAUTHORIZED,
-        );
+        throw this.oauthHttp("invalid_client", "client_secret required", HttpStatus.UNAUTHORIZED);
       }
       const ok = await this.oauth.verifyClientSecret(clientId, clientSecret);
       if (!ok) {
         throw this.oauthHttp(
           "invalid_client",
           "client authentication failed",
-          HttpStatus.UNAUTHORIZED,
+          HttpStatus.UNAUTHORIZED
         );
       }
     }
@@ -665,13 +630,13 @@ export class OAuthController {
   @Get(".well-known/oauth-authorization-server/entity/:entityId")
   async entityMetadata(
     @Param("entityId") entityIdSlug: string,
-    @Query("environmentId") environmentId: string | undefined,
+    @Query("environmentId") environmentId: string | undefined
   ) {
     const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: `MCP not enabled for entity '${entityIdSlug}'` },
-        HttpStatus.NOT_FOUND,
+        HttpStatus.NOT_FOUND
       );
     }
     const issuer = this.issuerUrl;
@@ -687,11 +652,7 @@ export class OAuthController {
       response_types_supported: ["code"],
       grant_types_supported: ["authorization_code", "refresh_token"],
       code_challenge_methods_supported: ["S256"],
-      token_endpoint_auth_methods_supported: [
-        "client_secret_basic",
-        "client_secret_post",
-        "none",
-      ],
+      token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"],
       scopes_supported: [...ENTITY_MCP_SCOPES],
       // Non-standard hint so MCP clients can render the entity's name.
       "platos:entity_id": entityIdSlug,
@@ -711,13 +672,13 @@ export class OAuthController {
       token_endpoint_auth_method?: "client_secret_basic" | "client_secret_post" | "none";
       grant_types?: string[];
       scope?: string;
-    },
+    }
   ) {
     const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
-        HttpStatus.NOT_FOUND,
+        HttpStatus.NOT_FOUND
       );
     }
     // PIFSP-21 — redirect_uri allowlist enforcement. When the operator
@@ -734,7 +695,7 @@ export class OAuthController {
               error: "invalid_redirect_uri",
               error_description: `redirect_uri '${uri}' not in entity allowlist`,
             },
-            HttpStatus.BAD_REQUEST,
+            HttpStatus.BAD_REQUEST
           );
         }
       }
@@ -778,7 +739,7 @@ export class OAuthController {
     @Query("state") state: string | undefined,
     @Query("code_challenge") codeChallenge: string | undefined,
     @Query("code_challenge_method") codeChallengeMethod: string | undefined,
-    @Query("environmentId") environmentId: string | undefined,
+    @Query("environmentId") environmentId: string | undefined
   ): Promise<void> {
     const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
@@ -866,8 +827,7 @@ export class OAuthController {
       throw error;
     }
 
-    const webappBase =
-      env.APP_ORIGIN ?? env.PLATOS_WEBAPP_ADMIN_URL ?? "http://localhost:3030";
+    const webappBase = env.APP_ORIGIN ?? env.PLATOS_WEBAPP_ADMIN_URL ?? "http://localhost:3030";
     const consentUrl = new URL("/oauth/consent", webappBase);
     consentUrl.searchParams.set("transaction", transaction);
     res.redirect(302, consentUrl.toString());
@@ -888,7 +848,7 @@ export class OAuthController {
     @Body()
     body: {
       transaction?: string;
-    },
+    }
   ): Promise<void> {
     const consent = body.transaction
       ? await this.oauth.inspectConsentTransaction(body.transaction)
@@ -925,7 +885,12 @@ export class OAuthController {
     }
     const anonClientEntityPk = (anonClient as { entityPk?: string | null }).entityPk ?? null;
     if (!anonClientEntityPk || anonClientEntityPk !== ent.entityPk) {
-      res.status(400).json({ error: "invalid_client", error_description: "client is not registered for this entity" });
+      res
+        .status(400)
+        .json({
+          error: "invalid_client",
+          error_description: "client is not registered for this entity",
+        });
       return;
     }
     let consumed;
@@ -944,7 +909,10 @@ export class OAuthController {
         entityId: ent.entityPk,
         environmentId: ent.environmentId,
         mcpUserId,
-        firstSeenIp: (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ?? (req.socket?.remoteAddress ?? null),
+        firstSeenIp:
+          (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ??
+          req.socket?.remoteAddress ??
+          null,
         userAgent: req.headers["user-agent"] ?? null,
       },
     });
@@ -992,13 +960,13 @@ export class OAuthController {
       client_id?: string;
       client_secret?: string;
       refresh_token?: string;
-    },
+    }
   ) {
     const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
-        HttpStatus.NOT_FOUND,
+        HttpStatus.NOT_FOUND
       );
     }
     const { clientId, clientSecret } = this.extractClientCredentials(authorization, body);
@@ -1014,23 +982,19 @@ export class OAuthController {
       throw this.oauthHttp(
         "invalid_client",
         "client is not registered for this entity",
-        HttpStatus.UNAUTHORIZED,
+        HttpStatus.UNAUTHORIZED
       );
     }
     if (client.tokenEndpointAuthMethod !== "none") {
       if (!clientSecret) {
-        throw this.oauthHttp(
-          "invalid_client",
-          "client_secret required",
-          HttpStatus.UNAUTHORIZED,
-        );
+        throw this.oauthHttp("invalid_client", "client_secret required", HttpStatus.UNAUTHORIZED);
       }
       const ok = await this.oauth.verifyClientSecret(clientId, clientSecret);
       if (!ok) {
         throw this.oauthHttp(
           "invalid_client",
           "client authentication failed",
-          HttpStatus.UNAUTHORIZED,
+          HttpStatus.UNAUTHORIZED
         );
       }
     }
@@ -1038,10 +1002,7 @@ export class OAuthController {
     try {
       if (body.grant_type === "authorization_code") {
         if (!body.code || !body.code_verifier || !body.redirect_uri) {
-          throw new OAuthError(
-            "invalid_request",
-            "code, redirect_uri, code_verifier required",
-          );
+          throw new OAuthError("invalid_request", "code, redirect_uri, code_verifier required");
         }
         const result = await this.oauth.exchangeAuthCode({
           clientId,
@@ -1109,22 +1070,18 @@ export class OAuthController {
       token_type_hint?: "access_token" | "refresh_token";
       client_id?: string;
       client_secret?: string;
-    },
+    }
   ) {
     const ent = await this.resolveEntityForMcp(entityIdSlug, environmentId);
     if (!ent) {
       throw new HttpException(
         { error: "not_found", error_description: "entity MCP not enabled" },
-        HttpStatus.NOT_FOUND,
+        HttpStatus.NOT_FOUND
       );
     }
     const { clientId, clientSecret } = this.extractClientCredentials(authorization, body);
     if (!clientId) {
-      throw this.oauthHttp(
-        "invalid_client",
-        "client_id required",
-        HttpStatus.UNAUTHORIZED,
-      );
+      throw this.oauthHttp("invalid_client", "client_id required", HttpStatus.UNAUTHORIZED);
     }
     const client = await this.oauth.findClient(clientId);
     if (!client) {
@@ -1135,23 +1092,19 @@ export class OAuthController {
       throw this.oauthHttp(
         "invalid_client",
         "client is not registered for this entity",
-        HttpStatus.UNAUTHORIZED,
+        HttpStatus.UNAUTHORIZED
       );
     }
     if (client.tokenEndpointAuthMethod !== "none") {
       if (!clientSecret) {
-        throw this.oauthHttp(
-          "invalid_client",
-          "client_secret required",
-          HttpStatus.UNAUTHORIZED,
-        );
+        throw this.oauthHttp("invalid_client", "client_secret required", HttpStatus.UNAUTHORIZED);
       }
       const ok = await this.oauth.verifyClientSecret(clientId, clientSecret);
       if (!ok) {
         throw this.oauthHttp(
           "invalid_client",
           "client authentication failed",
-          HttpStatus.UNAUTHORIZED,
+          HttpStatus.UNAUTHORIZED
         );
       }
     }
@@ -1184,7 +1137,8 @@ export class OAuthController {
   //
   // They paste provider descriptors into PlatosEntityMcpConfig.identityProviders:
   //   [{ "type": "oauth2_pkce", "authorizationUrl": "...", "tokenUrl": "...",
-  //      "clientId": "...", "clientSecret": "...", "scopes": ["..."] }]
+  //      "userInfoUrl": "...", "clientId": "...", "clientSecret": "...",
+  //      "scopes": ["..."] }]
   // ═════════════════════════════════════════════════════════════════════
 
   /**
@@ -1198,11 +1152,9 @@ export class OAuthController {
     @Param("entityId") entityIdSlug: string,
     @Req() _req: Request,
     @Res() res: Response,
-    @Query("transaction") transaction: string | undefined,
+    @Query("transaction") transaction: string | undefined
   ): Promise<void> {
-    const consent = transaction
-      ? await this.oauth.inspectConsentTransaction(transaction)
-      : null;
+    const consent = transaction ? await this.oauth.inspectConsentTransaction(transaction) : null;
     if (!consent || !consent.entityId || consent.entity?.externalId !== entityIdSlug) {
       res.status(400).json({ error: "invalid consent transaction" });
       return;
@@ -1217,7 +1169,8 @@ export class OAuthController {
     if (!providerCfg) {
       res.status(400).json({
         error: "oidc_not_configured",
-        error_description: "This entity has not configured an identity provider. Set identityProviders in the MCP Identity tab.",
+        error_description:
+          "This entity has not configured an identity provider. Set identityProviders in the MCP Identity tab.",
       });
       return;
     }
@@ -1239,7 +1192,9 @@ export class OAuthController {
 
     // Build a signed state blob so the callback can recover all params.
     // Format: base64url(json) + "." + HMAC-SHA256(base64url(json), secret)
-    const callbackUrl = `${this.issuerUrl}/oauth/entity/${encodeURIComponent(entityIdSlug)}/oidc-callback`;
+    const callbackUrl = `${this.issuerUrl}/oauth/entity/${encodeURIComponent(
+      entityIdSlug
+    )}/oidc-callback`;
     const statePayload = {
       transaction,
       entityPkceVerifier,
@@ -1248,10 +1203,7 @@ export class OAuthController {
     };
     const stateJson = Buffer.from(JSON.stringify(statePayload)).toString("base64url");
     const secret = env.SESSION_SECRET ?? "";
-    const stateSig = crypto
-      .createHmac("sha256", secret)
-      .update(stateJson)
-      .digest("base64url");
+    const stateSig = crypto.createHmac("sha256", secret).update(stateJson).digest("base64url");
     const signedState = `${stateJson}.${stateSig}`;
 
     // BUG-3: validate authorizationUrl to prevent SSRF via operator-supplied config.
@@ -1259,7 +1211,9 @@ export class OAuthController {
     if (!authUrlValidation.ok) {
       res.status(400).json({
         error: "invalid_configuration",
-        error_description: `authorizationUrl blocked: ${describeUrlValidationError(authUrlValidation.error)}`,
+        error_description: `authorizationUrl blocked: ${describeUrlValidationError(
+          authUrlValidation.error
+        )}`,
       });
       return;
     }
@@ -1269,7 +1223,10 @@ export class OAuthController {
     authUrl.searchParams.set("response_type", "code");
     authUrl.searchParams.set("client_id", providerCfg.clientId);
     authUrl.searchParams.set("redirect_uri", callbackUrl);
-    authUrl.searchParams.set("scope", (providerCfg.scopes ?? []).join(" ") || "openid email profile");
+    authUrl.searchParams.set(
+      "scope",
+      (providerCfg.scopes ?? []).join(" ") || "openid email profile"
+    );
     authUrl.searchParams.set("code_challenge", entityPkceChallenge);
     authUrl.searchParams.set("code_challenge_method", "S256");
     authUrl.searchParams.set("state", signedState);
@@ -1288,7 +1245,7 @@ export class OAuthController {
     @Res() res: Response,
     @Query("code") code: string | undefined,
     @Query("state") signedState: string | undefined,
-    @Query("error") entityError: string | undefined,
+    @Query("error") entityError: string | undefined
   ): Promise<void> {
     // Propagate entity-side errors (user denied, etc.) back to MCP client.
     if (entityError) {
@@ -1319,20 +1276,32 @@ export class OAuthController {
 
     const sp = this.verifyAndDecodeState(signedState);
     if (!sp) {
-      res.status(400).json({ error: "invalid_state", error_description: "state tampered or expired" });
+      res
+        .status(400)
+        .json({ error: "invalid_state", error_description: "state tampered or expired" });
       return;
     }
 
     const consent = await this.oauth.inspectConsentTransaction(sp.transaction);
     if (!consent || !consent.entityId || consent.entity?.externalId !== entityIdSlug) {
-      res.status(400).json({ error: "invalid_state", error_description: "consent transaction expired or consumed" });
+      res
+        .status(400)
+        .json({
+          error: "invalid_state",
+          error_description: "consent transaction expired or consumed",
+        });
       return;
     }
     let consumed;
     try {
       consumed = await this.oauth.consumeConsentTransaction(sp.transaction);
     } catch {
-      res.status(400).json({ error: "invalid_state", error_description: "consent transaction already consumed" });
+      res
+        .status(400)
+        .json({
+          error: "invalid_state",
+          error_description: "consent transaction already consumed",
+        });
       return;
     }
     const ent = await this.resolveEntityForMcp(entityIdSlug, consent.environmentId);
@@ -1376,7 +1345,10 @@ export class OAuthController {
       });
       const tokenRes = await fetch(providerCfg.tokenUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
         body: tokenBody.toString(),
         signal: AbortSignal.timeout(10_000),
       });
@@ -1384,7 +1356,13 @@ export class OAuthController {
         const txt = await tokenRes.text().catch(() => "");
         throw new Error(`entity token endpoint returned ${tokenRes.status}: ${txt}`);
       }
-      entityTokenData = await tokenRes.json() as typeof entityTokenData;
+      entityTokenData = (await tokenRes.json()) as typeof entityTokenData;
+      if (
+        typeof entityTokenData.access_token !== "string" ||
+        !entityTokenData.access_token.trim()
+      ) {
+        throw new Error("entity token endpoint omitted access_token");
+      }
     } catch (err: any) {
       const errUrl = new URL(consent.redirectUri);
       errUrl.searchParams.set("error", "server_error");
@@ -1394,29 +1372,47 @@ export class OAuthController {
       return;
     }
 
-    // Extract user identity from id_token or userinfo if present.
-    // BUG-12: the id_token JWT signature is NOT verified (the provider's JWKS
-    // endpoint is not available). We trust the sub because the token came from
-    // the entity's own token endpoint over TLS. To prevent cross-entity sub
-    // collision (a sub from entity A matching entity B's user), we scope-salt
-    // the externalSub with the entityPk before any DB lookup/upsert.
+    // Resolve identity from the provider's authenticated user-info endpoint.
+    // Never decode an unverified id_token: doing so lets unsigned/incorrectly
+    // signed JWT claims become Platos identity authority. The access token was
+    // obtained server-to-server and userInfoUrl is protected by the same SSRF
+    // policy as the authorization and token endpoints.
     let email: string | undefined;
+    let emailVerified = false;
     let rawSub: string | undefined;
     let name: string | undefined;
-    if (entityTokenData.id_token) {
-      try {
-        const parts = entityTokenData.id_token.split(".");
-        if (parts.length >= 2) {
-          const claims = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as Record<string, unknown>;
-          rawSub = String(claims.sub ?? "");
-          email = typeof claims.email === "string" ? claims.email : undefined;
-          name = typeof claims.name === "string" ? claims.name : undefined;
-        }
-      } catch { /* id_token parse failures are non-fatal */ }
+    const userInfoValidation = await validatePublicUrl(providerCfg.userInfoUrl);
+    if (!userInfoValidation.ok) {
+      const errUrl = new URL(consent.redirectUri);
+      errUrl.searchParams.set("error", "server_error");
+      errUrl.searchParams.set("error_description", "entity userInfoUrl blocked by SSRF guard");
+      if (consent.state) errUrl.searchParams.set("state", consent.state);
+      res.redirect(302, errUrl.toString());
+      return;
     }
-    // Fallback: use access_token prefix as raw sub if no id_token.
-    if (!rawSub) {
-      rawSub = `${entityTokenData.access_token.slice(0, 16)}`;
+    try {
+      const userInfoRes = await fetch(providerCfg.userInfoUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${entityTokenData.access_token}`,
+          Accept: "application/json",
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!userInfoRes.ok) throw new Error(`userinfo endpoint returned ${userInfoRes.status}`);
+      const claims = (await userInfoRes.json()) as Record<string, unknown>;
+      rawSub = typeof claims.sub === "string" && claims.sub.trim() ? claims.sub : undefined;
+      email = typeof claims.email === "string" ? claims.email : undefined;
+      emailVerified = claims.email_verified === true;
+      name = typeof claims.name === "string" ? claims.name : undefined;
+      if (!rawSub) throw new Error("userinfo endpoint omitted sub");
+    } catch {
+      const errUrl = new URL(consent.redirectUri);
+      errUrl.searchParams.set("error", "server_error");
+      errUrl.searchParams.set("error_description", "entity userinfo lookup failed");
+      if (consent.state) errUrl.searchParams.set("state", consent.state);
+      res.redirect(302, errUrl.toString());
+      return;
     }
 
     const externalSubject = rawSub;
@@ -1431,9 +1427,10 @@ export class OAuthController {
       accessToken: entityTokenData.access_token,
       refreshToken: entityTokenData.refresh_token ?? null,
     });
-    const expiresAt = entityTokenData.expires_in
-      ? new Date(Date.now() + entityTokenData.expires_in * 1000)
-      : null;
+    const expiresAt =
+      Number.isFinite(entityTokenData.expires_in) && entityTokenData.expires_in! > 0
+        ? new Date(Date.now() + entityTokenData.expires_in! * 1000)
+        : null;
 
     const client = await this.oauth.findClient(consent.client.clientId);
     if (!client || client.entityPk !== ent.entityPk) {
@@ -1459,20 +1456,23 @@ export class OAuthController {
         },
         select: { id: true, activeSecretVersionId: true, revokedAt: true },
       });
-      const credential = existing?.activeSecretVersionId && !existing.revokedAt
-        ? await this.secretStore.rotateInTransaction(tx, {
-            authorization: serviceAuthorization,
-            credentialId: existing.id,
-            plaintext: tokenPayload,
-          })
-        : !existing
-        ? await this.secretStore.createInTransaction(tx, {
-          authorization: serviceAuthorization,
-          kind: CredentialKind.ENTITY_SECRET,
-          name: credentialName,
-          plaintext: tokenPayload,
-        })
-        : (() => { throw new Error("entity_oauth_credential_unavailable"); })();
+      const credential =
+        existing?.activeSecretVersionId && !existing.revokedAt
+          ? await this.secretStore.rotateInTransaction(tx, {
+              authorization: serviceAuthorization,
+              credentialId: existing.id,
+              plaintext: tokenPayload,
+            })
+          : !existing
+          ? await this.secretStore.createInTransaction(tx, {
+              authorization: serviceAuthorization,
+              kind: CredentialKind.ENTITY_SECRET,
+              name: credentialName,
+              plaintext: tokenPayload,
+            })
+          : (() => {
+              throw new Error("entity_oauth_credential_unavailable");
+            })();
       await tx.credential.update({
         where: { id: credential.id },
         data: { expiresAt, lastUsedAt: new Date() },
@@ -1492,7 +1492,7 @@ export class OAuthController {
           mcpUserId,
           provider,
           email: email ?? null,
-          emailVerified: !!email,
+          emailVerified,
           externalSubject,
           displayName: name ?? null,
           credentialId: credential.id,
@@ -1502,7 +1502,7 @@ export class OAuthController {
           mcpUserId,
           credentialId: credential.id,
           email: email ?? undefined,
-          emailVerified: !!email,
+          emailVerified,
           displayName: name ?? undefined,
           lastLoginAt: new Date(),
           revokedAt: null,
@@ -1538,6 +1538,7 @@ export class OAuthController {
     type: string;
     authorizationUrl: string;
     tokenUrl: string;
+    userInfoUrl: string;
     clientId: string;
     clientSecret?: string;
     scopes?: string[];
@@ -1551,6 +1552,7 @@ export class OAuthController {
     if (!cfg) return null;
     if (typeof cfg.authorizationUrl !== "string" || !cfg.authorizationUrl.trim()) return null;
     if (typeof cfg.tokenUrl !== "string" || !cfg.tokenUrl.trim()) return null;
+    if (typeof cfg.userInfoUrl !== "string" || !cfg.userInfoUrl.trim()) return null;
     if (typeof cfg.clientId !== "string" || !cfg.clientId.trim()) return null;
     if (cfg.clientSecret !== undefined && typeof cfg.clientSecret !== "string") return null;
     if (
@@ -1564,10 +1566,10 @@ export class OAuthController {
       type: cfg.type as string,
       authorizationUrl: cfg.authorizationUrl.trim(),
       tokenUrl: cfg.tokenUrl.trim(),
+      userInfoUrl: cfg.userInfoUrl.trim(),
       clientId: cfg.clientId.trim(),
-      clientSecret: typeof cfg.clientSecret === "string" && cfg.clientSecret
-        ? cfg.clientSecret
-        : undefined,
+      clientSecret:
+        typeof cfg.clientSecret === "string" && cfg.clientSecret ? cfg.clientSecret : undefined,
       scopes: Array.isArray(cfg.scopes) ? cfg.scopes.map((scope) => scope.trim()) : undefined,
     };
   }
@@ -1584,16 +1586,16 @@ export class OAuthController {
     const sig = signedState.slice(dot + 1);
     // BUG-19: use the static top-level crypto import instead of dynamic require().
     const secret = env.SESSION_SECRET ?? "";
-    const expectedSig = crypto
-      .createHmac("sha256", secret)
-      .update(payload)
-      .digest("base64url");
+    const expectedSig = crypto.createHmac("sha256", secret).update(payload).digest("base64url");
     const sigBuf = Buffer.from(sig, "utf8");
     const expBuf = Buffer.from(expectedSig, "utf8");
     if (sigBuf.length !== expBuf.length) return null;
     if (!crypto.timingSafeEqual(sigBuf, expBuf)) return null;
     try {
-      const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<string, unknown>;
+      const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+        string,
+        unknown
+      >;
       // Reject state older than 15 minutes (user has that long to complete auth).
       if (!parsed.ts || Math.abs(Date.now() / 1000 - Number(parsed.ts)) > 900) return null;
       if (typeof parsed.transaction !== "string" || !parsed.transaction) return null;
@@ -1602,6 +1604,4 @@ export class OAuthController {
       return null;
     }
   }
-
-
 }


### PR DESCRIPTION
## Summary

Systematic MCP/backend route audit fixes:

- exact method/path allowlists for Docs, Platform, Entity, OAuth, channel, health, metrics, OpenAPI, privacy, and internal callback boundaries
- remove dormant production `/test/*` bypass and obsolete maintenance exemptions
- admit the previously blocked HMAC-authenticated scoped-env invalidation callback
- route Platform MCP legacy SSE sessions through Redis for multi-replica safety
- revalidate Platform/OAuth credentials on every SSE message without storing raw bearers
- derive entity OAuth identity from an SSRF-validated authenticated user-info endpoint instead of unverified ID-token payloads
- preserve authoritative `email_verified` semantics

## Local evidence

- generated control-plane contract: 202 MCP tools / 297 REST operations, clean
- scope audit: 385 files, zero unscoped calls
- focused auth/MCP/OAuth/callback suites: 152/152 passed
- expanded ScopeGuard suite: 105/105 passed
- broader Agent run used one worker and progressed without assertion failures; PostgreSQL suites were skipped without local infrastructure, and the run was stopped after an existing runtime suite left the process open
- no local Docker was started

Remote CI is authoritative for full typecheck/build and database-backed evidence.
