### PR TITLE
fix(auth): close operator-auth fail-open, mandate internal token (WIN-293)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,9 +22,22 @@ ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef 
 # as X-Platos-Internal-Auth on every server-to-server call; the agent grants the
 # "operator" tier over its direct-header channel ONLY for callers that present
 # it. If unset, compose refuses to boot and the webapp fails fast at startup —
-# there is no unauthenticated operator fallback. Generate with:
-#     openssl rand -hex 32                        # min 16 chars; 64 hex recommended
-PLATOS_INTERNAL_AUTH_TOKEN=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+# there is no unauthenticated operator fallback. Not auto-generated: you must
+# set it. The value below is a recognizable placeholder and is REJECTED at
+# startup when NODE_ENV=production, so a copied .env cannot ship a public token.
+#
+# Operating procedures:
+#   generate  — openssl rand -hex 32   (min 16 chars; 64 hex recommended)
+#   preflight — before boot, confirm the same non-placeholder value is present
+#               for BOTH the agent and webapp services (compose reads one env),
+#               and for every durable-execution worker that signs internal
+#               callbacks (the litellm-cost-refresh and budget-alert tasks
+#               read this token; a worker without it 403s on push).
+#   rotate    — set the new value for agent + webapp + workers together, then
+#               restart; there is no dual-accept window, so rotate in one step.
+#   rollback  — keep the prior value until the new one is confirmed live on all
+#               three; revert all three together if a callback starts 403ing.
+PLATOS_INTERNAL_AUTH_TOKEN=feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface
 
 # ─────────────────────────────────────────────────────────────
 # Platos agent — REQUIRED for compose to boot.

--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@
 SESSION_SECRET=abcdef1234-replace-with-real-secret
 MAGIC_LINK_SECRET=abcdef1234-replace-with-real-secret
 ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef # New installs: 64 hex chars. Existing 32-byte UTF-8 values remain valid.
+# WIN-293 — REQUIRED control-plane trust anchor shared by the webapp and the
+# agent (compose passes the SAME value to both services). The webapp sends it
+# as X-Platos-Internal-Auth on every server-to-server call; the agent grants the
+# "operator" tier over its direct-header channel ONLY for callers that present
+# it. If unset, compose refuses to boot and the webapp fails fast at startup —
+# there is no unauthenticated operator fallback. Generate with:
+#     openssl rand -hex 32                        # min 16 chars; 64 hex recommended
+PLATOS_INTERNAL_AUTH_TOKEN=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 
 # ─────────────────────────────────────────────────────────────
 # Platos agent — REQUIRED for compose to boot.

--- a/apps/agent/src/auth/scope.guard.test.ts
+++ b/apps/agent/src/auth/scope.guard.test.ts
@@ -527,6 +527,90 @@ describe("ScopeGuard — Path 2 direct headers", () => {
   });
 });
 
+describe("ScopeGuard — WIN-293 direct-header operator fail-closed", () => {
+  // Guarantee these tests never inherit a control-plane token leaked from
+  // another suite's env mutation: the fail-open only reproduces when the
+  // trust anchor is genuinely absent.
+  let previousToken: string | undefined;
+  beforeEach(() => {
+    previousToken = process.env.PLATOS_INTERNAL_AUTH_TOKEN;
+    delete process.env.PLATOS_INTERNAL_AUTH_TOKEN;
+  });
+  afterEach(() => {
+    if (previousToken === undefined) delete process.env.PLATOS_INTERNAL_AUTH_TOKEN;
+    else process.env.PLATOS_INTERNAL_AUTH_TOKEN = previousToken;
+  });
+
+  const directHeaders = {
+    "x-platos-organization-id": "org_1",
+    "x-platos-project-id": "proj_1",
+    "x-platos-environment-id": "env_1",
+    "x-platos-user-id": "user_1",
+  };
+
+  // (a) THE VULNERABILITY. Unauthenticated direct-header caller, NO AccessKey
+  // configured for the scope (verifyAccessKey → null) and NO control-plane
+  // token. The old guard (`if (keyResult === false)`) skipped the reject on
+  // null and handed out `principal: "operator"` to a caller with no credential.
+  // Non-vacuity: against the OLD logic this resolves to TRUE (no 401), so every
+  // assertion below fails; against the fixed `if (keyResult !== true)` it
+  // resolves FALSE with a 401. Proven empirically by reverting the one-line
+  // condition — see the implementer's report.
+  it("rejects the direct-header operator path when no AccessKey is configured (null) and no control-plane token is present", async () => {
+    const authService = { verifyAccessKey: vi.fn().mockResolvedValue(null) };
+    const guard = new ScopeGuard(authService as any);
+    const ctx = mockExecutionContext(directHeaders, "/api/v1/agent/threads", undefined, "POST");
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(false);
+    expect(authService.verifyAccessKey).toHaveBeenCalledOnce();
+    const response = ctx.switchToHttp().getResponse() as any;
+    expect(response.status).toHaveBeenCalledWith(401);
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "INVALID_ACCESS_KEY" })
+    );
+  });
+
+  // (b) DEFAULT-INSTALL COMPAT. The webapp presents the now-mandatory
+  // PLATOS_INTERNAL_AUTH_TOKEN, so hasValidControlPlaneAuth short-circuits the
+  // AccessKey block entirely: operator is granted and verifyAccessKey is never
+  // called — even though it would have returned null (no keys configured). This
+  // is the path every default install relies on now that the token is required.
+  it("grants operator via the mandatory control-plane token and skips the AccessKey check", async () => {
+    process.env.PLATOS_INTERNAL_AUTH_TOKEN = "win293-control-plane-trust-anchor-token";
+    const authService = { verifyAccessKey: vi.fn().mockResolvedValue(null) };
+    const guard = new ScopeGuard(authService as any);
+    const ctx = mockExecutionContext(
+      { ...directHeaders, "x-platos-internal-auth": "win293-control-plane-trust-anchor-token" },
+      "/api/v1/agent/threads",
+      undefined,
+      "POST"
+    );
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(authService.verifyAccessKey).not.toHaveBeenCalled();
+    expect((ctx.switchToHttp().getRequest() as any).scope.principal).toBe("operator");
+  });
+
+  // (c) POSITIVE-KEY PATH. A runtime caller that presents a valid Environment
+  // AccessKey (verifyAccessKey → true) is still granted operator over the
+  // direct-header channel with no control-plane token — the one credential the
+  // fixed condition accepts.
+  it("grants operator on the direct-header path with a valid AccessKey (true)", async () => {
+    const authService = { verifyAccessKey: vi.fn().mockResolvedValue(true) };
+    const guard = new ScopeGuard(authService as any);
+    const ctx = mockExecutionContext(
+      { ...directHeaders, "x-platos-api-key": "platos_live_valid" },
+      "/api/v1/agent/threads",
+      undefined,
+      "POST"
+    );
+
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
+    expect(authService.verifyAccessKey).toHaveBeenCalledOnce();
+    expect((ctx.switchToHttp().getRequest() as any).scope.principal).toBe("operator");
+  });
+});
+
 describe("ScopeGuard — Path 1 session token", () => {
   beforeEach(() => {
     vi.stubEnv("SESSION_SECRET", "scope-guard-platform-secret-32-chars");
@@ -711,6 +795,24 @@ describe("ScopeGuard — Path 1 session token", () => {
     await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(true);
     expect(h.prisma.mcpBearerToken.updateMany).toHaveBeenCalledOnce();
     expect(h.verifyAccessKey).toHaveBeenCalledOnce();
+  });
+
+  // WIN-293 regression guard for the OTHER verifyAccessKey call site (the
+  // session-token path). Here the caller is ALREADY authenticated by a valid
+  // X-Platos-Session-Token, so verifyAccessKey → null correctly means "no
+  // optional AccessKey gate configured" and MUST still allow. The harness
+  // default-mocks verifyAccessKey → null, so this proves the fail-closed change
+  // was confined to the direct-header site: if someone mirrored the fix onto
+  // this site (`!== true`), null would reject and this test would fail.
+  it("keeps the session-token path allowed when verifyAccessKey returns null (optional-gate semantics preserved)", async () => {
+    const h = makeAuthHarness();
+    expect(await h.auth.verifyAccessKey({} as any, undefined, undefined)).toBeNull();
+    const token = await h.auth.createEntitySessionToken(h.scope as any, "bearer_A", 300);
+    const ctx = mockExecutionContext({ "x-platos-session-token": token! });
+
+    await expect(new ScopeGuard(h.auth).canActivate(ctx)).resolves.toBe(true);
+    expect(h.verifyAccessKey).toHaveBeenCalled();
+    expect((ctx.switchToHttp().getRequest() as any).scope.principal).toBe("end-user");
   });
 
   it("rejects the removed legacy two-part token format", async () => {

--- a/apps/agent/src/auth/scope.guard.ts
+++ b/apps/agent/src/auth/scope.guard.ts
@@ -791,13 +791,30 @@ export class ScopeGuard implements CanActivate {
           providedKey,
           origin
         );
-        if (keyResult === false) {
+        // WIN-293 — fail CLOSED on the unauthenticated direct-header operator
+        // path. Reaching here means the caller presented NO valid control-plane
+        // token (hasValidControlPlaneAuth already returned false above) and this
+        // is not an AccessKey lifecycle route, yet the scope block above already
+        // stamped principal: "operator". Confirm that promotion ONLY on a
+        // POSITIVE AccessKey match. verifyAccessKey returns `null` when no
+        // AccessKey is configured for the scope and `false` when one is
+        // configured but the presented key is missing/invalid — BOTH must reject
+        // here, so an anonymous caller can never be handed operator merely
+        // because no key exists. The trusted webapp reaches operator surfaces
+        // through the mandatory PLATOS_INTERNAL_AUTH_TOKEN (checked above), never
+        // through this branch. The session-token site keeps the opposite
+        // semantics: there `null` means "no optional gate configured" and
+        // correctly allows, because the token already authenticated the caller.
+        if (keyResult !== true) {
           const resp = context.switchToHttp().getResponse();
           resp
             .status(401)
             .json({
               error: "INVALID_ACCESS_KEY",
-              message: "X-Platos-Api-Key is missing or invalid for this scope.",
+              message:
+                keyResult === null
+                  ? "Operator access via direct scope headers requires a configured X-Platos-Api-Key or the internal control-plane token."
+                  : "X-Platos-Api-Key is missing or invalid for this scope.",
             });
           return false;
         }

--- a/apps/agent/src/shared/env-internal-auth-sentinel.test.ts
+++ b/apps/agent/src/shared/env-internal-auth-sentinel.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { validateAgentEnv } from "./env";
+
+// WIN-293 — the control-plane trust anchor must not boot in production with the
+// public `.env.example` placeholder, or the fail-closed operator guard is
+// defeated by a well-known token.
+const SENTINEL =
+  "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface";
+
+const PROD_BASE = {
+  NODE_ENV: "production",
+  DATABASE_URL: "postgresql://localhost:5432/platos",
+  REDIS_URL: "redis://localhost:6379",
+  SESSION_SECRET: "prod-session-secret-long-enough",
+  PLATOS_ENCRYPTION_KEY: "11".repeat(32),
+  PLATOS_MESSAGE_ENCRYPTION_KEY: "22".repeat(32),
+  PLATOS_ERASURE_HASH_SALT: "44".repeat(32),
+  PLATOS_COMPONENT_AUTH_SECRET: "prod-component-secret-strong",
+  PLATOS_CREDENTIAL_ROOT_KEY_VERSION: "1",
+  PLATOS_CREDENTIAL_ROOT_KEYS: JSON.stringify({ "1": "33".repeat(32) }),
+};
+
+describe("PLATOS_INTERNAL_AUTH_TOKEN production sentinel", () => {
+  it("rejects the .env.example placeholder in production", () => {
+    const result = validateAgentEnv({
+      ...PROD_BASE,
+      PLATOS_INTERNAL_AUTH_TOKEN: SENTINEL,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(JSON.stringify(result)).toContain("PLATOS_INTERNAL_AUTH_TOKEN");
+      expect(JSON.stringify(result)).toContain("sentinel");
+    }
+  });
+
+  it("requires the token to be present in production", () => {
+    const { PLATOS_INTERNAL_AUTH_TOKEN, ...noToken } = {
+      ...PROD_BASE,
+      PLATOS_INTERNAL_AUTH_TOKEN: SENTINEL,
+    };
+    void PLATOS_INTERNAL_AUTH_TOKEN;
+    const result = validateAgentEnv(noToken);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(JSON.stringify(result)).toContain("PLATOS_INTERNAL_AUTH_TOKEN");
+    }
+  });
+
+  it("raises NO token-specific issue for a real random token in production", () => {
+    // Isolates the token rule from other prod-env requirements: a real random
+    // value must produce zero PLATOS_INTERNAL_AUTH_TOKEN issues (the env may
+    // still be invalid for unrelated reasons, which this test does not assert).
+    const result = validateAgentEnv({
+      ...PROD_BASE,
+      PLATOS_INTERNAL_AUTH_TOKEN: "aa".repeat(32),
+    });
+    const tokenIssue = result.ok
+      ? false
+      : JSON.stringify(result).includes("PLATOS_INTERNAL_AUTH_TOKEN");
+    expect(tokenIssue).toBe(false);
+  });
+});

--- a/apps/agent/src/shared/env.ts
+++ b/apps/agent/src/shared/env.ts
@@ -20,6 +20,12 @@ const DEV_SENTINEL_SESSION_SECRET = "dev-session-secret-rotate-before-prod";
 const DEV_SENTINEL_WEBAPP_ENCRYPTION_KEY =
   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 const DEV_COMPONENT_AUTH_SECRET = "dev-internal-secret-change-me";
+// WIN-293 — the `.env.example` placeholder for the control-plane trust anchor.
+// A distinct value (not reused from the encryption-key sentinel) so a copied
+// `.env` is recognizable, and rejected in production below: shipping a public
+// value here would hand every reader the operator credential.
+const DEV_SENTINEL_INTERNAL_AUTH_TOKEN =
+  "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface";
 const COMPONENT_AUTH_PLACEHOLDERS = new Set([
   "",
   DEV_COMPONENT_AUTH_SECRET,
@@ -486,6 +492,25 @@ export const AgentEnvSchema = z
           path: ["PLATOS_COMPONENT_AUTH_SECRET"],
           message:
             "PLATOS_COMPONENT_AUTH_SECRET must be set to a strong random value in production",
+        });
+      }
+      // WIN-293 — the control-plane trust anchor is the ONLY credential that
+      // grants the operator tier over the direct-header channel. It must be
+      // present and must not be the public `.env.example` placeholder, or the
+      // fail-closed guard is defeated by a well-known token.
+      if (!data.PLATOS_INTERNAL_AUTH_TOKEN) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["PLATOS_INTERNAL_AUTH_TOKEN"],
+          message: "PLATOS_INTERNAL_AUTH_TOKEN is required in production",
+        });
+      }
+      if (data.PLATOS_INTERNAL_AUTH_TOKEN === DEV_SENTINEL_INTERNAL_AUTH_TOKEN) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["PLATOS_INTERNAL_AUTH_TOKEN"],
+          message:
+            "PLATOS_INTERNAL_AUTH_TOKEN is the .env.example sentinel value — rotate before going to production",
         });
       }
     }

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -8,7 +8,12 @@ const schema = z.object({
   PLATOS_AGENT_API_URL: z.string().url().default("http://localhost:3100"),
   // Authenticates server-to-server dashboard requests to the Agent. It is
   // never exposed to the browser and is distinct from an Environment API key.
-  PLATOS_INTERNAL_AUTH_TOKEN: z.string().min(16).optional(),
+  // WIN-293 — REQUIRED. This token is the trust anchor for the webapp→agent
+  // control-plane path: the agent's ScopeGuard grants "operator" over the
+  // direct-header channel only for callers that present it. Fail fast at boot
+  // if unset so a running install can never silently fall back to an
+  // unauthenticated operator grant.
+  PLATOS_INTERNAL_AUTH_TOKEN: z.string().min(16),
   RESEND_API_KEY: z.string().optional(),
   FROM_EMAIL: z.string().default("Platos <no-reply@platos.dev>"),
   BACKDOOR_PLATOS_DEV: z.string().optional(),

--- a/apps/webapp/app/env.server.ts
+++ b/apps/webapp/app/env.server.ts
@@ -19,6 +19,23 @@ const schema = z.object({
   BACKDOOR_PLATOS_DEV: z.string().optional(),
   BACKDOOR_PLATOS_DEV_EMAIL: z.string().email().optional(),
   PLATOS_TEST_MODE: z.string().optional(),
+}).superRefine((data, ctx) => {
+  // WIN-293 — the webapp SENDS this token to the agent, so a webapp running the
+  // public `.env.example` placeholder leaks the operator credential regardless
+  // of which agent it points at. Reject the placeholder in production, matching
+  // the agent's own sentinel check.
+  if (
+    data.NODE_ENV === "production" &&
+    data.PLATOS_INTERNAL_AUTH_TOKEN ===
+      "feedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedfacefeedface"
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["PLATOS_INTERNAL_AUTH_TOKEN"],
+      message:
+        "PLATOS_INTERNAL_AUTH_TOKEN is the .env.example sentinel value — rotate before going to production",
+    });
+  }
 });
 
 export const env = schema.parse(process.env);

--- a/docker-compose.platos.yml
+++ b/docker-compose.platos.yml
@@ -445,9 +445,14 @@ services:
       PLATOS_ATTACHMENT_PRESIGN_TTL_SECONDS: "${PLATOS_ATTACHMENT_PRESIGN_TTL_SECONDS:-900}"
       PLATOS_ATTACHMENT_GRACE_DAYS: "${PLATOS_ATTACHMENT_GRACE_DAYS:-7}"
       PLATOS_ATTACHMENT_ORG_QUOTA_BYTES: "${PLATOS_ATTACHMENT_ORG_QUOTA_BYTES:-10737418240}"
-      # Admin token — shared with the webapp so the scheduled retention
-      # task can POST /api/v1/agent/attachments/retention.
-      PLATOS_INTERNAL_AUTH_TOKEN: "${PLATOS_INTERNAL_AUTH_TOKEN:-}"
+      # Control-plane trust anchor — shared with the webapp. Authenticates
+      # trusted webapp→agent traffic (the ScopeGuard grants operator over the
+      # direct-header channel only for callers that present it) AND lets the
+      # scheduled retention task POST /api/v1/agent/attachments/retention.
+      # WIN-293 — REQUIRED: without it the agent's direct-header operator path
+      # would have to fall back to an unauthenticated grant. Same value in the
+      # webapp block below.
+      PLATOS_INTERNAL_AUTH_TOKEN: "${PLATOS_INTERNAL_AUTH_TOKEN:?required — 64 hex chars from openssl rand -hex 32}"
       PLATOS_ERASURE_HASH_SALT: "${PLATOS_ERASURE_HASH_SALT:?required — openssl rand -hex 32}"
       # Erased-subject write barrier retention. See docs/gdpr-erasure.md.
       PLATOS_ERASURE_TOMBSTONE_TTL_DAYS: "${PLATOS_ERASURE_TOMBSTONE_TTL_DAYS:-30}"
@@ -635,8 +640,11 @@ services:
       # attached uploads default to 30 days.
       PLATOS_ATTACHMENT_GRACE_DAYS: "${PLATOS_ATTACHMENT_GRACE_DAYS:-7}"
       PLATOS_ATTACHMENT_TTL_DAYS: "${PLATOS_ATTACHMENT_TTL_DAYS:-30}"
-      # Admin token shared with the agent's scheduled retention task.
-      PLATOS_INTERNAL_AUTH_TOKEN: "${PLATOS_INTERNAL_AUTH_TOKEN:-}"
+      # Control-plane trust anchor shared with the agent (must match the agent
+      # block's value). The webapp sends it as X-Platos-Internal-Auth on every
+      # server-to-server call so the agent authenticates the dashboard without a
+      # browser-generated AccessKey. WIN-293 — REQUIRED.
+      PLATOS_INTERNAL_AUTH_TOKEN: "${PLATOS_INTERNAL_AUTH_TOKEN:?required — 64 hex chars from openssl rand -hex 32}"
     healthcheck:
       test:
         [


### PR DESCRIPTION
⚠️ **DRAFT — approved token mandate; review corrections applied. Merge after rebase onto #129 (both touch docker-compose.platos.yml).**

Closes the fail-open where a credential-less direct-header request was granted `principal: "operator"`.

## The fix (surgical)
`scope.guard.ts`, one condition at the direct-header operator site only: `if (keyResult === false)` → `if (keyResult !== true)`. Old guard rejected only `false`, so `null` (no keys configured) granted operator to an unauthenticated caller. Now operator via this path requires a positive key match. **Session-token site byte-for-byte unchanged.**

## Trust anchor — the token is REQUIRED (not auto-generated)
`null`-passes was the mechanism the default deployment used for webapp→agent, because `PLATOS_INTERNAL_AUTH_TOKEN` defaulted to empty. So the fix establishes the real anchor:
- `docker-compose.platos.yml`: token `:?required` — **compose fails fast when it is absent; it does not generate a value.**
- `apps/webapp/app/env.server.ts`: token required (drops `.optional()`).
- `.env.example`: documents it as required, with generation/preflight/rotation/rollback procedures.

## Review corrections (commit 311f69c)
1. **Production sentinel rejection.** The `.env.example` placeholder is a distinct `feedface…` value (not the reused encryption-key `deadbeef…`), and both the agent (`env.ts`, matching EOBD.3) and webapp (`env.server.ts` superRefine) **reject it under NODE_ENV=production** — a copied `.env` can no longer ship a public operator token. New `env-internal-auth-sentinel.test.ts` (3 tests) proves rejection of the placeholder and of an absent token; 164 auth+env tests green.
2. Removed the inaccurate "auto-generated" language.
3. Added ops procedures (generation / preflight / rotation / rollback / durable-worker propagation) to `.env.example`.

## ⚠️ Breaking on upgrade (mandate approved)
`PLATOS_INTERNAL_AUTH_TOKEN` is now required; existing deployments must set it before upgrading or the agent/webapp refuse to boot. Live test.platos.dev already has matching non-empty values, so it is compatible. Belongs in release notes.

Independently verified: fail-open closed, session path untouched, default deployment fail-closed. Full analysis + verdict on Linear WIN-293. **Separate pre-existing residual tracked as WIN-296** (AccessKey-lifecycle routes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177AxniPpEvRuXqfgpxfSP6