### PR TITLE
fix(infra): contain edge metadata and Docker build context (WIN-291)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,3 +61,14 @@ CHANGESETS.md
 CONTRIBUTING.md
 README.md
 LICENSE
+
+# WIN-291 — host-level edge/runbook material must never enter the build context.
+# apps/agent/Dockerfile uses `COPY . .`, so anything not excluded here is shipped
+# into the image builder. /deploy and /hosting hold edge routing + runbooks.
+/deploy
+/hosting
+/.server-changes
+
+# Agent worktrees are created INSIDE the repo at .claude/worktrees/. Without this
+# they re-enter the build context carrying a full second copy of the tree.
+/.claude

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -399,7 +399,7 @@ is present, `input_cached_tokens: 1e-8` is present, and the old `2.5e-8` appears
 | | |
 |---|---|
 | Branch | `feat/prompt-caching-and-serving-research` @ `20b2fc5`, pushed to origin |
-| Deployed | test.platos.dev (187.127.142.170), agent + webapp, sequentially |
+| Deployed | test.platos.dev, agent + webapp, sequentially |
 | Rollback | previous tree preserved at `/opt/platos-prev` |
 | Services | all six healthy; agent healthy in 20s, webapp in 20s |
 | Live gate | **PASSED** — 98% steady-state cache read, 99% cross-turn |

--- a/apps/agent/src/mcp-platform/host-router.middleware.test.ts
+++ b/apps/agent/src/mcp-platform/host-router.middleware.test.ts
@@ -68,7 +68,7 @@ describe("isPublicMcpHost", () => {
     expect(isPublicMcpHost("platos.dev")).toBe(false);
     expect(isPublicMcpHost("localhost")).toBe(false);
     expect(isPublicMcpHost("127.0.0.1")).toBe(false);
-    expect(isPublicMcpHost("187.127.142.170")).toBe(false);
+    expect(isPublicMcpHost("203.0.113.10")).toBe(false);
   });
   it("ignores case", () => {
     expect(isPublicMcpHost("MCP.Platos.Dev")).toBe(true);

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -27,15 +27,31 @@ upgrades transparently, so the only requirement is that the path points at `:310
 
 ### Apply / update
 
-```bash
-# Requires PLATOS_EDGE_HOST and PLATOS_EDGE_USER to be exported.
-# Access is key-only (WIN-291); password authentication is disabled on the edge host.
-: "${PLATOS_EDGE_HOST:?set PLATOS_EDGE_HOST — see the private operator runbook}"
-: "${PLATOS_EDGE_USER:=root}"
+Access is key-only (WIN-291) — password authentication is disabled on the edge
+host. The normal path runs as the **unprivileged `ubuntu` account** with
+`NOPASSWD` sudo. **Direct `root` login is recovery-only and must not be used
+here.**
 
-scp deploy/Caddyfile "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST:/etc/caddy/Caddyfile"
-ssh "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST" \
-  'caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile && systemctl reload caddy'
+```bash
+: "${PLATOS_EDGE_HOST:?set PLATOS_EDGE_HOST — see the private operator runbook}"
+: "${PLATOS_EDGE_USER:=ubuntu}"
+
+# 1. Upload the candidate to a location the unprivileged account can write.
+scp deploy/Caddyfile "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST:/tmp/Caddyfile.new"
+
+# 2. Validate the CANDIDATE before it replaces the live file, back up, install,
+#    reload. Ordering matters: validating after the copy would mean an invalid
+#    config is already live by the time the check fails.
+ssh "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST" '
+  set -eu
+  sudo caddy validate --config /tmp/Caddyfile.new --adapter caddyfile
+  sudo cp -a /etc/caddy/Caddyfile "/etc/caddy/Caddyfile.bak.$(date +%Y%m%d%H%M%S)"
+  sudo install -o root -g root -m 0644 /tmp/Caddyfile.new /etc/caddy/Caddyfile
+  sudo systemctl reload caddy
+  rm -f /tmp/Caddyfile.new
+'
 ```
 
-`systemctl reload caddy` is zero-downtime. Back up the existing file first.
+`systemctl reload caddy` is zero-downtime. The backup is taken automatically by
+step 2 above; timestamped copies accumulate in `/etc/caddy/` and should be pruned
+periodically.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,10 @@
 # Deploy config — test.platos.dev edge
 
-Host-level infra config for the `test.platos.dev` VPS (`srv1549678`, `187.127.142.170`).
+Host-level infra config for the `test.platos.dev` edge VPS.
+
+> **Host details are deliberately not committed.** Set `PLATOS_EDGE_HOST` in your shell
+> (see the private operator runbook for the current value). This repository is public;
+> host addresses, hostnames and root-shell runbooks must not be published here.
 These files live on the host **outside** `/opt/platos`, so they are NOT part of the
 `docker compose` tar-deploy — they are tracked here so the edge routing survives a
 box rebuild and is reviewable.
@@ -24,8 +28,14 @@ upgrades transparently, so the only requirement is that the path points at `:310
 ### Apply / update
 
 ```bash
-scp deploy/Caddyfile root@187.127.142.170:/etc/caddy/Caddyfile
-ssh root@187.127.142.170 'caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile && systemctl reload caddy'
+# Requires PLATOS_EDGE_HOST and PLATOS_EDGE_USER to be exported.
+# Access is key-only (WIN-291); password authentication is disabled on the edge host.
+: "${PLATOS_EDGE_HOST:?set PLATOS_EDGE_HOST — see the private operator runbook}"
+: "${PLATOS_EDGE_USER:=root}"
+
+scp deploy/Caddyfile "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST:/etc/caddy/Caddyfile"
+ssh "$PLATOS_EDGE_USER@$PLATOS_EDGE_HOST" \
+  'caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile && systemctl reload caddy'
 ```
 
 `systemctl reload caddy` is zero-downtime. Back up the existing file first.

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -21,8 +21,10 @@
 # the public internet. To expose them externally (e.g. for a developer tool
 # running off-host), set the corresponding *_PUBLIC_BIND env to `0.0.0.0`:
 #   POSTGRES_PUBLIC_BIND=0.0.0.0 REDIS_PUBLIC_BIND=0.0.0.0 docker compose up -d
-# The webapp (3030) and agent (3100) remain bound to 0.0.0.0 — they're
-# designed to sit behind Caddy or a similar reverse proxy.
+# The webapp (3030) and agent (3100) are bound to 127.0.0.1 — they sit behind
+# Caddy (or a similar reverse proxy) on the host, which reaches them over
+# localhost. Set WEBAPP_PUBLIC_BIND / the agent's bind to 0.0.0.0 only for a
+# deliberately public single-host install without a fronting proxy.
 #
 # ─── Log rotation + mem limits (EOBD.54) ──────────────────────────────────
 # Every service ships with a json-file log driver capped at 50MB × 5 files
@@ -504,7 +506,13 @@ services:
     logging: *default-logging
     mem_limit: ${WEBAPP_MEM_LIMIT:-2g}
     ports:
-      - "3030:3000"
+      # WIN-291 — loopback-bound, matching the agent (127.0.0.1:3100). The webapp
+      # exposes the operator dashboard + BFF; publishing on 0.0.0.0 put it on the
+      # public internet with only an undocumented provider-side filter in front.
+      # Caddy reaches it via host localhost:3030, so proxied access is unaffected;
+      # direct external access is removed. Override with WEBAPP_PUBLIC_BIND for a
+      # deliberately public single-host install.
+      - "${WEBAPP_PUBLIC_BIND:-127.0.0.1}:3030:3000"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- remove hardcoded test edge IP and provider hostname from tracked deployment documentation and tests
- parameterize edge deployment commands
- exclude host-level deploy/hosting state and in-repository agent worktrees from Docker build contexts
- preserve the vocabulary-boundary count and document the containment result

## Host containment evidence

- recovery path proved before change via key-authenticated ubuntu account with non-interactive sudo
- sshd configuration validated before reload
- password authentication now rejected; public-key authentication remains available
- host firewall/fail2ban and root-key pruning are intentionally outside this PR pending allowlist and operator-identity decisions

## Verification reported for exact head

- three CI gates passed
- vocabulary exceptions unchanged at 20,349
- zero tracked raw edge host/IP references remain
- `git diff --check origin/v1...origin/tejas/win-291-infra-containment` passes

## Review notes

This PR targets the frozen `v1` branch, not `main`. Host-side actions are recorded as evidence but are not represented as repository code. Independent review should verify Docker build-context exclusion and ensure the parameterized runbook does not regress operational recovery.