### PR TITLE
ci: run the CI gate on v1 pull requests (bootstrap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v1]
   push:
-    branches: [main]
+    branches: [main, v1]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
**Merge this first.** It is the reason PRs #129–#132 show zero checks.

`ci.yml` triggered only on `main`, but the entire V1 refactor is on `v1`. So every v1 PR ran no gate — typecheck, vocabulary, route-parity, tenancy-auth, cross-scope-isolation, postgres-memory. This adds `v1` to the pull_request + push filters.

GitHub reads `pull_request` triggers from the **base** branch, so v1 PRs only begin getting checks once this lands on `v1`. Until then, none of the open v1 PRs can be gated — this is the bootstrap.

Scope limited to `ci.yml`. `build-images.yml` (Playwright + image builds) stays main-only until nearer the M7 cutover. `main` unchanged and frozen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177AxniPpEvRuXqfgpxfSP6