### PR TITLE
fix(control-plane): repair REST census + semantic operator detector (WIN-294)

### DIFF
--- a/apps/agent/scripts/generate-control-plane.mjs
+++ b/apps/agent/scripts/generate-control-plane.mjs
@@ -34,6 +34,7 @@ const TOOL_NAME_PATTERN = /^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$/;
 
 const PRODUCTION_MOUNTED_CONTROLLERS = {
   AgentController: "agent-runtime/agent-runtime.module.ts",
+  AttachmentUploadController: "agent-runtime/agent-runtime.module.ts",
   ChannelAppsController: "agent-runtime/agent-runtime.module.ts",
   ChannelsController: "agent-runtime/agent-runtime.module.ts",
   JobExecutionController: "agent-runtime/agent-runtime.module.ts",
@@ -50,9 +51,11 @@ const PRODUCTION_MOUNTED_CONTROLLERS = {
   McpEntityController: "mcp-platform/mcp-platform.module.ts",
   McpPlatformController: "mcp-platform/mcp-platform.module.ts",
   MemoryController: "memory/memory.module.ts",
+  MemoryFeedbackAdminController: "memory/memory.module.ts",
   MetricsController: "monitoring/monitoring.module.ts",
   OAuthController: "oauth/oauth.module.ts",
   OpenApiController: "openapi/openapi.module.ts",
+  PerformanceEvidenceController: "performance-evidence/performance-evidence.module.ts",
   ErasureController: "privacy/privacy.module.ts",
   ProvidersController: "providers/providers.module.ts",
   SkillsController: "skills/skills.module.ts",
@@ -496,6 +499,27 @@ function classifyRest(method, path) {
   };
 }
 
+/**
+ * A route enforces operator scope when its body calls requireOperator/
+ * getOperatorScope directly, OR when it delegates to a same-class helper method
+ * whose own body makes one of those calls (e.g. `this.operatorScope(req)` in
+ * providers.controller.ts). `operatorHelpers` is the set of such helper method
+ * names collected from the enclosing controller class. The trailing `(` guards
+ * against a helper name being a prefix of an unrelated method call.
+ */
+function enforcesOperatorScope(memberText, operatorHelpers) {
+  if (
+    memberText.includes("requireOperator(") ||
+    memberText.includes("getOperatorScope(")
+  ) {
+    return true;
+  }
+  for (const helper of operatorHelpers) {
+    if (memberText.includes(`this.${helper}(`)) return true;
+  }
+  return false;
+}
+
 function extractRestOperations() {
   assertMountedControllerPolicy();
   const implementations = [];
@@ -516,6 +540,20 @@ function extractRestOperations() {
       if (!controller) continue;
       if (!Object.hasOwn(PRODUCTION_MOUNTED_CONTROLLERS, statement.name.text)) continue;
       const bases = decoratorPaths(controller, sf);
+      // Collect same-class helper methods that themselves enforce operator scope
+      // so a route delegating to one (e.g. `this.operatorScope(req)`) is not read
+      // as unguarded. See enforcesOperatorScope.
+      const operatorHelpers = new Set();
+      for (const candidate of statement.members) {
+        if (!ts.isMethodDeclaration(candidate) || !candidate.name) continue;
+        const text = candidate.getText(sf);
+        if (
+          text.includes("requireOperator(") ||
+          text.includes("getOperatorScope(")
+        ) {
+          operatorHelpers.add(candidate.name.getText(sf));
+        }
+      }
       for (const member of statement.members) {
         if (!ts.isMethodDeclaration(member) || !member.name) continue;
         for (const [decorator, method] of verbs) {
@@ -530,9 +568,10 @@ function extractRestOperations() {
                 controller: statement.name.text,
                 handler: member.name.getText(sf),
                 source: relative(repoDir, path).replaceAll("\\", "/"),
-                requiresOperator:
-                  member.getText(sf).includes("requireOperator(") ||
-                  member.getText(sf).includes("getOperatorScope("),
+                requiresOperator: enforcesOperatorScope(
+                  member.getText(sf),
+                  operatorHelpers,
+                ),
               });
             }
           }

--- a/apps/agent/src/control-plane/operation-manifest.generated.json
+++ b/apps/agent/src/control-plane/operation-manifest.generated.json
@@ -6909,6 +6909,23 @@
         ]
       },
       {
+        "id": "POST /api/v1/agent/admin/memory-feedback/backfill",
+        "method": "POST",
+        "path": "/api/v1/agent/admin/memory-feedback/backfill",
+        "classification": "REST_ONLY",
+        "policyRule": "explicit-default-rest-only",
+        "mcpTools": [],
+        "mappingRationale": null,
+        "implementations": [
+          {
+            "controller": "MemoryFeedbackAdminController",
+            "handler": "runBackfill",
+            "source": "apps/agent/src/memory/memory-feedback-admin.controller.ts",
+            "requiresOperator": true
+          }
+        ]
+      },
+      {
         "id": "POST /api/v1/agent/admin/privacy/erasures",
         "method": "POST",
         "path": "/api/v1/agent/admin/privacy/erasures",
@@ -7345,6 +7362,23 @@
             "controller": "AgentController",
             "handler": "resolveApproval",
             "source": "apps/agent/src/agent-runtime/agent.controller.ts",
+            "requiresOperator": false
+          }
+        ]
+      },
+      {
+        "id": "POST /api/v1/agent/attachments/presigned",
+        "method": "POST",
+        "path": "/api/v1/agent/attachments/presigned",
+        "classification": "REST_ONLY",
+        "policyRule": "explicit-default-rest-only",
+        "mcpTools": [],
+        "mappingRationale": null,
+        "implementations": [
+          {
+            "controller": "AttachmentUploadController",
+            "handler": "presign",
+            "source": "apps/agent/src/agent-runtime/attachment-upload.controller.ts",
             "requiresOperator": false
           }
         ]
@@ -8595,6 +8629,23 @@
         ]
       },
       {
+        "id": "GET /api/v1/agent/internal/performance-evidence/:requestId",
+        "method": "GET",
+        "path": "/api/v1/agent/internal/performance-evidence/:requestId",
+        "classification": "INTERNAL",
+        "policyRule": "agent-internal-prefix",
+        "mcpTools": [],
+        "mappingRationale": null,
+        "implementations": [
+          {
+            "controller": "PerformanceEvidenceController",
+            "handler": "consume",
+            "source": "apps/agent/src/performance-evidence/performance-evidence.controller.ts",
+            "requiresOperator": false
+          }
+        ]
+      },
+      {
         "id": "POST /api/v1/agent/internal/skill-run",
         "method": "POST",
         "path": "/api/v1/agent/internal/skill-run",
@@ -9606,7 +9657,7 @@
             "controller": "ProvidersController",
             "handler": "listKeys",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -9625,7 +9676,7 @@
             "controller": "ProvidersController",
             "handler": "createKey",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -9644,7 +9695,7 @@
             "controller": "ProvidersController",
             "handler": "deleteKey",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -9661,7 +9712,7 @@
             "controller": "ProvidersController",
             "handler": "updateKey",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -9678,7 +9729,7 @@
             "controller": "ProvidersController",
             "handler": "rotateKeySecret",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -9695,7 +9746,7 @@
             "controller": "ProvidersController",
             "handler": "createKeyWithSecret",
             "source": "apps/agent/src/providers/providers.controller.ts",
-            "requiresOperator": false
+            "requiresOperator": true
           }
         ]
       },
@@ -12010,15 +12061,15 @@
       "MAPPED": 82,
       "MCP_ONLY": 120
     },
-    "restOperations": 297,
-    "restRouteBindings": 297,
+    "restOperations": 300,
+    "restRouteBindings": 300,
     "ambiguousRestOperations": 0,
     "restClassifications": {
       "DEPRECATED": 15,
-      "INTERNAL": 13,
+      "INTERNAL": 14,
       "MAPPED": 82,
       "PUBLIC_TRANSPORT": 45,
-      "REST_ONLY": 142
+      "REST_ONLY": 144
     }
   }
 }

--- a/apps/agent/src/openapi/openapi.generated.json
+++ b/apps/agent/src/openapi/openapi.generated.json
@@ -263,6 +263,32 @@
         "x-platos-mcp-tools": []
       }
     },
+    "/api/v1/agent/admin/memory-feedback/backfill": {
+      "post": {
+        "operationId": "post__api_v1_agent_admin_memory_feedback_backfill",
+        "summary": "MemoryFeedbackAdminController.runBackfill",
+        "tags": [
+          "rest_only"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response. REST payload schemas are intentionally omitted until a source schema is available."
+          }
+        },
+        "security": [
+          {
+            "sessionToken": []
+          },
+          {
+            "directHeaders": []
+          }
+        ],
+        "x-platos-classification": "REST_ONLY",
+        "x-platos-auth-class": "OPERATOR",
+        "x-platos-policy-rule": "explicit-default-rest-only",
+        "x-platos-mcp-tools": []
+      }
+    },
     "/api/v1/agent/admin/privacy/erasures": {
       "post": {
         "operationId": "post__api_v1_agent_admin_privacy_erasures",
@@ -1114,6 +1140,32 @@
         "x-platos-mcp-tools": [
           "approvals.resolve"
         ]
+      }
+    },
+    "/api/v1/agent/attachments/presigned": {
+      "post": {
+        "operationId": "post__api_v1_agent_attachments_presigned",
+        "summary": "AttachmentUploadController.presign",
+        "tags": [
+          "rest_only"
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response. REST payload schemas are intentionally omitted until a source schema is available."
+          }
+        },
+        "security": [
+          {
+            "sessionToken": []
+          },
+          {
+            "directHeaders": []
+          }
+        ],
+        "x-platos-classification": "REST_ONLY",
+        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-policy-rule": "explicit-default-rest-only",
+        "x-platos-mcp-tools": []
       }
     },
     "/api/v1/agent/budgets": {
@@ -3353,6 +3405,39 @@
         "x-platos-mcp-tools": []
       }
     },
+    "/api/v1/agent/internal/performance-evidence/{requestId}": {
+      "get": {
+        "operationId": "get__api_v1_agent_internal_performance_evidence_by_requestId",
+        "summary": "PerformanceEvidenceController.consume",
+        "tags": [
+          "internal"
+        ],
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Operation response. REST payload schemas are intentionally omitted until a source schema is available."
+          }
+        },
+        "security": [
+          {
+            "internalAuth": []
+          }
+        ],
+        "x-platos-classification": "INTERNAL",
+        "x-platos-auth-class": "INTERNAL_SHARED_SECRET",
+        "x-platos-policy-rule": "agent-internal-prefix",
+        "x-platos-mcp-tools": []
+      }
+    },
     "/api/v1/agent/internal/skill-run": {
       "post": {
         "operationId": "post__api_v1_agent_internal_skill_run",
@@ -5075,7 +5160,7 @@
           }
         ],
         "x-platos-classification": "MAPPED",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-rest-to-mcp",
         "x-platos-mcp-tools": [
           "providers.list_keys"
@@ -5101,7 +5186,7 @@
           }
         ],
         "x-platos-classification": "MAPPED",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-rest-to-mcp",
         "x-platos-mcp-tools": [
           "providers.add_key"
@@ -5139,7 +5224,7 @@
           }
         ],
         "x-platos-classification": "MAPPED",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-rest-to-mcp",
         "x-platos-mcp-tools": [
           "providers.delete_key"
@@ -5175,7 +5260,7 @@
           }
         ],
         "x-platos-classification": "REST_ONLY",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-default-rest-only",
         "x-platos-mcp-tools": []
       }
@@ -5211,7 +5296,7 @@
           }
         ],
         "x-platos-classification": "REST_ONLY",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-default-rest-only",
         "x-platos-mcp-tools": []
       }
@@ -5237,7 +5322,7 @@
           }
         ],
         "x-platos-classification": "REST_ONLY",
-        "x-platos-auth-class": "SCOPED_USER",
+        "x-platos-auth-class": "OPERATOR",
         "x-platos-policy-rule": "explicit-default-rest-only",
         "x-platos-mcp-tools": []
       }
@@ -9232,6 +9317,6 @@
     }
   },
   "x-platos-manifest-version": "M0.1",
-  "x-platos-rest-operation-count": 297,
+  "x-platos-rest-operation-count": 300,
   "x-platos-mcp-tool-count": 202
 }

--- a/docs/control-plane-parity.generated.md
+++ b/docs/control-plane-parity.generated.md
@@ -7,10 +7,10 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 ## Summary
 
 - MCP tools: **202** across **35** namespaces (24 admin-tier).
-- REST operations: **297** unique method/path pairs from **297** route bindings.
+- REST operations: **300** unique method/path pairs from **300** route bindings.
 - Ambiguous duplicate REST method/path pairs: **0**.
 - MCP classifications: MAPPED=82, MCP_ONLY=120.
-- REST classifications: DEPRECATED=15, INTERNAL=13, MAPPED=82, PUBLIC_TRANSPORT=45, REST_ONLY=142.
+- REST classifications: DEPRECATED=15, INTERNAL=14, MAPPED=82, PUBLIC_TRANSPORT=45, REST_ONLY=144.
 
 ## REST inventory
 
@@ -24,6 +24,7 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 | `POST /api/v1/agent/access-key` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/agent.controller.ts#createOrRotateAccessKey` |
 | `POST /api/v1/agent/access-key/origins` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/agent.controller.ts#setAllowedOrigins` |
 | `GET /api/v1/agent/activity/recent` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/agent.controller.ts#recentActivity` |
+| `POST /api/v1/agent/admin/memory-feedback/backfill` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/memory/memory-feedback-admin.controller.ts#runBackfill` |
 | `POST /api/v1/agent/admin/privacy/erasures` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/privacy/erasure.controller.ts#create` |
 | `GET /api/v1/agent/admin/privacy/erasures/:operationId` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/privacy/erasure.controller.ts#get` |
 | `POST /api/v1/agent/admin/privacy/erasures/:operationId/retry` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/privacy/erasure.controller.ts#retry` |
@@ -49,6 +50,7 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 | `GET /api/v1/agent/agents/:agentId/tool-mappings` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/agent.controller.ts#getAgentToolMappings` |
 | `PATCH /api/v1/agent/agents/:agentId/tool-mappings/:toolId` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/agent.controller.ts#setAgentToolEnabled` |
 | `POST /api/v1/agent/approvals/:approvalId/resolve` | MAPPED | `approvals.resolve` | Reviewed behavioral equivalence: the REST adapter and approvals.resolve invoke the same scope-pinned MonitoringApprovalsService operation; only transport parameters/envelopes differ. | `apps/agent/src/agent-runtime/agent.controller.ts#resolveApproval` |
+| `POST /api/v1/agent/attachments/presigned` | REST_ONLY | — | `explicit-default-rest-only` | `apps/agent/src/agent-runtime/attachment-upload.controller.ts#presign` |
 | `GET /api/v1/agent/budgets` | MAPPED | `budgets.list` | Reviewed behavioral equivalence: the REST adapter and budgets.list invoke the same scope-pinned BudgetService cap operation; only transport parameters/envelopes differ. | `apps/agent/src/agent-runtime/agent.controller.ts#listBudgets` |
 | `POST /api/v1/agent/budgets` | MAPPED | `budgets.upsert` | Reviewed behavioral equivalence: the REST adapter and budgets.upsert invoke the same scope-pinned BudgetService cap operation; only transport parameters/envelopes differ. | `apps/agent/src/agent-runtime/agent.controller.ts#upsertBudget` |
 | `DELETE /api/v1/agent/budgets/:capId` | MAPPED | `budgets.delete` | Reviewed behavioral equivalence: the REST adapter and budgets.delete invoke the same scope-pinned BudgetService cap operation; only transport parameters/envelopes differ. | `apps/agent/src/agent-runtime/agent.controller.ts#deleteBudget` |
@@ -118,6 +120,7 @@ The **explicit operation manifest** is canonical. Platform MCP metadata is seede
 | `POST /api/v1/agent/internal/durable-turn` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/agent-runtime/agent.controller.ts#internalDurableTurn` |
 | `POST /api/v1/agent/internal/employee-run` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/agent-runtime/agent.controller.ts#internalEmployeeRun` |
 | `POST /api/v1/agent/internal/jobs/execute` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/agent-runtime/job-execution.controller.ts#execute` |
+| `GET /api/v1/agent/internal/performance-evidence/:requestId` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/performance-evidence/performance-evidence.controller.ts#consume` |
 | `POST /api/v1/agent/internal/skill-run` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/agent-runtime/agent.controller.ts#internalSkillRun` |
 | `POST /api/v1/agent/internal/subagent-report` | INTERNAL | — | `agent-internal-prefix` | `apps/agent/src/agent-runtime/agent.controller.ts#internalSubagentReport` |
 | `GET /api/v1/agent/jobs` | MAPPED | `jobs.list` | Reviewed behavioral equivalence: the REST adapter and jobs.list invoke the same Environment-owned Job operation; only transport parameters/envelopes differ. | `apps/agent/src/agent-runtime/jobs.controller.ts#list` |


### PR DESCRIPTION
Fixes two defects in `generate-control-plane.mjs` found during M0.2. Independently verified via before/after manifest diff.

## Defect 1 — 3 production-mounted controllers missing from the allowlist
`PRODUCTION_MOUNTED_CONTROLLERS` omitted three controllers that are genuinely mounted (import chain traced to `app.module.ts`), so the manifest undercounted the live REST surface:
- `POST /api/v1/agent/attachments/presigned` (AttachmentUploadController)
- `POST /api/v1/agent/admin/memory-feedback/backfill` (MemoryFeedbackAdminController)
- `GET /api/v1/agent/internal/performance-evidence/:requestId` (PerformanceEvidenceController)

**restOperations 297 → 300.** `TestController` correctly stays excluded.

## Defect 2 — `requiresOperator` was a naive text match
It missed `providers.controller.ts`'s `this.operatorScope(req)` wrapper. Fixed with class-scoped helper resolution: a route is operator-enforcing if it calls `requireOperator`/`getOperatorScope` directly **or** delegates to a helper that does. A whole-codebase AST scan found no other wrapper sites.

**requiresOperator 113 → 120** — the ticket predicted 118; the true count is **120**. Independently confirmed decomposition: 6 flips (all `providers/keys*`) + 1 newly-counted route (`memory-feedback/backfill`, calls `requireOperator` directly). Suggest correcting the ticket's acceptance value to 120.

## Independent verification (orchestrator, not the author)
Before/after manifest diff: **exactly** 3 routes added, 0 removed, **0 classification changes** on pre-existing ops, MCP tool inventory **byte-identical**. 6 operator flips all on `providers/keys*`, 1 new operator op. Generator `--check` exit 0; route-parity audit current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177AxniPpEvRuXqfgpxfSP6