### PR TITLE
WIN-267 G3: the AgentsContract assembler already existed — the correction, and the sweep that found three more stale claims

### DIFF
--- a/apps/core-api/mutations-win267-g3.json
+++ b/apps/core-api/mutations-win267-g3.json
@@ -1,0 +1,187 @@
+{
+  "$schema-note": "Hand-maintained. Data, not code: nothing under src/ imports this file.",
+  "purpose": [
+    "WIN-267 G3 was briefed to BUILD the AgentsContract assembler that",
+    "`IDENTITY_ACCESS_UNASSEMBLED` said no factory assembles. There was nothing",
+    "to build: `agentsContract` has been exported from",
+    "packages/contexts/agents/contracts/index.ts since before that sentence was",
+    "written, from the `.` entry point `app.module.ts` already imports the",
+    "`AgentsContract` TYPE from.",
+    "",
+    "So the tranche's deliverable is a CORRECTION, and a correction is worth",
+    "nothing unless something would notice it going stale again. That is what",
+    "this sweep measures. The three cases added to installation.test.ts each",
+    "join a claim to something apps/core-api does not own -- the agents",
+    "package's module graph, ADAPTER_BINDINGS, and the resolver reading each",
+    "context package's own exports map -- and the mutations below break each",
+    "join in both directions.",
+    "",
+    "TWO OF THE EIGHT ARE THE POINT. G3-M07 makes the claim BECOME TRUE by",
+    "publishing governance's ./application/index.js, and G3-M08 removes the",
+    "factory the correction rests on, in the artifact the runner actually",
+    "resolves. A correction that survived either of those would be prose."
+  ],
+  "procedure": [
+    "Base: tejas/win-267-compose @ ff06655f (the head of PR #153, open against v1).",
+    "Runner: pnpm --filter @platos/core-api exec vitest run src/composition/installation.test.ts",
+    "Baseline: 20 passed (20). 17 of those are the suite as it stood at ff06655f.",
+    "Each mutation applied to the working tree, the runner re-run, the tree",
+    "restored from a byte copy taken before the sweep, and the baseline",
+    "re-confirmed green at the end (20 passed).",
+    "",
+    "G3-M08 IS RECORDED HONESTLY AS A SECOND ATTEMPT. Renaming",
+    "`agentsContract` in packages/contexts/agents/contracts/index.ts and",
+    "rebuilding FAILED the build -- the agents package's own contracts",
+    "suite imports it -- so dist was never regenerated and the runner still",
+    "resolved the old artifact and stayed GREEN. That first attempt was a",
+    "VACUOUS pass, not a survivor, and it is written down because counting it",
+    "as one would have been the exact accounting error this project's mutation",
+    "discipline exists to stop. The mutation was re-applied to",
+    "packages/contexts/agents/dist/contracts/index.js, which is what the",
+    "runner resolves, and killed there."
+  ],
+  "sweep": {
+    "head": "the tree of the commit that carries this file, on tejas/win-267-g3-agents (base tejas/win-267-compose @ ff06655f)",
+    "entries": 8,
+    "killed": 8,
+    "equivalent": 0,
+    "vacuous": 0,
+    "rejected": 0
+  },
+  "mutations": [
+    {
+      "name": "G3-M01 the withdrawn claim is restored into the runtime reason string",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "\" whose AgentsContract slot needs a composed agents -- agentsContract does\" +",
+      "to": "\" and an AgentsContract no factory assembles\" +",
+      "suites": ["vitest"],
+      "note": "The headline. The sentence this tranche withdrew is put back verbatim; the case that exists to stop it coming back must notice. It asserts the ABSENCE of the wording rather than only the presence of the correction, because a future edit that reintroduced the claim alongside the correction would otherwise pass.",
+      "kills": [
+        "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
+      ]
+    },
+    {
+      "name": "G3-M02 the reason stops NAMING the factory that withdrew the claim",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "agentsContract does\" +\n  \" assemble",
+      "to": "a factory does\" +\n  \" assemble",
+      "suites": ["vitest"],
+      "note": "The other direction of M01. A reason that says 'a factory does assemble it' is unfalsifiable prose; naming `agentsContract` is what lets a reader grep for the thing and what makes G3-M08 able to kill. Without this case the correction could decay into a vaguer sentence with nothing going red.",
+      "kills": [
+        "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
+      ]
+    },
+    {
+      "name": "G3-M03 AGENTS_UNBOUND_PORTS gains a port that IS bound",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "Object.freeze([\n  \"AgentVersionLock\",",
+      "to": "Object.freeze([\n  \"AgentsRepository\",\n  \"AgentVersionLock\",",
+      "suites": ["vitest"],
+      "note": "`AgentsRepository` is on a row of ADAPTER_BINDINGS against postgres-tenancy. The list is joined to that table rather than to itself, so a name that is in fact bound cannot sit on it -- which is the failure mode that made the sentence this tranche withdrew wrong for three tranches.",
+      "kills": [
+        "the context bundles those adapters can satisfy > blocks that contract on two agents ports instead, and joins them to the table"
+      ]
+    },
+    {
+      "name": "G3-M04 AGENTS_UNBOUND_PORTS silently loses one of the two",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "  \"AgentVersionLock\",\n  \"MacroRecorder\",\n]);",
+      "to": "  \"AgentVersionLock\",\n]);",
+      "suites": ["vitest"],
+      "note": "The shrinking direction, which is how a list of blockers goes quietly optimistic. Both the length and the membership are pinned, and each member must also be NAMED in the reason an operator reads, so dropping one fails twice.",
+      "kills": [
+        "the context bundles those adapters can satisfy > blocks that contract on two agents ports instead, and joins them to the table"
+      ]
+    },
+    {
+      "name": "G3-M05 governance is dropped from UNIMPORTABLE_CONTEXT_FACTORIES",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "  \"governance\",\n  \"jobs\",",
+      "to": "  \"jobs\",",
+      "suites": ["vitest"],
+      "note": "The one entry a future tranche has the strongest incentive to remove, because governance is what identity-access is waiting on. Its membership is asserted by name and not only by the count, so removing it cannot be hidden by adding another.",
+      "kills": [
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+      ]
+    },
+    {
+      "name": "G3-M06 a context that IS importable is put on the unimportable list",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "from": "  \"channels\",\n  \"conversations\",",
+      "to": "  \"tenancy\",\n  \"conversations\",",
+      "suites": ["vitest"],
+      "note": "`tenancy` publishes ./application/index.js and app.module.ts imports createTenancyService through it. The import RESOLVES, so the rejects assertion fails. This is the case's non-vacuity guard from the pessimistic side: the list cannot be padded with contexts that are fine.",
+      "kills": [
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+      ]
+    },
+    {
+      "name": "G3-M07 governance PUBLISHES ./application/index.js -- the claim becomes TRUE",
+      "file": "packages/contexts/governance/package.json",
+      "from": "\"exports\": { \".\": ..., \"./application/ports/index.js\": ..., \"./application/testing/index.js\": ... }",
+      "to": "the same map plus \"./application/index.js\": { \"types\": \"./dist/application/index.d.ts\", \"import\": \"./dist/application/index.js\" }",
+      "suites": ["vitest"],
+      "note": "THE MUTATION THIS TRANCHE WAS ASKED FOR: the claim becoming true again. Nothing else changed -- dist/application/index.js was already built, so publishing the subpath is the whole of it -- and the import stops rejecting. A tranche that composes governance will hit this case on its first run, which is the intended way for it to learn that the manifest line and the adapters have to land together.",
+      "kills": [
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+      ]
+    },
+    {
+      "name": "G3-M08 agentsContract is renamed in the artifact the runner resolves",
+      "file": "packages/contexts/agents/dist/contracts/index.js",
+      "from": "agentsContract",
+      "to": "assembleAgents",
+      "suites": ["vitest"],
+      "note": "The deepest one, and the only mutation in this sweep outside apps/core-api's own source. The correction rests on a VALUE import of another package's factory; if that import were decorative the case would pass without it. Renaming the export in packages/contexts/agents/dist/contracts/index.js -- the file @platos/context-agents's `.` condition resolves to -- makes the import undefined and the case red. See `procedure` for the first attempt, which was vacuous and is not counted.",
+      "kills": [
+        "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
+      ]
+    }
+  ],
+  "rejectedMutations": [],
+  "declaredUnfalsifiable": [
+    {
+      "name": "E01 no composition is unblocked by this correction, so none is asserted",
+      "file": "apps/core-api/src/composition/context-ports.ts",
+      "classification": "no-behaviour-to-mutate--the-finding-is-that-the-work-was-unnecessary",
+      "measurement": [
+        "The brief allowed for the deliverable being 'a three-line composition",
+        "change plus a test that proves it'. It is not even that: correcting the",
+        "claim composes NOTHING, and this entry records that as a measured",
+        "result rather than leaving a reader to wonder why no context moved.",
+        "",
+        "MEASURED, per context, by joining every context's dependency bundle to",
+        "ADAPTER_BINDINGS and to the set constructAdapters actually builds.",
+        "Fourteen contexts are uncomposed. Every one of them has at least one",
+        "driven port that is on NO binding row, or one whose row names a",
+        "directory on UNIMPLEMENTED_ADAPTERS, or a peer in the same state:",
+        "",
+        "  agents          AgentVersionLock, MacroRecorder unbound; skills peer",
+        "  channels        ChannelAdapterRegistry, ChannelCredentialReader,",
+        "                  AgentDirectory, ChannelEventCipher unbound",
+        "  conversations   all four store ports bound -- blocked only by SEVEN",
+        "                  uncomposed peers, the nearest thing to a near miss",
+        "  cost-monitoring SpendLedger, BudgetCapCache unbound",
+        "  eventing        DestinationScreen, NotificationQueue unbound",
+        "  files           every port bound; ObjectStore's directory",
+        "                  objectstore-minio is on UNIMPLEMENTED_ADAPTERS",
+        "  governance      five unbound; agents peer; factory unimportable",
+        "  identity-access all six driven ports bound; kernel SafetyEventSink",
+        "  jobs            JobHandlerRuntime unbound; DurableRuntime unbuilt",
+        "  memory          EmbeddingModel, ExtractionJudge, ContentDigest unbound",
+        "  observability   ProjectionOutbox, ErasedSubjectRegister,",
+        "                  SubjectLocatorSource unbound; ObservabilitySink's",
+        "                  clickhouse-observability unbuilt",
+        "  privacy         SubjectDirectory, SubjectHasher, LegalHoldRegister",
+        "  skills          SkillSourceFetcher, EnvironmentKeyDirectory,",
+        "                  SkillSandbox unbound; files peer",
+        "  tools           ToolDispatch, ContentDigest unbound",
+        "",
+        "So the false claim was never the SOLE blocker for any context, which is",
+        "why this tranche composes nothing and says so. What it changes is what",
+        "the next milestone believes the remaining work IS: not four assemblers",
+        "to write, but adapter directories to build and manifest lines to add."
+      ]
+    }
+  ]
+}

--- a/apps/core-api/mutations-win267-g3.json
+++ b/apps/core-api/mutations-win267-g3.json
@@ -11,15 +11,17 @@
     "So the tranche's deliverable is a CORRECTION, and a correction is worth",
     "nothing unless something would notice it going stale again. That is what",
     "this sweep measures. The three cases added to installation.test.ts each",
-    "join a claim to something apps/core-api does not own -- the agents",
-    "package's module graph, ADAPTER_BINDINGS, and the resolver reading each",
-    "context package's own exports map -- and the mutations below break each",
-    "join in both directions.",
+    "join a claim to something apps/core-api does not own -- the nine context",
+    "packages' module graphs, ADAPTER_BINDINGS, and the seventeen context",
+    "manifests' own exports maps -- and the mutations below break each join",
+    "from both sides.",
     "",
-    "TWO OF THE EIGHT ARE THE POINT. G3-M07 makes the claim BECOME TRUE by",
-    "publishing governance's ./application/index.js, and G3-M08 removes the",
-    "factory the correction rests on, in the artifact the runner actually",
-    "resolves. A correction that survived either of those would be prose."
+    "THREE OF THE NINE ARE THE POINT. G3-M07 makes the claim BECOME TRUE by",
+    "publishing governance's ./application/index.js. G3-M08 and G3-M09 remove",
+    "the factories the correction rests on -- `agents` and `tools`, two of the",
+    "four contexts the withdrawn sentence accused -- in the artifacts the",
+    "runner actually resolves. A correction that survived any of those would",
+    "be prose."
   ],
   "procedure": [
     "Base: tejas/win-267-compose @ ff06655f (the head of PR #153, open against v1).",
@@ -28,6 +30,14 @@
     "Each mutation applied to the working tree, the runner re-run, the tree",
     "restored from a byte copy taken before the sweep, and the baseline",
     "re-confirmed green at the end (20 passed).",
+    "",
+    "THE SWEEP WAS RE-RUN IN FULL after rule (C4) forced the third case to change",
+    "instrument. Its first shape resolved a specifier assembled at run time, which",
+    "`composition-root.mjs` refuses outside apps/mcp-stdio/src/runtime.ts; a LITERAL",
+    "dynamic import of a subpath that does not exist then failed in Vite's transform,",
+    "so no case ran at all. The case now joins the manifests for the absent half and",
+    "nine STATIC imports for the present half. Every mutation below was re-applied",
+    "against that shape rather than carried over from the first.",
     "",
     "G3-M08 IS RECORDED HONESTLY AS A SECOND ATTEMPT. Renaming",
     "`agentsContract` in packages/contexts/agents/contracts/index.ts and",
@@ -42,8 +52,8 @@
   ],
   "sweep": {
     "head": "the tree of the commit that carries this file, on tejas/win-267-g3-agents (base tejas/win-267-compose @ ff06655f)",
-    "entries": 8,
-    "killed": 8,
+    "entries": 9,
+    "killed": 9,
     "equivalent": 0,
     "vacuous": 0,
     "rejected": 0
@@ -54,7 +64,9 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "\" whose AgentsContract slot needs a composed agents -- agentsContract does\" +",
       "to": "\" and an AgentsContract no factory assembles\" +",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "The headline. The sentence this tranche withdrew is put back verbatim; the case that exists to stop it coming back must notice. It asserts the ABSENCE of the wording rather than only the presence of the correction, because a future edit that reintroduced the claim alongside the correction would otherwise pass.",
       "kills": [
         "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
@@ -65,7 +77,9 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "agentsContract does\" +\n  \" assemble",
       "to": "a factory does\" +\n  \" assemble",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "The other direction of M01. A reason that says 'a factory does assemble it' is unfalsifiable prose; naming `agentsContract` is what lets a reader grep for the thing and what makes G3-M08 able to kill. Without this case the correction could decay into a vaguer sentence with nothing going red.",
       "kills": [
         "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
@@ -76,7 +90,9 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "Object.freeze([\n  \"AgentVersionLock\",",
       "to": "Object.freeze([\n  \"AgentsRepository\",\n  \"AgentVersionLock\",",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "`AgentsRepository` is on a row of ADAPTER_BINDINGS against postgres-tenancy. The list is joined to that table rather than to itself, so a name that is in fact bound cannot sit on it -- which is the failure mode that made the sentence this tranche withdrew wrong for three tranches.",
       "kills": [
         "the context bundles those adapters can satisfy > blocks that contract on two agents ports instead, and joins them to the table"
@@ -87,7 +103,9 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "  \"AgentVersionLock\",\n  \"MacroRecorder\",\n]);",
       "to": "  \"AgentVersionLock\",\n]);",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "The shrinking direction, which is how a list of blockers goes quietly optimistic. Both the length and the membership are pinned, and each member must also be NAMED in the reason an operator reads, so dropping one fails twice.",
       "kills": [
         "the context bundles those adapters can satisfy > blocks that contract on two agents ports instead, and joins them to the table"
@@ -98,10 +116,12 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "  \"governance\",\n  \"jobs\",",
       "to": "  \"jobs\",",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "The one entry a future tranche has the strongest incentive to remove, because governance is what identity-access is waiting on. Its membership is asserted by name and not only by the count, so removing it cannot be hidden by adding another.",
       "kills": [
-        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"
       ]
     },
     {
@@ -109,10 +129,12 @@
       "file": "apps/core-api/src/composition/context-ports.ts",
       "from": "  \"channels\",\n  \"conversations\",",
       "to": "  \"tenancy\",\n  \"conversations\",",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "`tenancy` publishes ./application/index.js and app.module.ts imports createTenancyService through it. The import RESOLVES, so the rejects assertion fails. This is the case's non-vacuity guard from the pessimistic side: the list cannot be padded with contexts that are fine.",
       "kills": [
-        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"
       ]
     },
     {
@@ -120,10 +142,12 @@
       "file": "packages/contexts/governance/package.json",
       "from": "\"exports\": { \".\": ..., \"./application/ports/index.js\": ..., \"./application/testing/index.js\": ... }",
       "to": "the same map plus \"./application/index.js\": { \"types\": \"./dist/application/index.d.ts\", \"import\": \"./dist/application/index.js\" }",
-      "suites": ["vitest"],
+      "suites": [
+        "vitest"
+      ],
       "note": "THE MUTATION THIS TRANCHE WAS ASKED FOR: the claim becoming true again. Nothing else changed -- dist/application/index.js was already built, so publishing the subpath is the whole of it -- and the import stops rejecting. A tranche that composes governance will hit this case on its first run, which is the intended way for it to learn that the manifest line and the adapters have to land together.",
       "kills": [
-        "the context bundles those adapters can satisfy > cannot import eight context factories, and proves it against Node's resolver"
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"
       ]
     },
     {
@@ -131,10 +155,26 @@
       "file": "packages/contexts/agents/dist/contracts/index.js",
       "from": "agentsContract",
       "to": "assembleAgents",
-      "suites": ["vitest"],
-      "note": "The deepest one, and the only mutation in this sweep outside apps/core-api's own source. The correction rests on a VALUE import of another package's factory; if that import were decorative the case would pass without it. Renaming the export in packages/contexts/agents/dist/contracts/index.js -- the file @platos/context-agents's `.` condition resolves to -- makes the import undefined and the case red. See `procedure` for the first attempt, which was vacuous and is not counted.",
+      "suites": [
+        "vitest"
+      ],
+      "note": "The deepest one, and the only mutation in this sweep outside apps/core-api's own source. The correction rests on a VALUE import of another package's factory; if that import were decorative the case would pass without it. Renaming the export in packages/contexts/agents/dist/contracts/index.js -- the file @platos/context-agents's `.` condition resolves to -- makes the import undefined and TWO cases red: the correction's own, and the importability partition, which counts `agents` among the six factories reachable from a `.` entry point. See `procedure` for the first attempt, which was vacuous and is not counted.",
       "kills": [
-        "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble"
+        "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble",
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"
+      ]
+    },
+    {
+      "name": "G3-M09 toolsContract is renamed in the artifact the runner resolves",
+      "file": "packages/contexts/tools/dist/contracts/index.js",
+      "from": "toolsContract",
+      "to": "assembleTools",
+      "suites": [
+        "vitest"
+      ],
+      "note": "`tools` is one of the four contexts the withdrawn sentence named as publishing 'their use cases one by one and no assembler over them'. Nothing in this repository composes it, so without a mutation its side of the partition would rest on an import nobody exercises. Renaming the export in the artifact @platos/context-tools's `.` condition resolves to makes the partition red, which is what makes the withdrawal of the claim about `tools` -- not just about `agents` -- a measured result.",
+      "kills": [
+        "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"
       ]
     }
   ],

--- a/apps/core-api/mutations-win267-g3.json
+++ b/apps/core-api/mutations-win267-g3.json
@@ -39,11 +39,11 @@
     "nine STATIC imports for the present half. Every mutation below was re-applied",
     "against that shape rather than carried over from the first.",
     "",
-    "G3-M08 IS RECORDED HONESTLY AS A SECOND ATTEMPT. Renaming",
+    "G3-M08 IS RECORDED HONESTLY AS A SECOND APPLICATION. Renaming",
     "`agentsContract` in packages/contexts/agents/contracts/index.ts and",
     "rebuilding FAILED the build -- the agents package's own contracts",
     "suite imports it -- so dist was never regenerated and the runner still",
-    "resolved the old artifact and stayed GREEN. That first attempt was a",
+    "resolved the old artifact and stayed GREEN. That first application was a",
     "VACUOUS pass, not a survivor, and it is written down because counting it",
     "as one would have been the exact accounting error this project's mutation",
     "discipline exists to stop. The mutation was re-applied to",
@@ -158,7 +158,7 @@
       "suites": [
         "vitest"
       ],
-      "note": "The deepest one, and the only mutation in this sweep outside apps/core-api's own source. The correction rests on a VALUE import of another package's factory; if that import were decorative the case would pass without it. Renaming the export in packages/contexts/agents/dist/contracts/index.js -- the file @platos/context-agents's `.` condition resolves to -- makes the import undefined and TWO cases red: the correction's own, and the importability partition, which counts `agents` among the six factories reachable from a `.` entry point. See `procedure` for the first attempt, which was vacuous and is not counted.",
+      "note": "The deepest one, and the only mutation in this sweep outside apps/core-api's own source. The correction rests on a VALUE import of another package's factory; if that import were decorative the case would pass without it. Renaming the export in packages/contexts/agents/dist/contracts/index.js -- the file @platos/context-agents's `.` condition resolves to -- makes the import undefined and TWO cases red: the correction's own, and the importability partition, which counts `agents` among the six factories reachable from a `.` entry point. See `procedure` for the first application of it, which was vacuous and is not counted.",
       "kills": [
         "the context bundles those adapters can satisfy > names an AgentsContract that a published factory DOES assemble",
         "the context bundles those adapters can satisfy > cannot import eight context factories, and partitions all seventeen manifests"

--- a/apps/core-api/src/composition/context-ports.ts
+++ b/apps/core-api/src/composition/context-ports.ts
@@ -24,21 +24,35 @@
 // Seventeen contexts are declared. `app.module.ts` can compose a context only
 // when THREE things are true at once, and the count falls away fast:
 //
-//   1. the context publishes a factory that assembles its whole contract.
-//      THIRTEEN do; FOUR do not -- `agents`, `tools`, `memory` and
-//      `cost-monitoring` publish their use cases one by one and no assembler
-//      over them.
+//   1. the context publishes a factory that assembles its whole contract, AND
+//      this package can import it. SEVENTEEN publish one; NINE are importable.
 //
-//      THIS SENTENCE USED TO SAY ELEVEN AND SIX, AND IT NAMED `secrets` AND
-//      `providers` AMONG THE SIX. It was wrong on both, and it was wrong at v1
-//      rather than newly wrong: `secretsContract` has been exported from
-//      `packages/contexts/secrets/contracts/index.ts` and `providersContract`
-//      from `packages/contexts/providers/contracts/index.ts` since before this
-//      note was written, and both are on the `.` entry point every package
-//      already publishes. WIN-267 A3 repeated the claim in
-//      `PROVIDERS_UNASSEMBLED` and made a decision on it. It is corrected here by
-//      MEASUREMENT and, more to the point, by acting on it: both contexts are
-//      composed below.
+//      THIS CONDITION USED TO BE ONE CLAUSE AND IT WAS FALSE THREE TIMES OVER.
+//      It read "THIRTEEN do; FOUR do not -- `agents`, `tools`, `memory` and
+//      `cost-monitoring` publish their use cases one by one and no assembler
+//      over them", and before that "ELEVEN and SIX", naming `secrets` and
+//      `providers` among the six. Every version of it has been wrong in the same
+//      direction and wrong at v1 rather than newly wrong. `agentsContract`,
+//      `toolsContract`, `memoryContract` and `costMonitoringContract` sit in
+//      their own packages' `contracts/index.ts` beside `secretsContract` and
+//      `providersContract` -- the `.` entry point this file already imports
+//      `DEFAULT_PROVIDERS_POLICY` from -- and the other eleven contexts publish
+//      a `create*Contract` or `create*Service` in `application/`. WIN-267 G3
+//      grepped for the four the way A3 should have grepped for the two, and
+//      found the same answer: there is no context in this tree without an
+//      assembler, and there never was.
+//
+//      SO THE CONDITION IS SPLIT, because the half that is real is a MANIFEST
+//      question and not an authoring one. Nine factories can be named from here:
+//      six from `.`, and `identity-access`, `tenancy` and `skills` from the
+//      `./application/index.js` their manifests publish. The other eight --
+//      `UNIMPORTABLE_CONTEXT_FACTORIES` below -- publish only `.`,
+//      `./application/ports/index.js` and `./application/testing/index.js`, so
+//      their factory exists, is tested, and cannot be imported by the one file
+//      entitled to call it. That is WIN-297's finding, unchanged and still open
+//      for eight contexts; the fix is a line of `APPLICATION_ENTRY_PROJECTS`
+//      each, and that generator's own rule holds it back until the context is
+//      actually composed.
 //
 //   2. every driven port in its dependency bundle has an implementation SOMEWHERE
 //      in this tree.
@@ -98,13 +112,37 @@
 // no row in `ADAPTER_BINDINGS` and no adapter directory anywhere:
 // `RatingTargetReader`, `TranscriptReader` and `ActivityReader` are ADR M0.3 §2
 // read seams whose own header says "the composition root implements it by asking
-// whichever context owns the rows" -- `conversations`, `tools` and `jobs`, none
-// of which publishes a contract assembler; `EvalRunQueue` needs the kernel
-// `DurableRuntime`, whose directory is one of the seven still on
-// `UNIMPLEMENTED_ADAPTERS`; and `Judge` has no directory at all. Its bundle also
-// names `AgentsContract`, and `agents` publishes its use cases one by one.
-// `@platos/context-governance` does not even publish `./application/index.js`,
-// so the factory is not importable from here.
+// whichever context owns the rows" -- `conversations`, `tools` and `jobs`;
+// `EvalRunQueue` needs the kernel `DurableRuntime`, whose directory is one of
+// the seven still on `UNIMPLEMENTED_ADAPTERS`; and `Judge` has no directory at
+// all. `@platos/context-governance` also publishes no `./application/index.js`,
+// so `createGovernanceContract` is not importable from here even once those five
+// land -- see `UNIMPORTABLE_CONTEXT_FACTORIES`.
+//
+// AND ITS `AgentsContract` SLOT IS NOT AN ASSEMBLER PROBLEM, WHICH IS WIN-267
+// G3's FINDING. This paragraph used to end "and `agents` publishes its use cases
+// one by one", and that was false: `agentsContract` is exported from
+// `packages/contexts/agents/contracts/index.ts`, the same `.` entry point
+// `app.module.ts` already imports the `AgentsContract` TYPE from. What actually
+// blocks the slot is that the root must hand over a composed `agents`, and
+// `agents` is itself short: `AgentVersionLock` and `MacroRecorder` are on no row
+// of `ADAPTER_BINDINGS` (`AGENTS_UNBOUND_PORTS`), and its `skills` peer is a
+// tenth context this root does not compose -- `skills` needs
+// `SkillSourceFetcher`, `EnvironmentKeyDirectory` and `SkillSandbox`, none of
+// which has a directory, and a `files` peer whose `ObjectStore` is
+// `objectstore-minio`, still on `UNIMPLEMENTED_ADAPTERS`.
+//
+// SO THE CHAIN IS FIVE CONTEXTS DEEP AND IT IS WORTH WRITING DOWN, because the
+// sentence this replaced read as though `governance` were the last mile:
+//
+//   identity-access <- governance <- agents <- skills <- files <- objectstore-minio
+//
+// ELEVEN driven ports across those four contexts have no adapter directory --
+// governance's five, agents' two, skills' three and files' one. FOUR of the
+// eight missing manifest lines are on this path too: `files` and `governance`
+// on the chain itself, and `conversations` and `jobs` among the three contexts
+// the read seams must be implemented over. The third of those, `tools`, is one
+// of the nine already importable, from its own `.` entry point.
 //
 // A rate limiter alone would therefore NOT have been enough:
 // `consume-rate-limit.ts` writes `identity.rate_limit.degraded` into this sink,
@@ -172,8 +210,13 @@ export const IDENTITY_ACCESS_UNASSEMBLED =
   " TotpCodeVerifier is tokenmint-totp; SafetyEventSink is implemented only by" +
   " the governance context, whose own bundle names five driven ports no adapter" +
   " directory satisfies (RatingTargetReader, TranscriptReader, ActivityReader," +
-  " Judge, EvalRunQueue) and an AgentsContract no factory assembles, so this" +
-  " root cannot compose it";
+  " Judge, EvalRunQueue), whose createGovernanceContract this root cannot import" +
+  " because @platos/context-governance publishes no ./application/index.js, and" +
+  " whose AgentsContract slot needs a composed agents -- agentsContract does" +
+  " assemble that contract, from the package's own . entry point, but agents" +
+  " names two driven ports no adapter directory satisfies (AgentVersionLock," +
+  " MacroRecorder) and a skills peer this root does not compose; so this root" +
+  " cannot compose it";
 
 /**
  * The five governance ports that keep the sink out of reach, named once.
@@ -190,6 +233,82 @@ export const GOVERNANCE_UNBOUND_PORTS: readonly string[] = Object.freeze([
   "ActivityReader",
   "Judge",
   "EvalRunQueue",
+]);
+
+/**
+ * The two `agents` ports that keep the peer BEHIND that sink out of reach.
+ *
+ * WIN-267 G3. They exist because the clause they replace was FALSE. The sentence
+ * above used to end "and an AgentsContract no factory assembles", and
+ * `agentsContract` has been exported from
+ * `packages/contexts/agents/contracts/index.ts` -- the `.` entry point
+ * `app.module.ts` already imports `AgentsContract` FROM -- since before that
+ * sentence was written. It is the third claim of that exact shape this
+ * programme has had to withdraw: `secrets` and `providers` sat uncomposed
+ * against the same wording and were composed the moment somebody grepped.
+ *
+ * SO THE BLOCKER IS RESTATED WHERE IT ACTUALLY IS, and it is two adapter
+ * directories rather than an assembler. `AgentsDependencies` names FOUR driven
+ * ports: `AgentsRepository` and `ScaffoldingRepository` are `postgres-tenancy`
+ * (WIN-258 T5, two rows of `ADAPTER_BINDINGS`), and these two are on no row of
+ * that table and in no `packages/adapters/` directory.
+ *
+ * READ BACK BY `installation.test.ts` AGAINST `ADAPTER_BINDINGS`, in both
+ * directions, exactly as `GOVERNANCE_UNBOUND_PORTS` is: each name here must
+ * appear on NO binding row, and the two that ARE bound must be present by owner.
+ * The day a directory implements one of these, that case fails and this list has
+ * to move -- which is what stops a correction from going stale the way the
+ * sentence it replaced did.
+ */
+export const AGENTS_UNBOUND_PORTS: readonly string[] = Object.freeze([
+  "AgentVersionLock",
+  "MacroRecorder",
+]);
+
+/**
+ * The eight contexts whose contract factory this root cannot IMPORT.
+ *
+ * WIN-267 G3, and it is the other half of the same correction. The note at the
+ * head of this file used to say FOUR contexts "publish their use cases one by
+ * one and no assembler over them", naming `agents`, `tools`, `memory` and
+ * `cost-monitoring`. All four publish one, and all four publish it from `.`:
+ * `agentsContract`, `toolsContract`, `memoryContract` and
+ * `costMonitoringContract` sit in their packages' own `contracts/index.ts`
+ * beside `secretsContract` and `providersContract`. SEVENTEEN of seventeen
+ * contexts publish a factory over their whole contract; ZERO do not.
+ *
+ * WHAT IS REAL IS A DIFFERENT PROBLEM WITH A DIFFERENT FIX. Nine factories are
+ * reachable from here -- six from `.` and three (`identity-access`, `tenancy`,
+ * `skills`) from the `./application/index.js` their manifests publish. The eight
+ * below keep theirs in `application/` behind a manifest that publishes only
+ * `.`, `./application/ports/index.js` and `./application/testing/index.js`, so
+ * `createGovernanceContract` and its seven siblings cannot be named here at all.
+ * That is one line of `APPLICATION_ENTRY_PROJECTS` per context, not an assembler
+ * to write -- and `gen-v1-skeleton.mjs`'s own rule says why the line is not here
+ * yet: the list is "the contexts `apps/core-api` ACTUALLY composes", so the
+ * entry follows the composition rather than leading it.
+ *
+ * IT MATTERS MOST FOR `governance`. A tranche that lands all five of
+ * `GOVERNANCE_UNBOUND_PORTS` still cannot compose the context, because the
+ * factory is not importable -- so the port work and the manifest line have to
+ * land together, and this constant is what says so before somebody discovers it
+ * at the end.
+ *
+ * READ BACK BY `installation.test.ts` BY IMPORTING: each subpath is resolved at
+ * run time and must REJECT. A negative about packaging is exactly the kind of
+ * claim this file has been wrong about before, so it is measured against Node's
+ * own resolver rather than asserted, and the day a manifest publishes one of
+ * these the case fails and this list has to move.
+ */
+export const UNIMPORTABLE_CONTEXT_FACTORIES: readonly string[] = Object.freeze([
+  "channels",
+  "conversations",
+  "eventing",
+  "files",
+  "governance",
+  "jobs",
+  "observability",
+  "privacy",
 ]);
 
 /**

--- a/apps/core-api/src/composition/installation.test.ts
+++ b/apps/core-api/src/composition/installation.test.ts
@@ -13,6 +13,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DEFAULT_PROVIDER_CATALOGUE, DEFAULT_PROVIDERS_POLICY } from "@platos/context-providers";
+// WIN-267 G3. Imported as a VALUE, from the `.` entry point `app.module.ts`
+// already imports the `AgentsContract` TYPE from. The import itself is the
+// assertion: the sentence this suite reads back used to claim no factory
+// assembles this contract, and a claim about another package's exports is only
+// worth anything if the module graph is what settles it.
+import { agentsContract } from "@platos/context-agents";
+import { secretsContract } from "@platos/context-secrets";
+import { providersContract } from "@platos/context-providers";
 
 import { composeApplication } from "../app.module.js";
 import { loadPlatformConfiguration } from "../config/platform.js";
@@ -27,8 +35,10 @@ import {
   type AdapterName,
 } from "./adapter-bindings.js";
 import {
+  AGENTS_UNBOUND_PORTS,
   GOVERNANCE_UNBOUND_PORTS,
   IDENTITY_ACCESS_UNASSEMBLED,
+  UNIMPORTABLE_CONTEXT_FACTORIES,
   assembleContextPorts,
 } from "./context-ports.js";
 
@@ -624,6 +634,128 @@ describe("the context bundles those adapters can satisfy", () => {
     expect(bundle?.cipher).toBe(keyring);
     expect(bundle?.hasher).toBe(keyring);
     expect(bundle?.unitOfWork).toBe(postgres?.unitOfWork);
+  });
+
+  it("names an AgentsContract that a published factory DOES assemble", () => {
+    // WIN-267 G3 — THE CLAIM THIS CASE EXISTS TO KILL. `IDENTITY_ACCESS_UNASSEMBLED`
+    // used to end "and an AgentsContract no factory assembles". That was the
+    // THIRD claim of this exact shape the programme has had to withdraw: the
+    // same wording stood over `secrets` and `providers` until WIN-267 grepped,
+    // and both had been composable since v1.
+    //
+    // THE IMPORT AT THE HEAD OF THIS FILE IS THE ASSERTION, and it is a join to
+    // the agents package's own module graph rather than to a string this file
+    // wrote. `agentsContract` resolves through `@platos/context-agents`'s `.`
+    // condition -- `dist/contracts/index.js` -- which is the same specifier
+    // `app.module.ts` already imports `AgentsContract` from, so this cannot pass
+    // by reaching somewhere the composition root may not reach.
+    expect(typeof agentsContract).toBe("function");
+    // SAME SHAPE AS THE TWO COMPOSED PEERS, checked rather than described. The
+    // brief for this tranche was "build the assembler the way `secretsContract`
+    // and `providersContract` are built"; there was nothing to build, and the
+    // way to show that is that all three are already one function of one bundle
+    // off one entry point.
+    expect(typeof secretsContract).toBe("function");
+    expect(typeof providersContract).toBe("function");
+    for (const factory of [agentsContract, secretsContract, providersContract]) {
+      expect(factory).toHaveLength(1);
+    }
+
+    // AND THE SENTENCE MUST NOT SAY OTHERWISE AGAIN. Two directions: the
+    // withdrawn wording is gone, and the replacement names the factory that
+    // withdrew it, so a future edit cannot quietly restore the old claim without
+    // failing here.
+    const { assembly } = readiness(FULLY_DECLARED);
+    const declined = assembly.unassembled.find((row) => row.context === "identity-access");
+    expect(declined?.reason).not.toContain("no factory assembles");
+    expect(declined?.reason).not.toContain("publishes its use cases one by one");
+    expect(declined?.reason).toContain("agentsContract");
+  });
+
+  it("blocks that contract on two agents ports instead, and joins them to the table", () => {
+    // WHERE THE BLOCKER ACTUALLY IS, once the assembler claim is withdrawn. The
+    // root cannot hand `governance` an `AgentsContract` because it cannot BUILD
+    // one, and `AgentsDependencies`' four driven ports split two and two.
+    const { assembly } = readiness(FULLY_DECLARED);
+    const declined = assembly.unassembled.find((row) => row.context === "identity-access");
+    const ports = new Set(ADAPTER_BINDINGS.map((binding) => binding.port));
+
+    // THE TWO THAT ARE SATISFIED, derived from the binding table BY OWNER rather
+    // than from a list this file wrote -- the same join the identity-access and
+    // providers cases make. A port that left the table, or one that arrived,
+    // changes this set without anybody editing the case.
+    const owned = ADAPTER_BINDINGS.filter((binding) => binding.owner === "agents");
+    expect(owned.map((binding) => binding.port).sort()).toEqual([
+      "AgentsRepository",
+      "ScaffoldingRepository",
+    ]);
+    for (const binding of owned) expect(UNIMPLEMENTED_ADAPTERS).not.toContain(binding.adapter);
+
+    // AND THE TWO THAT ARE NOT, joined the way `GOVERNANCE_UNBOUND_PORTS` is:
+    // each must appear on NO row, and must be NAMED in the reason. The day a
+    // directory implements one, this case fails and the sentence has to be
+    // re-derived -- which is precisely what the wording it replaced never had.
+    expect(AGENTS_UNBOUND_PORTS).toHaveLength(2);
+    for (const port of AGENTS_UNBOUND_PORTS) {
+      expect(ports, `${port} must still be bound to no adapter`).not.toContain(port);
+      expect(declined?.reason).toContain(port);
+    }
+    // The two sets must not overlap, or "unbound" would be a list of things that
+    // are in fact bound and the loop above would be vacuous.
+    for (const binding of owned) expect(AGENTS_UNBOUND_PORTS).not.toContain(binding.port);
+  });
+
+  it("cannot import eight context factories, and proves it against Node's resolver", async () => {
+    // THE OTHER HALF OF THE SAME CORRECTION, and the one that will bite the next
+    // tranche. Every one of the seventeen contexts publishes a factory over its
+    // whole contract; EIGHT of them keep it in `application/` behind a manifest
+    // that publishes no `./application/index.js`, so this package cannot name it.
+    //
+    // MEASURED, NOT ASSERTED, because a negative about packaging is exactly the
+    // kind of claim this file has been wrong about three times. The specifier is
+    // built at run time so nothing resolves it statically, and the rejection
+    // comes from the RESOLVER reading each package's own `exports` map -- Vite's
+    // under this runner, Node's under `node --import`, both off the same
+    // manifest -- rather than from a manifest this test re-parsed. The day a
+    // context publishes the subpath the import RESOLVES and this case fails,
+    // which is what forces the list to move.
+    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toHaveLength(8);
+    for (const context of UNIMPORTABLE_CONTEXT_FACTORIES) {
+      const specifier = `@platos/context-${context}/application/index.js`;
+      // THE WHOLE MESSAGE, NOT JUST A THROW, and that is the non-vacuity guard.
+      // A misspelled context rejects too -- "Cannot find package '...'", on a
+      // package that does not exist -- and would make this loop pass while
+      // proving nothing about any manifest. `Missing ... specifier in <package>`
+      // is the resolver saying the package IS there and its `exports` map does
+      // not name this subpath, which is the claim. Pinned verbatim: if the
+      // resolver rewords it this goes red and a reader re-derives it, which is
+      // the right direction for a case whose whole job is to stop a negative
+      // going stale.
+      await expect(
+        import(/* @vite-ignore */ specifier),
+        `${context} must still publish no ./application/index.js`,
+      ).rejects.toThrow(
+        `Missing "./application/index.js" specifier in "@platos/context-${context}" package`,
+      );
+    }
+
+    // AND THE OTHER DIRECTION, without which the loop above would pass on eight
+    // names nobody could import for any reason -- a typo, a package that does
+    // not exist. THREE contexts DO publish the subpath and their factory
+    // resolves through it; `governance` is the one that matters, because a
+    // tranche that lands all five of `GOVERNANCE_UNBOUND_PORTS` still could not
+    // compose it.
+    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toContain("governance");
+    for (const [context, factory] of [
+      ["tenancy", "createTenancyService"],
+      ["identity-access", "createIdentityAccessService"],
+      ["skills", "createSkillsContract"],
+    ] as const) {
+      expect(UNIMPORTABLE_CONTEXT_FACTORIES).not.toContain(context);
+      const specifier = `@platos/context-${context}/application/index.js`;
+      const module_ = (await import(/* @vite-ignore */ specifier)) as Record<string, unknown>;
+      expect(typeof module_[factory], `${context} publishes ${factory}`).toBe("function");
+    }
   });
 
   it("declines secrets and providers by NAMING the directory that is missing", () => {

--- a/apps/core-api/src/composition/installation.test.ts
+++ b/apps/core-api/src/composition/installation.test.ts
@@ -10,6 +10,9 @@
 // operator hits when a store is down at boot — which is the path that used to
 // kill the process, and which two of the cases below now pin.
 
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DEFAULT_PROVIDER_CATALOGUE, DEFAULT_PROVIDERS_POLICY } from "@platos/context-providers";
@@ -21,6 +24,21 @@ import { DEFAULT_PROVIDER_CATALOGUE, DEFAULT_PROVIDERS_POLICY } from "@platos/co
 import { agentsContract } from "@platos/context-agents";
 import { secretsContract } from "@platos/context-secrets";
 import { providersContract } from "@platos/context-providers";
+// WIN-267 G3. THE OTHER THREE FACTORIES ON A `.` ENTRY POINT, imported for the
+// same reason: the sentence this suite reads back named `agents`, `tools`,
+// `memory` and `cost-monitoring` as the four contexts with no assembler, and
+// the only honest way to withdraw a claim about another package's exports is to
+// resolve them. Nothing composes these three; the import IS the assertion.
+import { toolsContract } from "@platos/context-tools";
+import { memoryContract } from "@platos/context-memory";
+import { costMonitoringContract } from "@platos/context-cost-monitoring";
+// And the THREE reached through `./application/index.js` instead. STATIC, so
+// rule (C4) can see them: `composition-root.mjs` refuses a specifier assembled
+// at run time, and this is the shape that proves the resolver rather than
+// evading it. `app.module.ts` already imports the first two this way.
+import { createIdentityAccessService } from "@platos/context-identity-access/application/index.js";
+import { createTenancyService } from "@platos/context-tenancy/application/index.js";
+import { createSkillsContract } from "@platos/context-skills/application/index.js";
 
 import { composeApplication } from "../app.module.js";
 import { loadPlatformConfiguration } from "../config/platform.js";
@@ -705,57 +723,112 @@ describe("the context bundles those adapters can satisfy", () => {
     for (const binding of owned) expect(AGENTS_UNBOUND_PORTS).not.toContain(binding.port);
   });
 
-  it("cannot import eight context factories, and proves it against Node's resolver", async () => {
+  it("cannot import eight context factories, and partitions all seventeen manifests", () => {
     // THE OTHER HALF OF THE SAME CORRECTION, and the one that will bite the next
     // tranche. Every one of the seventeen contexts publishes a factory over its
     // whole contract; EIGHT of them keep it in `application/` behind a manifest
     // that publishes no `./application/index.js`, so this package cannot name it.
     //
-    // MEASURED, NOT ASSERTED, because a negative about packaging is exactly the
-    // kind of claim this file has been wrong about three times. The specifier is
-    // built at run time so nothing resolves it statically, and the rejection
-    // comes from the RESOLVER reading each package's own `exports` map -- Vite's
-    // under this runner, Node's under `node --import`, both off the same
-    // manifest -- rather than from a manifest this test re-parsed. The day a
-    // context publishes the subpath the import RESOLVES and this case fails,
-    // which is what forces the list to move.
-    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toHaveLength(8);
-    for (const context of UNIMPORTABLE_CONTEXT_FACTORIES) {
-      const specifier = `@platos/context-${context}/application/index.js`;
-      // THE WHOLE MESSAGE, NOT JUST A THROW, and that is the non-vacuity guard.
-      // A misspelled context rejects too -- "Cannot find package '...'", on a
-      // package that does not exist -- and would make this loop pass while
-      // proving nothing about any manifest. `Missing ... specifier in <package>`
-      // is the resolver saying the package IS there and its `exports` map does
-      // not name this subpath, which is the claim. Pinned verbatim: if the
-      // resolver rewords it this goes red and a reader re-derives it, which is
-      // the right direction for a case whose whole job is to stop a negative
-      // going stale.
-      await expect(
-        import(/* @vite-ignore */ specifier),
-        `${context} must still publish no ./application/index.js`,
-      ).rejects.toThrow(
-        `Missing "./application/index.js" specifier in "@platos/context-${context}" package`,
-      );
+    // JOINED TO THE MANIFESTS, WHICH IS WHAT THE RESOLVER READS. A negative
+    // about packaging is exactly the kind of claim this file has been wrong
+    // about three times, so it is measured against the `exports` map of every
+    // context package rather than asserted -- and against ALL SEVENTEEN, as a
+    // PARTITION, so a context cannot fall out of both halves and be counted by
+    // neither. The day a manifest publishes the subpath, it moves from one side
+    // of the partition to the other and this case fails.
+    //
+    // IT READS THE FILES RATHER THAN IMPORTING THE SUBPATHS, and that is rule
+    // (C4) rather than a preference: a specifier assembled at run time is one
+    // `composition-root.mjs` refuses outside `apps/mcp-stdio/src/runtime.ts`,
+    // because no boundary rule can see it, and a LITERAL dynamic import of a
+    // subpath that does not exist fails in Vite's transform -- the whole file
+    // fails to load and no case runs, which is a vacuous red rather than an
+    // assertion. `config/sections.test.ts` reads the platform's own files the
+    // same way for the same reason.
+    const root = fileURLToPath(new URL("../../../../", import.meta.url));
+    const manifestOf = (context: string): { readonly exports?: Record<string, unknown> } =>
+      JSON.parse(readFileSync(`${root}packages/contexts/${context}/package.json`, "utf8")) as {
+        readonly exports?: Record<string, unknown>;
+      };
+
+    // The seventeen ADR M0.3 §4 names, spelled out rather than globbed: a
+    // directory listing would shrink silently with the tree and make the
+    // partition below a statement about whatever happened to be there.
+    const contexts = [
+      "identity-access", "tenancy", "secrets", "providers", "agents", "skills",
+      "tools", "memory", "channels", "files", "observability", "cost-monitoring",
+      "governance", "jobs", "conversations", "eventing", "privacy",
+    ] as const;
+    expect(contexts).toHaveLength(17);
+
+    // A FACTORY IS IMPORTABLE BY EITHER OF TWO ROUTES, and getting that wrong is
+    // how the sentence being withdrawn stayed wrong: `cost-monitoring`, `memory`,
+    // `providers` and `tools` publish NO `./application/index.js` and are
+    // importable anyway, because their factory is on the `.` entry point. A
+    // partition drawn on the manifest subpath alone would put those four on the
+    // wrong side and reproduce the original error in a new place.
+    //
+    // ROUTE ONE, PROVED BY THE MODULE GRAPH. Every one of these was imported
+    // statically at the head of this file, from the `.` specifier
+    // `app.module.ts` already imports each context's TYPE from. Delete any of
+    // the six exports and this file stops resolving.
+    const onDotEntry = {
+      agents: agentsContract,
+      "cost-monitoring": costMonitoringContract,
+      memory: memoryContract,
+      providers: providersContract,
+      secrets: secretsContract,
+      tools: toolsContract,
+    } as const;
+    // ROUTE TWO, PROVED THE SAME WAY, through the subpath the eight do not have.
+    const onApplicationEntry = {
+      "identity-access": createIdentityAccessService,
+      skills: createSkillsContract,
+      tenancy: createTenancyService,
+    } as const;
+    for (const [context, factory] of [
+      ...Object.entries(onDotEntry),
+      ...Object.entries(onApplicationEntry),
+    ]) {
+      expect(typeof factory, `${context} publishes an importable factory`).toBe("function");
     }
 
-    // AND THE OTHER DIRECTION, without which the loop above would pass on eight
-    // names nobody could import for any reason -- a typo, a package that does
-    // not exist. THREE contexts DO publish the subpath and their factory
-    // resolves through it; `governance` is the one that matters, because a
-    // tranche that lands all five of `GOVERNANCE_UNBOUND_PORTS` still could not
-    // compose it.
-    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toContain("governance");
-    for (const [context, factory] of [
-      ["tenancy", "createTenancyService"],
-      ["identity-access", "createIdentityAccessService"],
-      ["skills", "createSkillsContract"],
-    ] as const) {
-      expect(UNIMPORTABLE_CONTEXT_FACTORIES).not.toContain(context);
-      const specifier = `@platos/context-${context}/application/index.js`;
-      const module_ = (await import(/* @vite-ignore */ specifier)) as Record<string, unknown>;
-      expect(typeof module_[factory], `${context} publishes ${factory}`).toBe("function");
+    // THE MANIFEST HALF, which is the only instrument that can speak for the
+    // absent: route two exists exactly when the package publishes the subpath.
+    const publishesEntry = contexts.filter(
+      (context) => manifestOf(context).exports?.["./application/index.js"] !== undefined,
+    );
+    expect([...publishesEntry].sort()).toEqual(
+      [...Object.keys(onApplicationEntry), "agents", "secrets"].sort(),
+    );
+
+    // AND THE PARTITION OVER ALL SEVENTEEN. Importable is the UNION of the two
+    // routes -- `agents` and `secrets` are in both -- and the complement is the
+    // list. 9 + 8 = 17, so a context cannot fall out of both halves and be
+    // counted by neither, which is what a list checked only against itself
+    // allows.
+    const importable = new Set([
+      ...Object.keys(onDotEntry),
+      ...Object.keys(onApplicationEntry),
+    ]);
+    expect(importable.size).toBe(9);
+    expect([...contexts].filter((context) => !importable.has(context)).sort()).toEqual(
+      [...UNIMPORTABLE_CONTEXT_FACTORIES].sort(),
+    );
+    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toHaveLength(8);
+    for (const context of UNIMPORTABLE_CONTEXT_FACTORIES) {
+      expect(contexts, `${context} must be one of the seventeen`).toContain(context);
+      // The manifest IS there and publishes `.` -- so each of these is a context
+      // that declined to publish the subpath, not a package that is missing,
+      // which is what a misspelled name on the list would be.
+      expect(Object.keys(manifestOf(context).exports ?? {})).toContain(".");
+      expect(manifestOf(context).exports?.["./application/index.js"]).toBeUndefined();
     }
+
+    // `governance` IS THE ONE THAT MATTERS. A tranche that lands all five of
+    // `GOVERNANCE_UNBOUND_PORTS` still could not compose it, because
+    // `createGovernanceContract` cannot be named from here at all.
+    expect(UNIMPORTABLE_CONTEXT_FACTORIES).toContain("governance");
   });
 
   it("declines secrets and providers by NAMING the directory that is missing", () => {

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "597cab9eab800384963e92966662424ec639dadfa1ee4766c74de7b71857f8cf",
+  "evidenceSha256": "bdb210a84c6a0312548c2b77b3f542a60cc91e23a2bb5bfe58d445141e721569",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "c38c73018823427959751be87ab036da0d5f889a24b864e7dcaa56d876ae55fd",
+    "aggregateSha256": "77a5f2d871fc83f0ed15a745910cb765ce29556031c75fa1cce3d68595922da5",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -2454,6 +2454,10 @@
         "sha256": "27cbdd65ca8e2a73e225e69e8d8f7b992aeef6c93334056a9c21dc7cc24a84ef"
       },
       {
+        "path": "apps/core-api/mutations-win267-g3.json",
+        "sha256": "1d72719326893ceaa9a66ef2539bcc4e3366b98d1c1dfbc67d68bb35ad36544d"
+      },
+      {
         "path": "apps/core-api/mutations-win267-t3.json",
         "sha256": "f1180ba916a61e91a9a0c8ba5c5715b0830b0a50bc09af5a054ba603770fb472"
       },
@@ -2479,11 +2483,11 @@
       },
       {
         "path": "apps/core-api/src/composition/context-ports.ts",
-        "sha256": "e6b0fade8d27d6ae012d23eeaa026c3324937c1ae73ddbbd4a14d9e49eae49b6"
+        "sha256": "cf80e0aad70c32c76ca6dfb46f2e0f1ddc733f8fb70aff6b9468a309f27d49e4"
       },
       {
         "path": "apps/core-api/src/composition/installation.test.ts",
-        "sha256": "4d48beb4a61469228a6f04fcd665b35302db54030f60f13703e8a579d8a8e173"
+        "sha256": "5a5a0149df00cf07d4ad053caccd43a5352d64621c6e18b6249273ccf1c1c4f0"
       },
       {
         "path": "apps/core-api/src/composition/registry.ts",
@@ -6227,7 +6231,7 @@
       },
       {
         "path": "docs/v1-ledger-rules.json",
-        "sha256": "d4b3fc0c3bd80aa39c84785c889bf2a6661bb349fd220d1357f45701bbeef39a"
+        "sha256": "e0f6780322ac8bb56afa4ae14eec40d09753f68f81981e9831172ef74bdee8d9"
       },
       {
         "path": "docs/v3-openapi.yaml",
@@ -19807,7 +19811,7 @@
       },
       {
         "path": "scripts/arch/gen-v1-skeleton.mjs",
-        "sha256": "f5a7a3e5149980bb5dd226fb53cc95ca26639656ed1ac08071701d0839212ffa"
+        "sha256": "768537af3735830c4fe9b75d7229522f5f59f81c3dbdea4c48f5fde4813d1cac"
       },
       {
         "path": "scripts/arch/gen-v1-skeleton.test.mjs",
@@ -20135,7 +20139,7 @@
       },
       {
         "path": "scripts/v1-ledger.test.mjs",
-        "sha256": "7ecbb3b41683244d56bdbd243664a30aec1817ce3014719034ebade182d7c7ea"
+        "sha256": "ffcbd82766947ddda4a3a8bd841cce8076a81aded073b880a5885b6eef170a04"
       },
       {
         "path": "scripts/vendored-build-audit.mjs",
@@ -26573,6 +26577,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 742
+            },
+            {
               "from": "apps/core-api/src/config/sections.test.ts",
               "kind": "reference",
               "line": 248
@@ -26625,7 +26634,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 625
+              "line": 636
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -26634,6 +26643,10 @@
             }
           ],
           "reversePaths": [
+            [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
             [
               "apps/core-api/src/config/sections.test.ts",
               "apps/core-api/src/config/sections.test.ts"
@@ -26684,6 +26697,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "apps/core-api/src/config/sections.test.ts",
             "apps/mcp-stdio/package.json",
             "apps/mcp-stdio/src/main.test.ts",
@@ -26732,7 +26746,7 @@
           "apps/mcp-stdio"
         ]
       },
-      "evidenceSha256": "6a476d5fb9e8d7ff3d783c2f625c33943a77e53dc1c42ea0ba926d9241a8de17",
+      "evidenceSha256": "f01bfb838c536bdf3ba906b49e24e6c60ae1f536cf98bb3b8a23ffd53427fd87",
       "manifestSha256": "c9bb318e0946a79c6a4572d2c852f7ac414cb361c6dab2e34c5543dcefcc00a3",
       "name": "@platos/mcp-stdio",
       "ociImageClosure": {
@@ -38201,7 +38215,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1725
+              "line": 1750
             }
           ],
           "reversePaths": [
@@ -38226,7 +38240,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "63ee1ccd463c0dc51da36145c32ed894fe9dbc884c5ff8c0932f221bbe4ed1b9",
+      "evidenceSha256": "bbafc9e2ff47788a1644bbae6ce98a7fb903ad38dba92a54f890cc30b5260fd2",
       "manifestSha256": "273951969710da5e07cfbb09885f792bbc938df2dfe3aed8d8e480438e113753",
       "name": "@platos/otlp-importer",
       "ociImageClosure": {
@@ -39367,7 +39381,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1724
+              "line": 1749
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -39592,7 +39606,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "55600e9eec8ffb92572cc06c8e45533612a46780fab50eaef60d4383e88791e2",
+      "evidenceSha256": "bfe81dd793f2499750ff01128ff1d0b7cd2d052217d57c95d7b0ef8d1b544bde",
       "manifestSha256": "5e3c30277d328e92c5781a7be8a60a9de1f5ab81898649bcd150b0ce5f3b48ab",
       "name": "@internal/run-engine",
       "ociImageClosure": {
@@ -46748,7 +46762,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1073
+              "line": 1084
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -46907,7 +46921,7 @@
           "packages/adapters/keyring-envelope"
         ]
       },
-      "evidenceSha256": "9e05b942943fdd5df64b7a06428bfc06843a7c474afc1b994b24ae0bd4136b8e",
+      "evidenceSha256": "df2e005c37529957d212745f93fbb9bcd62e7b45a25deb1e3f0969d2fe98610a",
       "manifestSha256": "ae371bc6b627e6693e9a7b45f6a789d1df3f4489f8b93db1ed61c9c2fefdd854",
       "name": "@platos/adapter-keyring-envelope",
       "ociImageClosure": {
@@ -47320,7 +47334,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 775
+              "line": 786
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -47499,7 +47513,7 @@
           "packages/adapters/model-router-providers"
         ]
       },
-      "evidenceSha256": "e9a0152802110b1636d574ef7c57f730f3bf12c3068de0f4e7aa14605402f0ac",
+      "evidenceSha256": "bfb879b288125673f739de9109ae4ec3e44926b95e383ac68341633036bb6273",
       "manifestSha256": "eaa4ecedce49dc05224e2c4b7982274d371f8fb27a60a9783fa643a8f6defcbd",
       "name": "@platos/adapter-model-router-providers",
       "ociImageClosure": {
@@ -47822,7 +47836,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1168
+              "line": 1179
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -47921,7 +47935,7 @@
           "packages/adapters/node-crypto-digest"
         ]
       },
-      "evidenceSha256": "f47f82207cf80779675cbee555e281f9a2bce250f5ca57312458068140edaf2b",
+      "evidenceSha256": "4cfde4c0c5d2763ba7308620fafcb30929e771d078cebc842cce7cc31c8883b4",
       "manifestSha256": "229fe0120b22a0df9fb190c46ea80e762a3efc68e6e509531147796557ea58ce",
       "name": "@platos/adapter-node-crypto-digest",
       "ociImageClosure": {
@@ -49431,7 +49445,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 889
+              "line": 900
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -49575,7 +49589,7 @@
           "packages/adapters/outbox"
         ]
       },
-      "evidenceSha256": "10b58cc7b173bc4536fa3a6620aacc0f31b73c0674ea8d5ad92529fc4684df48",
+      "evidenceSha256": "190db1ffe9998ba87372ccd670aa9937121d60ff7fe985959ec84d9a9081babe",
       "manifestSha256": "83a45d455aac9f0e888c1045ad4b91d9111960486ba77a4a087018299d5941b2",
       "name": "@platos/adapter-outbox",
       "ociImageClosure": {
@@ -50694,7 +50708,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 821
+              "line": 832
             },
             {
               "from": "scripts/vocabulary-boundary.test.mjs",
@@ -51543,7 +51557,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "0b73fb69a83448e7a9204f22abb6a86d9f0b05912cbe387d4e9452d2ae7f4acf",
+      "evidenceSha256": "ed03a0cddcf4ce032c6e4001fbf4b5bd917427031cee7c51e3b953343a8305c5",
       "manifestSha256": "8b4ac128fa6e660cb1132d155aaa0668fc2e907f366422dbbb922599f2917a71",
       "name": "@platos/adapter-postgres-tenancy",
       "ociImageClosure": {
@@ -52460,7 +52474,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1171
+              "line": 1182
             }
           ],
           "reversePaths": [
@@ -52574,7 +52588,7 @@
           "packages/adapters/redis-ratelimit"
         ]
       },
-      "evidenceSha256": "c7801b6afa4ad32cf5739c1a7169b9494e304852bac6b884d52ac81a1c9ff056",
+      "evidenceSha256": "a41065fa7b3bc6bd2f1c5a839e18c4e78de154a67e4e78260d2949ead0e3774f",
       "manifestSha256": "c34050bbafd7dbb339e9a1a8dabffc4ab2ab84203fc1f1739d9045c883563955",
       "name": "@platos/adapter-redis-ratelimit",
       "ociImageClosure": {
@@ -53307,7 +53321,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1169
+              "line": 1180
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -53431,7 +53445,7 @@
           "packages/adapters/tokenmint-totp"
         ]
       },
-      "evidenceSha256": "81226b5d20d15db25e69d96893ea6bd46f1678eb98e581e69145d84ee335024e",
+      "evidenceSha256": "ab68addc129864610ddf047c7c313c0f94ce02a2664dc54536407a3841704155",
       "manifestSha256": "6786de357df47e9fb13ec8d4c69ca91bb24c9ee6c47ebc7aa5565fa77883979b",
       "name": "@platos/adapter-tokenmint-totp",
       "ociImageClosure": {
@@ -54034,6 +54048,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 24
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/fixtures/tools-rows.sql",
               "kind": "reference",
               "line": 12
@@ -54226,10 +54245,14 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 953
+              "line": 964
             }
           ],
           "reversePaths": [
+            [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
             [
               "packages/adapters/postgres-tenancy/fixtures/tools-rows.sql",
               "packages/adapters/postgres-tenancy/fixtures/tools-rows.sql"
@@ -54388,6 +54411,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/fixtures/tools-rows.sql",
             "packages/adapters/postgres-tenancy/src/agents-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/agents-constraints.integration.test.ts",
@@ -54551,7 +54575,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "799413c03a36c9017f5d004a15270da44f40a20baae53ba05d815d8898c1bcd6",
+      "evidenceSha256": "9a005c447a0b46c482b4ef04dd4327cb2487c4396a30b11d84dbd39c1fc2dfad",
       "manifestSha256": "e43db9efa534960ba5ade2f86cf89a88453e7575222d56297d6b6ccfe816a8f3",
       "name": "@platos/context-agents",
       "ociImageClosure": {
@@ -55205,7 +55229,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 721
+              "line": 732
             }
           ],
           "reversePaths": [
@@ -55448,7 +55472,7 @@
           "packages/contexts/channels"
         ]
       },
-      "evidenceSha256": "e6b28d5e3b55689e3f882edc0548d1e213fe1e95928f862a9ad81d12146dbc8a",
+      "evidenceSha256": "d23ad24ef8246b470ea79ba642aaf65ca358786cf92e7d1963520f43a9173247",
       "manifestSha256": "83395ffe4b76070f9efb7bd1bb4b49d7228aea090069f569a5eec747aa98ab74",
       "name": "@platos/context-channels",
       "ociImageClosure": {
@@ -56155,7 +56179,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 813
+              "line": 824
             }
           ],
           "reversePaths": [
@@ -56466,7 +56490,7 @@
           "packages/contexts/conversations"
         ]
       },
-      "evidenceSha256": "04d422f8c8cde4a7946db141e01b2150c62c67ca13679aabeea4a5b3acfc9640",
+      "evidenceSha256": "d01c01bb349bf295b0f27fed43882ed087599e4fdaecbc3b7b9799b9a3898040",
       "manifestSha256": "218c32b5c5b423bdf39bf215d6365c07bbd746fca291a1b0609da87e2cebd4d8",
       "name": "@platos/context-conversations",
       "ociImageClosure": {
@@ -57070,6 +57094,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 34
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/cost-conformance.integration.test.ts",
               "kind": "reference",
               "line": 27
@@ -57237,6 +57266,10 @@
           ],
           "reversePaths": [
             [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/src/cost-conformance.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/cost-conformance.integration.test.ts"
             ],
@@ -57370,6 +57403,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/src/cost-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/cost-constraints.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/cost-idempotency.integration.test.ts",
@@ -57549,7 +57583,7 @@
           "packages/contexts/cost-monitoring"
         ]
       },
-      "evidenceSha256": "3822420485a4f340a72a05b640b71ab047b5d1225396aec537bf269e25ebbe75",
+      "evidenceSha256": "87e640bb43776ded21ce432a5bb5330737b9d5db55efbd0bc030e8f4aada33a6",
       "manifestSha256": "2e327d74bea9a17116d859d643836bc142e0977bd86d3a96567638fb75c7b3bb",
       "name": "@platos/context-cost-monitoring",
       "ociImageClosure": {
@@ -58184,7 +58218,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 644
+              "line": 655
             }
           ],
           "reversePaths": [
@@ -58405,7 +58439,7 @@
           "packages/contexts/eventing"
         ]
       },
-      "evidenceSha256": "bf40c9610a7e4c397470d94378f4ee48903fa774efd2a0bab6a42e825477885d",
+      "evidenceSha256": "8595e2a693859b713085cdccaf7d1363770a2e3fafdc0c36e3e7d0c459d91087",
       "manifestSha256": "57c1d00c9dc67970acaec3dc30138bbd18273e9d303ea3804f6a13ab6a2d012a",
       "name": "@platos/context-eventing",
       "ociImageClosure": {
@@ -59244,7 +59278,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1397
+              "line": 1408
             }
           ],
           "reversePaths": [
@@ -59596,7 +59630,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "455eb83b1aea4c83cbc0b9d72c93b14af2a8c4e975437654c6b7f8f9b778ad09",
+      "evidenceSha256": "26a904c684c84f4acfc79a9633a060f46ef9e01729d46fa0997e3a909a2bf31a",
       "manifestSha256": "39fe0424b871775bb785e2d759c32cd0e833a9cf71c9934313d397ca699950ca",
       "name": "@platos/context-files",
       "ociImageClosure": {
@@ -62127,6 +62161,11 @@
               "line": 3
             },
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 39
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/fixtures/identity-access-rows.sql",
               "kind": "reference",
               "line": 11
@@ -62348,6 +62387,10 @@
               "apps/core-api/src/app.module.test.ts"
             ],
             [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/fixtures/identity-access-rows.sql",
               "packages/adapters/postgres-tenancy/fixtures/identity-access-rows.sql"
             ],
@@ -62522,6 +62565,7 @@
           ],
           "roots": [
             "apps/core-api/src/app.module.test.ts",
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/fixtures/identity-access-rows.sql",
             "packages/adapters/postgres-tenancy/src/identity-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/identity-constraints.integration.test.ts",
@@ -63295,7 +63339,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "171f58a82adf0bf4a2180d2e8251eafaf99904699f45c900af075c4520c21e91",
+      "evidenceSha256": "bfb890db2a11ec665cc1353134e82b87f1da70198fc63f3a5e5bbc87c3f38c5c",
       "manifestSha256": "df554d7bb17a6aab26b8ff63eb9c6033d16e186a234ad9d69c52d1eca7edf146",
       "name": "@platos/context-identity-access",
       "ociImageClosure": {
@@ -64048,7 +64092,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1396
+              "line": 1407
             }
           ],
           "reversePaths": [
@@ -64343,7 +64387,7 @@
           "packages/contexts/jobs"
         ]
       },
-      "evidenceSha256": "7c0cdbeb7d6bb2946b4b6b41fe35a97b5d21f02d368adb357e61d90ad4137919",
+      "evidenceSha256": "cfda1c50461ca1eaa35cde92c62bb63c2daa08fcc81018c21c0bb6b28f2396eb",
       "manifestSha256": "da3cc481236d02e85484094c0def2d6fc84c838c3c285f44efe4619a6c26e08c",
       "name": "@platos/context-jobs",
       "ociImageClosure": {
@@ -64986,6 +65030,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 33
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/memory-conformance.integration.test.ts",
               "kind": "reference",
               "line": 24
@@ -65203,6 +65252,10 @@
           ],
           "reversePaths": [
             [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/src/memory-conformance.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/memory-conformance.integration.test.ts"
             ],
@@ -65376,6 +65429,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/src/memory-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/memory-constraints.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/memory-rows.test.ts",
@@ -65543,7 +65597,7 @@
           "packages/contexts/memory"
         ]
       },
-      "evidenceSha256": "6146f6f6054ba73a54b2040bd2592aa383d05efb11c0de2d2d8d49b24da18f64",
+      "evidenceSha256": "7aa2554d1e1a71c609a4293f8fe6a690b45a6c40ea92f54822ec12a89a5618c8",
       "manifestSha256": "d596af2fb68e3e6c3622cf1cfb1683e20f46b5fac434d3f8cd6bf37df74d5b28",
       "name": "@platos/context-memory",
       "ociImageClosure": {
@@ -66128,7 +66182,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 688
+              "line": 699
             }
           ],
           "reversePaths": [
@@ -66366,7 +66420,7 @@
           "packages/contexts/observability"
         ]
       },
-      "evidenceSha256": "c17112856c454e618eeb0765acbe71fc2f52cd17cc6d4ac29eca9b6edeeab435",
+      "evidenceSha256": "04aae092b1730510a6662b23b9770a4394f2728fd6dba4ea73706b527b5a41ce",
       "manifestSha256": "09d858b658a326451d6bdd026af44df9ba5d1b195ce0c71deffc0cb972afc6d7",
       "name": "@platos/context-observability",
       "ociImageClosure": {
@@ -66975,7 +67029,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 681
+              "line": 692
             }
           ],
           "reversePaths": [
@@ -67196,7 +67250,7 @@
           "packages/contexts/privacy"
         ]
       },
-      "evidenceSha256": "fcde7b2dc96b67c51de6037107a13d7d1a4786512d76e0141376c0b025bd1055",
+      "evidenceSha256": "30e48789fd40f31825445679c6d9bbdea4e0b8a2a253d54581228023264716a6",
       "manifestSha256": "8d9032044280327b5d3d795c13039f78e41ca275c9d6bce9f093b794a97473f1",
       "name": "@platos/context-privacy",
       "ociImageClosure": {
@@ -67792,7 +67846,7 @@
             {
               "file": "apps/core-api/src/composition/context-ports.ts",
               "from": "apps/core-api",
-              "line": 124,
+              "line": 162,
               "specifier": "@platos/context-providers"
             },
             {
@@ -68282,7 +68336,7 @@
             {
               "from": "apps/core-api/src/composition/installation.test.ts",
               "kind": "reference",
-              "line": 559
+              "line": 587
             },
             {
               "from": "packages/adapters/model-router-providers/src/adapter.test.ts",
@@ -68552,7 +68606,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 767
+              "line": 778
             }
           ],
           "reversePaths": [
@@ -69167,7 +69221,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "3108c79605d212b5e2dab3184a5afb7d1dce3bbfc0cd588c44fcb4b33592007b",
+      "evidenceSha256": "716f50795b91b07c25b49a7c13943cf956a9cc40fc586061024d7c19e9672c9b",
       "manifestSha256": "7462dcd3934c960646a6d3528915863411b9e195545de995cb54d10e6c43da83",
       "name": "@platos/context-providers",
       "ociImageClosure": {
@@ -70232,6 +70286,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 25
+            },
+            {
               "from": "packages/adapters/keyring-envelope/src/key-version-integrity.test.ts",
               "kind": "reference",
               "line": 28
@@ -70489,10 +70548,14 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1049
+              "line": 1060
             }
           ],
           "reversePaths": [
+            [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
             [
               "packages/adapters/keyring-envelope/src/key-version-integrity.test.ts",
               "packages/adapters/keyring-envelope/src/key-version-integrity.test.ts"
@@ -70703,6 +70766,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/keyring-envelope/src/key-version-integrity.test.ts",
             "packages/adapters/keyring-envelope/src/legacy-migration.test.ts",
             "packages/adapters/keyring-envelope/src/legacy-wire-compatibility.test.ts",
@@ -71149,7 +71213,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "5d8762608de614b5aa1337b99fc07efe00abd7ec7dbf8a0aad0cd9e355f5cead",
+      "evidenceSha256": "0e3487ded39b388f2051620cc71e41fa733616fd21979993e1665daa8c811c64",
       "manifestSha256": "03739f55f9812a44e47b5c9175c9ebb610f9448ba48bf906432c70796ecc3c03",
       "name": "@platos/context-secrets",
       "ociImageClosure": {
@@ -71784,6 +71848,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 41
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/skills-conformance.integration.test.ts",
               "kind": "reference",
               "line": 24
@@ -71941,6 +72010,10 @@
           ],
           "reversePaths": [
             [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/src/skills-conformance.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/skills-conformance.integration.test.ts"
             ],
@@ -72066,6 +72139,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/src/skills-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/skills-constraints.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/skills-rows.test.ts",
@@ -72245,7 +72319,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "8ac592d4817073e0ceaefd80f8b26442978722428a6ea26920c0f78f2a45d66d",
+      "evidenceSha256": "70182c940d6b88df820a644f0d2f0597b8739752258cb7cdb48351fe80c6bc8b",
       "manifestSha256": "f1e56a67ae6b3d846f0887d8a17048ad19d4e0356bf7f38d1056b58507a2e7e2",
       "name": "@platos/context-skills",
       "ociImageClosure": {
@@ -73923,6 +73997,11 @@
               "line": 10
             },
             {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 40
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/channels-transaction.integration.test.ts",
               "kind": "reference",
               "line": 39
@@ -74189,6 +74268,10 @@
               "apps/core-api/src/app.module.test.ts"
             ],
             [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/src/channels-transaction.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/channels-transaction.integration.test.ts"
             ],
@@ -74399,6 +74482,7 @@
           ],
           "roots": [
             "apps/core-api/src/app.module.test.ts",
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/src/channels-transaction.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/cost-transaction.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-transaction.integration.test.ts",
@@ -75035,7 +75119,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "d035ef57f3e44de7929c6fa42325ebee27d18259f4407afd7673a0e143ca7ef8",
+      "evidenceSha256": "664f9d0906c2fab77bde1b3ad55e9031e987d18e8a1a6d4ce18a220750496c4d",
       "manifestSha256": "552444b4f4df12b062f2eb788b926946ca8310d37b21721f111e9995e78b2a94",
       "name": "@platos/context-tenancy",
       "ociImageClosure": {
@@ -75587,7 +75671,7 @@
             {
               "file": "scripts/arch/gen-v1-skeleton.mjs",
               "from": "scripts/arch/gen-v1-skeleton.mjs",
-              "line": 1999,
+              "line": 2020,
               "specifier": "@platos/context-tools"
             }
           ],
@@ -75684,6 +75768,11 @@
         "testsFixtures": {
           "reachable": true,
           "reasons": [
+            {
+              "from": "apps/core-api/src/composition/installation.test.ts",
+              "kind": "reference",
+              "line": 32
+            },
             {
               "from": "packages/adapters/postgres-tenancy/src/plans-tools.integration.test.ts",
               "kind": "reference",
@@ -75857,10 +75946,14 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1258
+              "line": 1269
             }
           ],
           "reversePaths": [
+            [
+              "apps/core-api/src/composition/installation.test.ts",
+              "apps/core-api/src/composition/installation.test.ts"
+            ],
             [
               "packages/adapters/postgres-tenancy/src/plans-tools.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/plans-tools.integration.test.ts"
@@ -76003,6 +76096,7 @@
             ]
           ],
           "roots": [
+            "apps/core-api/src/composition/installation.test.ts",
             "packages/adapters/postgres-tenancy/src/plans-tools.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/tools-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/tools-constraints.integration.test.ts",
@@ -76166,7 +76260,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "b0abdc59bd68436bd5146413912c836cb7d55ac4b0458e9f13139dbec2bf517d",
+      "evidenceSha256": "2d9c30f551945655662a4c8f4c14fdb01a4e8eb2e40f18e7e1e762798c02f341",
       "manifestSha256": "87996481926b67e29a649aad1f8de452892ea7a0c07fa8f694e70a63420d490b",
       "name": "@platos/context-tools",
       "ociImageClosure": {
@@ -78954,7 +79048,7 @@
             {
               "file": "apps/core-api/src/composition/context-ports.ts",
               "from": "apps/core-api",
-              "line": 116,
+              "line": 154,
               "specifier": "@platos/kernel"
             },
             {
@@ -83112,7 +83206,7 @@
             {
               "file": "scripts/arch/gen-v1-skeleton.mjs",
               "from": "scripts/arch/gen-v1-skeleton.mjs",
-              "line": 1880,
+              "line": 1901,
               "specifier": "@platos/kernel"
             }
           ],
@@ -88900,7 +88994,7 @@
           "packages/kernel"
         ]
       },
-      "evidenceSha256": "63da857b878602a681a548304ebf9c7fdd9ceec4c6f7780fcc48f0b16506d1ce",
+      "evidenceSha256": "065c2e957665d8565bbfa9400dcdea551070e5a031120d3ac6d7ca8d1279de22",
       "manifestSha256": "4f315c3595455a1866bf39b540a93c4e447888035d3c5a445fc0bbf836219212",
       "name": "@platos/kernel",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `597cab9eab800384963e92966662424ec639dadfa1ee4766c74de7b71857f8cf`
+Evidence SHA-256: `bdb210a84c6a0312548c2b77b3f542a60cc91e23a2bb5bfe58d445141e721569`
 
 ## Baseline
 
@@ -41,7 +41,7 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
 | `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `f568dd97b0a6b7b3…` |
 | `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `f62621c47abb81e1…` |
-| `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `6a476d5fb9e8d7ff…` |
+| `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `f01bfb838c536bdf…` |
 | `apps/webapp` | `webapp` | yes | yes | yes | yes | retain-oci-image | no | no | `e106ac7819dbda24…` |
 | `docs` | `docs` | no | no | no | no | owner-review-repository-referenced | no | yes | `8d22bac63ce057c3…` |
 | `internal-packages/cache` | `@internal/cache` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9f2db1155272a42…` |
@@ -51,9 +51,9 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
-| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `63ee1ccd463c0dc5…` |
+| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `bbafc9e2ff47788a…` |
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `7e2bce57dce9388b…` |
-| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `55600e9eec8ffb92…` |
+| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `bfe81dd793f24997…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
 | `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `bcb59b7aa6c7706a…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
@@ -64,37 +64,37 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/adapters/channel-slack` | `@platos/adapter-channel-slack` | no | yes | yes | no | retain-application-deployable | no | no | `7da8e56cce5052ae…` |
 | `packages/adapters/clickhouse-observability` | `@platos/adapter-clickhouse-observability` | no | yes | yes | no | retain-application-deployable | no | no | `0e548018f3101554…` |
 | `packages/adapters/durable-runtime` | `@platos/adapter-durable-runtime` | no | yes | yes | no | retain-application-deployable | no | no | `facc4099bc582aac…` |
-| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `9e05b942943fdd5d…` |
-| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `e9a0152802110b16…` |
-| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `f47f82207cf80779…` |
+| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `df2e005c37529957…` |
+| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `bfb879b288125673…` |
+| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `4cfde4c0c5d2763b…` |
 | `packages/adapters/notifier-email` | `@platos/adapter-notifier-email` | no | yes | yes | no | retain-application-deployable | no | no | `ca71ec24fc235ca7…` |
 | `packages/adapters/notifier-webhook` | `@platos/adapter-notifier-webhook` | no | yes | yes | no | retain-application-deployable | no | no | `b725855ada9d92d1…` |
 | `packages/adapters/objectstore-minio` | `@platos/adapter-objectstore-minio` | no | yes | yes | no | retain-application-deployable | no | no | `5524e2315001c834…` |
-| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `10b58cc7b173bc45…` |
-| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `0b73fb69a83448e7…` |
+| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `190db1ffe9998ba8…` |
+| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `ed03a0cddcf4ce03…` |
 | `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `48678432dec206c3…` |
-| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `c7801b6afa4ad32c…` |
+| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `a41065fa7b3bc6bd…` |
 | `packages/adapters/redis-streams` | `@platos/adapter-redis-streams` | no | yes | yes | no | retain-application-deployable | no | no | `962ccb5f9dd651d7…` |
-| `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `81226b5d20d15db2…` |
-| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `799413c03a36c901…` |
-| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `e6b28d5e3b55689e…` |
-| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `04d422f8c8cde4a7…` |
-| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `3822420485a4f340…` |
-| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `bf40c9610a7e4c39…` |
-| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `455eb83b1aea4c83…` |
+| `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `ab68addc12986461…` |
+| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `9a005c447a0b46c4…` |
+| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `d23ad24ef8246b47…` |
+| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `d01c01bb349bf295…` |
+| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `87e640bb43776ded…` |
+| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `8595e2a693859b71…` |
+| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `26a904c684c84f4a…` |
 | `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `1626341503f495ec…` |
-| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `171f58a82adf0bf4…` |
-| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `7c0cdbeb7d6bb294…` |
-| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `6146f6f6054ba73a…` |
-| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `c17112856c454e61…` |
-| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `fcde7b2dc96b67c5…` |
-| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `3108c79605d212b5…` |
-| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `5d8762608de614b5…` |
-| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `8ac592d4817073e0…` |
-| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `d035ef57f3e44de7…` |
-| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `b0abdc59bd68436b…` |
+| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `bfb890db2a11ec66…` |
+| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `cfda1c50461ca1ea…` |
+| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `7aa2554d1e1a71c6…` |
+| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `04aae092b1730510…` |
+| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `30e48789fd40f318…` |
+| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `716f50795b91b07c…` |
+| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `0e3487ded39b388f…` |
+| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `70182c940d6b88df…` |
+| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `664f9d0906c2fab7…` |
+| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `2d9c30f551945655…` |
 | `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `d1ae004000a14ce5…` |
-| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `63da857b878602a6…` |
+| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `065c2e957665d856…` |
 | `packages/platools-js` | `@platosdev/platools-sdk` | no | no | no | no | owner-review-public-boundary | yes | yes | `51e254dc667559d2…` |
 | `packages/platos-client` | `@platosdev/client` | no | no | no | no | owner-review-public-boundary | yes | yes | `9756bf724fd0a127…` |
 | `packages/platos-embed` | `@platosdev/embed` | no | no | no | no | owner-review-public-boundary | yes | yes | `26f83fd504a22a2c…` |

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "7f8056f6e6df8372f4e5f56631655dd1891e76cd497bff2640e1f2318c9dbe0f",
+      "sha256": "5871b0cfb4185aff1eb8869366e226efa21fa55c1e54d90a0bf00e1d65609ce0",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "2c1a6b7acb49b8b4fe8c1225a1ef763c3b229badae6e02bddc76918fd4c47d06",
+      "sha256": "8d1cb14d737b35320bf000839c096eaeeed96dc9db23ba8fe1f35d5aeebe1ebe",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "42cbea68249dbc8a0717576be38434ef22a519d7c0d0586277083c994f0a2d5b",
+      "sha256": "194791596debbeb2750aeac609bfa1a918e2c8f1133840bede60b1165e518366",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "7f8056f6e6df8372f4e5f56631655dd1891e76cd497bff2640e1f2318c9dbe0f"
+      "sha256": "5871b0cfb4185aff1eb8869366e226efa21fa55c1e54d90a0bf00e1d65609ce0"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "2c1a6b7acb49b8b4fe8c1225a1ef763c3b229badae6e02bddc76918fd4c47d06"
+      "sha256": "8d1cb14d737b35320bf000839c096eaeeed96dc9db23ba8fe1f35d5aeebe1ebe"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "42cbea68249dbc8a0717576be38434ef22a519d7c0d0586277083c994f0a2d5b"
+      "sha256": "194791596debbeb2750aeac609bfa1a918e2c8f1133840bede60b1165e518366"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -3483,7 +3483,7 @@
     {
       "path": "docs/v1-ledger-rules.json",
       "mode": "100644",
-      "sha256": "d4b3fc0c3bd80aa39c84785c889bf2a6661bb349fd220d1357f45701bbeef39a"
+      "sha256": "e0f6780322ac8bb56afa4ae14eec40d09753f68f81981e9831172ef74bdee8d9"
     },
     {
       "path": "docs/v3-openapi.yaml",
@@ -3923,7 +3923,7 @@
     {
       "path": "scripts/v1-ledger.test.mjs",
       "mode": "100644",
-      "sha256": "7ecbb3b41683244d56bdbd243664a30aec1817ce3014719034ebade182d7c7ea"
+      "sha256": "ffcbd82766947ddda4a3a8bd841cce8076a81aded073b880a5885b6eef170a04"
     },
     {
       "path": "scripts/verify-advisory-nonvacuity.mjs",

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4729,8 +4729,8 @@
   "integration": {
     "lockfileSha256": "5c1115bd7ed55c05a22744f82b37dbe7642209c8795aadd488c7b2cd1d75a94e",
     "vocabularySha256": "85637f6dbb2a41acebb3bcc9711289a8b3c3fd8d90f9d0b57b78af0c04bd7274",
-    "ledgerRulesSha256": "d4b3fc0c3bd80aa39c84785c889bf2a6661bb349fd220d1357f45701bbeef39a",
-    "reachabilitySha256": "7f8056f6e6df8372f4e5f56631655dd1891e76cd497bff2640e1f2318c9dbe0f",
+    "ledgerRulesSha256": "e0f6780322ac8bb56afa4ae14eec40d09753f68f81981e9831172ef74bdee8d9",
+    "reachabilitySha256": "5871b0cfb4185aff1eb8869366e226efa21fa55c1e54d90a0bf00e1d65609ce0",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/v1-ledger-rules.json
+++ b/docs/v1-ledger-rules.json
@@ -2082,10 +2082,10 @@
     ]
   },
   "expected": {
-    "totalFiles": 5109,
+    "totalFiles": 5110,
     "areaCounts": {
       "apps-agent": 516,
-      "apps-core-api": 68,
+      "apps-core-api": 69,
       "apps-mcp-stdio": 8,
       "apps-webapp": 183,
       "docs-content": 737,
@@ -2095,7 +2095,7 @@
     },
     "kindCounts": {
       "asset": 155,
-      "config": 310,
+      "config": 311,
       "doc": 610,
       "fixture": 6,
       "generated": 44,
@@ -2109,7 +2109,7 @@
       "archive": 7,
       "move-refactor": 1631,
       "regenerate": 39,
-      "retain": 3430,
+      "retain": 3431,
       "unresolved": 2
     },
     "protectedCount": 1632,
@@ -2124,7 +2124,7 @@
       "apps-agent.source.runtime": 277,
       "apps-agent.test.suites": 206,
       "apps-agent.tooling.scripts": 11,
-      "apps-core-api.config.package": 5,
+      "apps-core-api.config.package": 6,
       "apps-core-api.doc.package": 1,
       "apps-core-api.entry.composition-root": 2,
       "apps-core-api.source.process": 30,
@@ -2250,6 +2250,6 @@
       "root-infra.tooling.scripts": 91,
       "root-infra.tooling.workspace-reachability": 1
     },
-    "classificationSha256": "1ddac8cff3c3c815ab3c64290581dccdf20dfc634c34c7736498678810bd769a"
+    "classificationSha256": "0e24781e27af6d9f86f70d79e98f686886999958e3738314d22828cd86074aa3"
   }
 }

--- a/scripts/arch/gen-v1-skeleton.mjs
+++ b/scripts/arch/gen-v1-skeleton.mjs
@@ -1169,37 +1169,58 @@ export const APPLICATION_ENTRY_PROJECTS = [
 // THE COUNT, AND WHERE IT FALLS AWAY. A context is composable only when three
 // things hold at once:
 //
-//   1. it publishes a factory over its whole contract. ELEVEN do —
-//      `createTenancyService`, `createIdentityAccessService`, and the nine
-//      `create*Contract` functions in `channels`, `conversations`, `eventing`,
-//      `files`, `governance`, `jobs`, `observability`, `privacy` and `skills`.
-//      SIX do not: `agents`, `tools`, `secrets`, `memory`, `cost-monitoring` and
-//      `providers` publish their use cases one at a time and no assembler.
+//   1. it publishes a factory over its whole contract, AND `apps/core-api` can
+//      IMPORT that factory. SEVENTEEN publish one; NINE are importable.
 //
 //   2. every driven port in its bundle has an implementation in this tree;
 //
 //   3. that implementation is reachable from a constructed adapter.
+//
+// CONDITION 1 USED TO BE ONE CLAUSE HERE AND IT WAS FALSE (WIN-267 G3). It read
+// "ELEVEN do ... SIX do not: `agents`, `tools`, `secrets`, `memory`,
+// `cost-monitoring` and `providers` publish their use cases one at a time and no
+// assembler". Every one of those six publishes an assembler, and publishes it
+// from `.`: `agentsContract`, `toolsContract`, `secretsContract`,
+// `memoryContract`, `costMonitoringContract` and `providersContract` are all in
+// their own packages' `contracts/index.ts`. `secrets` and `providers` were
+// corrected in `context-ports.ts` when they were composed; this copy of the
+// claim was not, and kept the other four wrong for a further tranche. There is
+// no context in this tree without an assembler, and there never was.
+//
+// WHAT IS REAL IS THE OTHER HALF, and it is this list's own subject. NINE
+// factories can be named from the composition root — six from `.`, and
+// `identity-access`, `tenancy` and `skills` from the `./application/index.js`
+// entries below. The remaining EIGHT — `channels`, `conversations`, `eventing`,
+// `files`, `governance`, `jobs`, `observability` and `privacy` — keep a
+// `create*Contract` in `application/` behind a manifest publishing only `.`,
+// `./application/ports/index.js` and `./application/testing/index.js`. That is
+// WIN-297's finding, still open for eight contexts, and the fix is one line here
+// each — held back by this list's own rule until the context is actually
+// composed.
 //
 // ONE context clears all three: `tenancy`, whose six driven ports and unit of
 // work are all properties of a single `PostgresTenancyAdapter` (WIN-258 tranches
 // 1 and 3). It is already on the list, and what changed is that it is now
 // composed over REAL PostgreSQL rather than over a bundle an install handed in.
 //
-// `identity-access` is the near miss and the one worth naming, because it looks
-// composable and is not: its `repository` IS on that adapter (tranche 2) and
-// `clock`, `ids` and `logger` are kernel ports the process holds, but
-// `rateLimiter` is `packages/adapters/redis-ratelimit` — still this generator's
-// own placeholder — and `hasher`, `minter`, `totp` and `cipher` are satisfied by
-// no adapter directory at all. `keyring-envelope`'s `Hasher` is `secrets`' port,
-// a different type in a different package, and nothing implements
-// `SecretHasher`, `TokenMinter`, `TotpCodeVerifier` or `MfaSecretCipher`.
+// `identity-access` WAS the near miss and its ports have since landed, so the
+// paragraph that stood here is withdrawn rather than carried: it said
+// `rateLimiter` is "still this generator's own placeholder" and that `hasher`,
+// `minter`, `totp` and `cipher` are "satisfied by no adapter directory at all".
+// WIN-267 A1, A2 and A3 closed all five — `redis-ratelimit`,
+// `node-crypto-digest`, `keyring-envelope` and `tokenmint-totp` — and all six of
+// its driven ports are now satisfied. What holds it is the kernel
+// `SafetyEventSink`, implemented only by `governance`.
 //
-// Of the other nine assemblers, every one needs at least one port whose adapter
-// is a placeholder — `ObjectStore`, `DurableRuntime`, `ObservabilitySink`,
-// `EventBus`, `ChannelAdapter` — or a peer contract from one of the six that
-// publish no assembler. `apps/core-api/src/composition/context-ports.ts` states
-// this per context and its suite checks the identity-access half against
-// `ADAPTER_BINDINGS` rather than asserting it.
+// AND `governance` IS IN THE UNIMPORTABLE EIGHT, which is the fact a tranche
+// planning that work needs first: landing adapters for its five unbound ports
+// still would not make it composable, because `createGovernanceContract` cannot
+// be named from the composition root until an entry appears above. Its
+// `AgentsContract` slot needs a composed `agents` too, and `agents` is short
+// `AgentVersionLock` and `MacroRecorder` plus a `skills` peer.
+// `apps/core-api/src/composition/context-ports.ts` states this per context, and
+// its suite checks the identity-access, agents and importability halves against
+// `ADAPTER_BINDINGS` and against the resolver rather than asserting them.
 // ---------------------------------------------------------------------------
 
 // ---------------------------------------------------------------------------

--- a/scripts/v1-ledger.test.mjs
+++ b/scripts/v1-ledger.test.mjs
@@ -618,7 +618,18 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // `transports/rest/index.ts` -- is edited in place and adds nothing.
     //
     // NO LEDGER RULE CHANGED BY EITHER. 44 + 3 + 10 = 57.
-    "apps-core-api": 57,
+    //
+    // WIN-267 G3 57 -> 58: `apps/core-api/mutations-win267-g3.json`, the THIRD
+    // mutation manifest to land beside `mutations.json` and
+    // `mutations-win267-t3.json` and the FOURTH tranche to use the convention.
+    // It classifies under the SAME rule its two siblings already do --
+    // `apps-core-api.config.package`, 5 -> 6 -- so no ledger rule changed for
+    // it either. Everything else G3 touches is an edit in place:
+    // `composition/context-ports.ts` and `composition/installation.test.ts`
+    // carry the correction and its three cases, and
+    // `scripts/arch/gen-v1-skeleton.mjs` carries the same correction to the
+    // second, staler copy of the claim. 44 + 3 + 10 + 1 = 58.
+    "apps-core-api": 58,
     // 0 -> 3. The stdio binary's runtime (config, frame loop, host-runtime
     // loader), the in-repository host runtime the executable evidence points at,
     // and its suite.
@@ -1566,7 +1577,14 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
   // A3's 1609. The identity this number exists to hold is that the total delta
   // and the per-area deltas are the SAME arithmetic, so a file that arrives in
   // one and not the other cannot pass both halves of this case.
-  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1640);
+  //
+  // WIN-267 G3 1640 -> 1641, and it is the WHOLE of that branch's file delta:
+  // ONE mutation manifest in `apps-core-api`, matching that area's 57 -> 58
+  // above. G3 adds no source file and no suite -- its three cases go into the
+  // `installation.test.ts` that already existed, which is also why the
+  // test-case census does not move (`apps/core-api` is outside PACKAGE_ROOTS).
+  // 1640 + 1 = 1641.
+  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1641);
   assert.deepEqual(
     Object.fromEntries(
       Object.entries(summary.areaCounts).map(([area, count]) => [area, count - rulesDocument.baseline.areaCounts[area]])
@@ -1692,7 +1710,14 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // green, and STILL landed red on both of these assertions: the sixth and
     // seventh time this second reconciliation has caught what the first one
     // signed off.
-    rulesDocument.baseline.totalFiles + 1640
+    //
+    // WIN-267 G3 1640 -> 1641, and it caught this branch too -- the EIGHTH and
+    // NINTH time. `--write` regenerated the fingerprint and `audit:v1-ledger`
+    // went green on a tree where BOTH of these assertions were still 1640. The
+    // one file is `apps/core-api/mutations-win267-g3.json`, in `apps-core-api`,
+    // matching that area's 57 -> 58; it ADOPTS NO PROJECT and CHANGES NO LEDGER
+    // RULE, so this delta too is purely additive: 1640 + 1 = 1641.
+    rulesDocument.baseline.totalFiles + 1641
   );
 });
 


### PR DESCRIPTION
## The deliverable is a correction, not an assembler

G3 was briefed to build the `AgentsContract` assembler that `IDENTITY_ACCESS_UNASSEMBLED` said "no factory assembles". **There was nothing to build.** `agentsContract` is exported from `packages/contexts/agents/contracts/index.ts:332` — the `.` entry point `app.module.ts` already imports the `AgentsContract` *type* from — and has been since before that sentence was written.

That is the **third** claim of this exact shape the programme has withdrawn. `secrets` and `providers` sat uncomposed against the same wording until WIN-267 grepped.

## The claim was wrong four more times over

Measured across all seventeen contexts:

| stated | measured at ff06655f |
| --- | --- |
| "FOUR do not publish an assembler: `agents`, `tools`, `memory`, `cost-monitoring`" | **all four do**, all from `.`, beside `secretsContract` and `providersContract` |
| "THIRTEEN publish a factory" | **seventeen of seventeen** do |
| generator's copy: "SIX do not, incl. `secrets` and `providers`" | never corrected when `context-ports.ts` was; kept the other four wrong for a further tranche |
| generator: `rateLimiter` "still this generator's own placeholder", `hasher`/`minter`/`totp`/`cipher` "satisfied by no adapter directory" | all five closed by A1/A2/A3 |

**The real problem is a manifest question, not an authoring one.** Nine factories are importable from the composition root — six from `.`, three from the `./application/index.js` their manifests publish. The other **eight** (`channels`, `conversations`, `eventing`, `files`, `governance`, `jobs`, `observability`, `privacy`) keep a `create*Contract` behind a manifest that publishes no such subpath.

## What this changes for the next milestone

`governance` is in the unimportable eight. **A tranche that lands all five of `GOVERNANCE_UNBOUND_PORTS` still cannot compose it** — `createGovernanceContract` cannot be named from `app.module.ts` at all. The port work and the manifest line have to land together.

And `identity-access` is not one context away. The chain is five deep:

```
identity-access <- governance <- agents <- skills <- files <- objectstore-minio
```

Eleven driven ports across those four contexts have no adapter directory — governance's five, agents' two, skills' three, files' one.

## This composes nothing, and says so

No composition was unblocked by the correction: every one of the fourteen uncomposed contexts has at least one genuinely unbound driven port, an adapter on `UNIMPLEMENTED_ADAPTERS`, or an uncomposed peer. `/readyz` read back off the running binary is unchanged — **47 of 54, `["tenancy","secrets","providers"]`**. `declaredUnfalsifiable` E01 in the mutation manifest records that null result per context rather than leaving a reader to wonder.

## Evidence

Three cases in `installation.test.ts`, each joined to something `apps/core-api` does not own — nine context packages' module graphs, `ADAPTER_BINDINGS`, and the seventeen manifests' own `exports` maps. **9 mutations, 9 kills, 0 vacuous** (`apps/core-api/mutations-win267-g3.json`), including publishing governance's subpath so the claim *becomes true* and renaming `agentsContract` and `toolsContract` in the artifacts the runner resolves.

Rule (C4) reshaped the third case mid-flight: a run-time-assembled specifier is refused outside `apps/mcp-stdio`, and a literal dynamic import of a missing subpath fails in Vite's *transform* — no case runs, a vacuous red. Sweep re-run in full against the new shape.

## Canaries

- ledger **5109 → 5110**, `apps-core-api` 68 → 69, delta 1640 → **1641**; the second reconciliation in `v1-ledger.test.mjs` caught both its pins after `--write` went green — the 8th and 9th time it has.
- test-case census **unmoved** (8071/545) — `apps/core-api` is outside `PACKAGE_ROOTS`.
- reachability **unmoved** — no placeholder released, because no adapter was built.

## Gates

91 laptop gates pass, 0 fail. Containerised suites on the Mac mini over ssh (Docker never ran on the laptop): postgres-tenancy 1077/1077, core-api, redis-cache, redis-ratelimit, cross-scope-isolation, differential-state-conservation, postgres-memory-evidence all green.

Two pre-existing failures, both **confirmed identical at the base** and untouched: `build-candidate-webapp` (expired Debian `bullseye-security` Release file, apt-get exit 100) and `deploy-platos.test.mjs` (2 pass / 2 fail, `docker.log` ENOENT, on laptop and mini alike).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzDWyb7YEERRegYTvNwzRp