### PR TITLE
WIN-303: refuse a tampered scope triple in governance's five canonical stores

### DIFF
--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "570bad1406b0d61596bd89ec9d369d6b08be2eb0bbc8be82b914d085ede77572",
+  "evidenceSha256": "04d333367dbe0a2ba92dacecf5bc85d30e427b2f43c0b35efaae02bc4556c6f2",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "4a0091d132b0a455c48b8f5165f86777b98b66c26957e015a2d05857f7d733c1",
+    "aggregateSha256": "b213cd4f64ca6f37ca3cad7a51f85d72bab5c26d25970652f2bbadb7978ce99e",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -4587,7 +4587,7 @@
       },
       {
         "path": "docs/error-taxonomy.json",
-        "sha256": "546892e6766f29bf7a1e3812eeb3437d71b56a108c5c41def9cabacce3538852"
+        "sha256": "df31927f0a85460eefbe3f47be98b4b27fcae7731fc0554b086a81f9f2c4653a"
       },
       {
         "path": "docs/errors-retrying.mdx",
@@ -6243,7 +6243,7 @@
       },
       {
         "path": "docs/v1-ledger-rules.json",
-        "sha256": "308f6ff87f7d4ea2b874da923e7993383e46e36d40b0847d7e6da443704be74d"
+        "sha256": "da460bd77194dc9d84ed4d29266dd476071e53fc800f45fb4fda4fcefc85d266"
       },
       {
         "path": "docs/v3-openapi.yaml",
@@ -11587,7 +11587,7 @@
       },
       {
         "path": "packages/adapters/postgres-tenancy/mutations-governance.json",
-        "sha256": "deb9b29b459b13f834b24042549711b6f96947d6ae4db9399c629ba4b1876ec5"
+        "sha256": "85f0e60ce53eee9ef8487122fb03ea39ffeaf53fc16b8954b39a40692dd1bc66"
       },
       {
         "path": "packages/adapters/postgres-tenancy/mutations-identity.json",
@@ -12095,7 +12095,7 @@
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-criteria.ts",
-        "sha256": "27e12843149332666c7c8039e5ea65425d20867822f0e94bb8ea0b813295dcab"
+        "sha256": "4c82e2aa7d3c8f503fc668d4fcc5a78d6402ca1fd6b1030180757279a8e2ac18"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
@@ -12107,11 +12107,11 @@
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-evals.ts",
-        "sha256": "eb334a1ed548532570d6fe704edddba8e492e0cbe11fc2732f35b7250701519e"
+        "sha256": "a291674b6fa6ec598fddbb6e28745ea732b046f363f308da11fd6db99b864890"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-golden-sets.ts",
-        "sha256": "0b769be63ff3b77ffc3ac13b176622bdf8333c1d002df26e86b6d20a986a8c44"
+        "sha256": "18ab1401a181fb35821dd3fa70c6225246d84408daea8dd6feb91b48626097d1"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-guards.ts",
@@ -12122,8 +12122,12 @@
         "sha256": "7faa24b576387e30468b7655ad4cb9763ac9a7a63384a50b96a7e104d899c5a2"
       },
       {
+        "path": "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+        "sha256": "eeba6f61066a31531bcbe93f274484606dec266ef4189a21808fe05907d5c6c4"
+      },
+      {
         "path": "packages/adapters/postgres-tenancy/src/governance-ratings.ts",
-        "sha256": "309348f00541383a4c63317b236fc59f243fd6de27cb9495291ceb18dbf5befe"
+        "sha256": "28bfd6dc8b6bb02f50ec191ef5fb6a4c877ba122cb6f5fc82c56d2dc7b8a3544"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
@@ -12151,15 +12155,19 @@
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-rows.ts",
-        "sha256": "05ea42fa36972f775c7b21e7566d79fe6d27ab5c881727fbcea688bafedb0771"
+        "sha256": "384a05b971e8178f5cf7f8084dbb8ef9459d38b6eae0f1ce94aabdcfb21996f8"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts",
-        "sha256": "8533c873da4e095f1d6583493d8ca9cf48c1f2c34c9d7f9abc17c34a1d21dcb1"
+        "sha256": "0dca6a88a04d39fa875814c96ee0bedde2bf189d9674258cbfaf46808bf1a547"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-safety.ts",
-        "sha256": "1db455f7cc15e2d3ae0ed9e3afeece19743c7fda3d87fb810274e2ece8960bec"
+        "sha256": "b48abc6cfd46b3960d853489f990f2db567d265b62bf4acc3942dccc99e8b800"
+      },
+      {
+        "path": "packages/adapters/postgres-tenancy/src/governance-scope.ts",
+        "sha256": "8807ba5162cda334feccc2cafa72d7db73b6bce54a67a70a4322abcfce0853ec"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-seam-activity.ts",
@@ -12171,11 +12179,11 @@
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-seam-guards.ts",
-        "sha256": "4039d48342789db94c657c69ce0700802be6aed15a54a2c9997297c44097196b"
+        "sha256": "05131ff4c8257ae5ef8374d20aa934b7813b1c4a8de4a13d781a141141710eec"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-statements.integration.test.ts",
-        "sha256": "77fd23f44400c57a9163e574ebbfbf3f328ed53de64adced385c6cdb36f7392b"
+        "sha256": "7c9e19d0b54981be077841afd831ef00f9f127d8331c1c3bc94ceef2affce9c0"
       },
       {
         "path": "packages/adapters/postgres-tenancy/src/governance-transaction.integration.test.ts",
@@ -14771,7 +14779,7 @@
       },
       {
         "path": "packages/contexts/governance/application/ports/index.ts",
-        "sha256": "4e6f6f8516e8a60ad803f7c56969bc332a460928571b569530d334cf4048ffa8"
+        "sha256": "c2fe17d813d8e3bdc0670e708df88b09aa0591b223fdb09dd93163fd26b31d9c"
       },
       {
         "path": "packages/contexts/governance/application/ports/judge.ts",
@@ -14899,7 +14907,7 @@
       },
       {
         "path": "packages/contexts/governance/contracts/index.test.ts",
-        "sha256": "9ea2ac540066315a76bbe51f388020af6c215a2fd575271b4e8923987641b8a4"
+        "sha256": "95359ced65699125d53cc20fc8e41dc854f038ebcf0583a43a0870dd994401e5"
       },
       {
         "path": "packages/contexts/governance/contracts/index.ts",
@@ -14923,11 +14931,11 @@
       },
       {
         "path": "packages/contexts/governance/domain/errors.test.ts",
-        "sha256": "302a25a28d1de58e02f967e30fea823e7b360a8bffc2e9927934e1142e73d1e2"
+        "sha256": "dfb521a6dd18abcae3aa9b3c3b8694d891219efa57be98bef69678195818d3d0"
       },
       {
         "path": "packages/contexts/governance/domain/errors.ts",
-        "sha256": "a16fde28759f61b07d7ea252a97b149fc15be4ff7d5d94440c935b14df0bd44d"
+        "sha256": "4bb14beb78ed0924ab4661ac6f10eb840086041ab3bd03909b1b79db7cddcf8e"
       },
       {
         "path": "packages/contexts/governance/domain/eval-aggregate.test.ts",
@@ -19815,7 +19823,7 @@
       },
       {
         "path": "scripts/arch/arch-boundaries.test.mjs",
-        "sha256": "8863c7b07462f92d3b0dce2f48188e02f9d6089169f41f1761167478492248c6"
+        "sha256": "8c759b1327b1bbefbaa89cc7d7b741d08dc51e003ac12899a44a0ed7344609bf"
       },
       {
         "path": "scripts/arch/boundary-rules.mjs",
@@ -19847,7 +19855,7 @@
       },
       {
         "path": "scripts/arch/env-access.mjs",
-        "sha256": "754c292ee523dcda4a9ce7bcf31d61cb170a0d8a1c440d65369a2dc1bc500a28"
+        "sha256": "0b30b4d2b5b68b4890deb0f7818a3817292c1b841eb6cae7ba69f6954a803470"
       },
       {
         "path": "scripts/arch/env-access.test.mjs",
@@ -19879,7 +19887,7 @@
       },
       {
         "path": "scripts/arch/max-file-lines.test.mjs",
-        "sha256": "a4efa7b4f7e010e4cd9753c3c130620d04603db593fedd8e6ee4d014f248ede6"
+        "sha256": "bedc71105ce9b8fc6222e2617c6c03e334b50d687512d3cab319338a67bcb6da"
       },
       {
         "path": "scripts/arch/route-ownership.mjs",
@@ -19907,11 +19915,11 @@
       },
       {
         "path": "scripts/arch/test-case-census.mjs",
-        "sha256": "d247bc2d85d8daa9fc75b2e3f78e43fa35424ad95fd363ba1ba5ee0bb63312c8"
+        "sha256": "46069742ba6a7a7149ef72c63051a63f973a1323397ebd276665b9c638b13d1e"
       },
       {
         "path": "scripts/arch/test-case-census.test.mjs",
-        "sha256": "198aeaa2e441849a7e10d08c570881fcf8174640c77f767628de8d752c37d8d2"
+        "sha256": "d2a5fee22d616518a8aa68e8c933ac2635cbd6e2077219db29d818f61130656e"
       },
       {
         "path": "scripts/arch/transaction-outcome.mjs",
@@ -20191,7 +20199,7 @@
       },
       {
         "path": "scripts/v1-ledger.test.mjs",
-        "sha256": "dc08918658ba8dde11eb05a34d4236cd106a4c0752c2e89035f0f484c10305e9"
+        "sha256": "56e6ef47993224c28885d6d5957b394a44251c7669ef70f3e8957abda37e554a"
       },
       {
         "path": "scripts/vendored-build-audit.mjs",
@@ -36537,7 +36545,7 @@
             {
               "from": "scripts/arch/arch-boundaries.test.mjs",
               "kind": "reference",
-              "line": 1359
+              "line": 1367
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -36652,7 +36660,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "b14b38b79bd335f68d65a0ddf4d18e8efa9a2bddf9ce125af4f80a6e1a3264cd",
+      "evidenceSha256": "82377f5198d6fa5eebd732e4e229efa4057126b1360478135cbd9bb3dcd919bf",
       "manifestSha256": "2664bbbb7140c4c9272e88b7cc56b3a72c1617b774ae4aff4606336caeccebdf",
       "name": "@platos/database",
       "ociImageClosure": {
@@ -38317,7 +38325,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1825
+              "line": 1848
             }
           ],
           "reversePaths": [
@@ -38342,7 +38350,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "1e3056c354e5034ecb507836bfdd468df6b2530d018d308dbd916cde2621ac5d",
+      "evidenceSha256": "f9ef3be1663e42d274f4ba61b4a85303719e3884fc4d4db4733305345c46bbaa",
       "manifestSha256": "273951969710da5e07cfbb09885f792bbc938df2dfe3aed8d8e480438e113753",
       "name": "@platos/otlp-importer",
       "ociImageClosure": {
@@ -38897,7 +38905,7 @@
             {
               "from": "scripts/arch/arch-boundaries.test.mjs",
               "kind": "reference",
-              "line": 1382
+              "line": 1390
             }
           ],
           "reversePaths": [
@@ -38987,7 +38995,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "a779e7c1e1979e30afae2bc32d9fb1ae398f26977b1043e79d49c7d539d8ef9f",
+      "evidenceSha256": "2a1a04bcb4c15a8f10daee632c9774715c91b78beb040b51701af4c46a899fcf",
       "manifestSha256": "2848f0f02171494d6112ab9631f2b0ed74a98d740454f7a2e43a442b2b3d6c16",
       "name": "@internal/redis",
       "ociImageClosure": {
@@ -39483,7 +39491,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1824
+              "line": 1847
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -39708,7 +39716,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "28aaf7f094925015862d4d628d593f20f5c96f4b2ce29838d689305966315372",
+      "evidenceSha256": "8f446c890305717106366520621b8db029c9008740d855fc29704b1f4c982051",
       "manifestSha256": "5e3c30277d328e92c5781a7be8a60a9de1f5ab81898649bcd150b0ce5f3b48ab",
       "name": "@internal/run-engine",
       "ociImageClosure": {
@@ -41520,6 +41528,11 @@
               "line": 71
             },
             {
+              "from": "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+              "kind": "reference",
+              "line": 178
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts",
               "kind": "reference",
               "line": 41
@@ -41642,7 +41655,7 @@
             {
               "from": "scripts/arch/arch-boundaries.test.mjs",
               "kind": "reference",
-              "line": 1354
+              "line": 1362
             },
             {
               "from": "scripts/arch/sole-writer.test.mjs",
@@ -42007,6 +42020,10 @@
               "packages/adapters/postgres-tenancy/src/files-transaction.integration.test.ts"
             ],
             [
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts"
+            ],
+            [
               "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts",
               "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts"
             ],
@@ -42253,6 +42270,7 @@
             "packages/adapters/postgres-tenancy/src/cost-transaction.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/eventing-transaction.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/files-transaction.integration.test.ts",
+            "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-transaction.integration.test.ts",
@@ -42454,7 +42472,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "67a220187f2f9487f42a49cd5a765f4bd133ced7d75f4fd353c9310e4a8aa441",
+      "evidenceSha256": "c4f895a4e871ac6af1e43d8046fa67b24427d6a20f8e935500381b6ab4bd6189",
       "manifestSha256": "22bd55003e357c1af7df013be8c2b416898d3b19fd4b38c763ffd701fb7e9de1",
       "name": "@platos/tenancy-database",
       "ociImageClosure": {
@@ -46647,7 +46665,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 2983
+              "line": 3018
             },
             {
               "from": "docs/v1-ledger-rules.json",
@@ -46909,7 +46927,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1768
+              "line": 1812
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -47073,7 +47091,7 @@
           "packages/adapters/keyring-envelope"
         ]
       },
-      "evidenceSha256": "a628e61d069bc9a14b3bfa4b5aab37eab4fce00d9eb8ccd2c257088b0702d03b",
+      "evidenceSha256": "5e19b4c260ab9a0a2279ab5b4454d8d651c3a99531c4cc65abac3ec066745c73",
       "manifestSha256": "ae371bc6b627e6693e9a7b45f6a789d1df3f4489f8b93db1ed61c9c2fefdd854",
       "name": "@platos/adapter-keyring-envelope",
       "ociImageClosure": {
@@ -47476,7 +47494,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1230
+              "line": 1254
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -47665,7 +47683,7 @@
           "packages/adapters/model-router-providers"
         ]
       },
-      "evidenceSha256": "e96d9796e0fdbc551d8eebe836a7e6ee1928769467e30ae5e590116875c6b29a",
+      "evidenceSha256": "976c64e1122e8f5d620cf592bbb136836d58707ff851590d70fc0c1b6637d038",
       "manifestSha256": "eaa4ecedce49dc05224e2c4b7982274d371f8fb27a60a9783fa643a8f6defcbd",
       "name": "@platos/adapter-model-router-providers",
       "ociImageClosure": {
@@ -47983,7 +48001,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1829
+              "line": 1873
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -48087,7 +48105,7 @@
           "packages/adapters/node-crypto-digest"
         ]
       },
-      "evidenceSha256": "f1aa64dbaaa23286b71c4428c7fb309ed51770a8638fbe7525c73b0b1393504e",
+      "evidenceSha256": "d3270e97663422d3c5d1d5c6617a2d6f343d30d4ab5a5fd4bd2afa8801b63f5c",
       "manifestSha256": "229fe0120b22a0df9fb190c46ea80e762a3efc68e6e509531147796557ea58ce",
       "name": "@platos/adapter-node-crypto-digest",
       "ociImageClosure": {
@@ -49592,7 +49610,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1710
+              "line": 1754
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -49741,7 +49759,7 @@
           "packages/adapters/outbox"
         ]
       },
-      "evidenceSha256": "609c2782f0c37ad38a71b0ad149a8f30c4670002a31aebd4dc66af62c4d229f6",
+      "evidenceSha256": "e0a3864c6aaa4291a7032ee654cd05a3deb6d0d402437ba041af13650ab8ecb9",
       "manifestSha256": "83a45d455aac9f0e888c1045ad4b91d9111960486ba77a4a087018299d5941b2",
       "name": "@platos/adapter-outbox",
       "ociImageClosure": {
@@ -49887,7 +49905,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 2991
+              "line": 3026
             },
             {
               "from": "docs/v1-ledger-rules.json",
@@ -50364,6 +50382,11 @@
             },
             {
               "from": "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
+              "kind": "workspace-owned-file",
+              "line": 1
+            },
+            {
+              "from": "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
               "kind": "workspace-owned-file",
               "line": 1
             },
@@ -50870,7 +50893,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1327
+              "line": 1351
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -51109,6 +51132,10 @@
             [
               "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts"
+            ],
+            [
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts"
             ],
             [
               "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
@@ -51586,6 +51613,7 @@
             "packages/adapters/postgres-tenancy/src/governance-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-constraints.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
+            "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-rows.test.ts",
@@ -51749,7 +51777,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "03fd26bcb8fae7b82359297edb9714cc2f5e46208447b248c0da2251f586c950",
+      "evidenceSha256": "39f5e1b9a76fab30a62306731f890c9ec785ffb4aa86237ca6fb75563eefcbc9",
       "manifestSha256": "c3c49b3941820594e187dcbb86c78001443c58add67ce25009e535c3f1374927",
       "name": "@platos/adapter-postgres-tenancy",
       "ociImageClosure": {
@@ -51890,7 +51918,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3015
+              "line": 3050
             },
             {
               "from": "docs/win-260-mutation-ledger.json",
@@ -52312,7 +52340,7 @@
           "packages/adapters/redis-cache"
         ]
       },
-      "evidenceSha256": "c0af8a0762b67a9ae2f87ef5b68dc782c3215fc89c0b14568e2575a25129e66b",
+      "evidenceSha256": "c50603b6486ec8726e0331d4b0eb1e12378f5be5e612a0c5cc369e7b845ae80f",
       "manifestSha256": "28d8382e77863b7c6b09e45dbccdcb4dd2e5d292e3dcdef574a37a2e21dac28d",
       "name": "@platos/adapter-redis-cache",
       "ociImageClosure": {
@@ -52646,7 +52674,7 @@
             {
               "from": "scripts/arch/max-file-lines.test.mjs",
               "kind": "reference",
-              "line": 878
+              "line": 879
             },
             {
               "from": "scripts/arch/sole-writer.test.mjs",
@@ -52780,7 +52808,7 @@
           "packages/adapters/redis-ratelimit"
         ]
       },
-      "evidenceSha256": "7a070e5ab8cf466843578c678f872486ee1d6d2e4b2b23d8f1a8a5dc66aa34b3",
+      "evidenceSha256": "c59f0e37275f2d5e14b09e8f4fe6f7b9222c37ca41e2575a3899cbe01c1cdd1f",
       "manifestSha256": "c34050bbafd7dbb339e9a1a8dabffc4ab2ab84203fc1f1739d9045c883563955",
       "name": "@platos/adapter-redis-ratelimit",
       "ociImageClosure": {
@@ -53844,7 +53872,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3023
+              "line": 3058
             },
             {
               "from": "packages/contexts/agents/README.md",
@@ -54427,7 +54455,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1113
+              "line": 1132
             },
             {
               "from": "scripts/license-distribution.test.mjs",
@@ -54767,7 +54795,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "50c56925423475846bd7e288b71c18ac66f9c7b5ae82c16dfc75cd4405d777f9",
+      "evidenceSha256": "3d58f06daa9a9c087867ab576af3951c56dc6c85d856a86db76b93c1c69763eb",
       "manifestSha256": "e43db9efa534960ba5ade2f86cf89a88453e7575222d56297d6b6ccfe816a8f3",
       "name": "@platos/context-agents",
       "ociImageClosure": {
@@ -54952,7 +54980,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3039
+              "line": 3074
             },
             {
               "from": "packages/contexts/channels/README.md",
@@ -55416,7 +55444,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1177
+              "line": 1196
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -55664,7 +55692,7 @@
           "packages/contexts/channels"
         ]
       },
-      "evidenceSha256": "1598f41685f721897cba2e3835c95bd18f16f5699d007cc8b47ede409f205ab8",
+      "evidenceSha256": "380358cab25e56c36361bcb990ab908592655b3be0e25e2720d8944cd9857e12",
       "manifestSha256": "83395ffe4b76070f9efb7bd1bb4b49d7228aea090069f569a5eec747aa98ab74",
       "name": "@platos/context-channels",
       "ociImageClosure": {
@@ -56361,7 +56389,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1306
+              "line": 1330
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -56682,7 +56710,7 @@
           "packages/contexts/conversations"
         ]
       },
-      "evidenceSha256": "78ea397fa4ea4b0bf1a625a63f4bc57bfe2c698c0b48f2df9c10454a3ed744cd",
+      "evidenceSha256": "6c6257b39b22c0b6639feb9ebdea1540ea38c2e887efc15a8f69afa0880aa576",
       "manifestSha256": "218c32b5c5b423bdf39bf215d6365c07bbd746fca291a1b0609da87e2cebd4d8",
       "name": "@platos/context-conversations",
       "ociImageClosure": {
@@ -56911,7 +56939,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3047
+              "line": 3082
             },
             {
               "from": "packages/contexts/cost-monitoring/README.md",
@@ -57453,7 +57481,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1000
+              "line": 1019
             }
           ],
           "reversePaths": [
@@ -57775,7 +57803,7 @@
           "packages/contexts/cost-monitoring"
         ]
       },
-      "evidenceSha256": "fb7dd276851263b2d5c6bb9e52e0e5324aef1bb86c6b5e8f5ce00bfb220e10f2",
+      "evidenceSha256": "3a77057b0eeb0e3092291e54d35a64e0310002614ea1a6416910750fb12f8a6c",
       "manifestSha256": "2e327d74bea9a17116d859d643836bc142e0977bd86d3a96567638fb75c7b3bb",
       "name": "@platos/context-cost-monitoring",
       "ociImageClosure": {
@@ -57943,7 +57971,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3071
+              "line": 3106
             },
             {
               "from": "packages/contexts/eventing/README.md",
@@ -58631,7 +58659,7 @@
           "packages/contexts/eventing"
         ]
       },
-      "evidenceSha256": "419ca1d8fccf4262cc5c67ae2f5bfea4a9b7b47c184c77949dcb1e04d9b5ee9e",
+      "evidenceSha256": "6a3165a9bf08aa402dd27b843a4076dbc7c44571ef0f5222786c6414f0305b93",
       "manifestSha256": "57c1d00c9dc67970acaec3dc30138bbd18273e9d303ea3804f6a13ab6a2d012a",
       "name": "@platos/context-eventing",
       "ociImageClosure": {
@@ -58910,7 +58938,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3079
+              "line": 3114
             },
             {
               "from": "packages/contexts/files/README.md",
@@ -59470,7 +59498,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1451
+              "line": 1464
             }
           ],
           "reversePaths": [
@@ -59822,7 +59850,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "e0c07220b7ad1cdeb9e7617f8d3446dfd4f15d62a5633c5db1626c9b90afbabd",
+      "evidenceSha256": "6c2b5c6c85588161c8c8687b262612ee44705df0df12eefd88ccb56e91a9331b",
       "manifestSha256": "39fe0424b871775bb785e2d759c32cd0e833a9cf71c9934313d397ca699950ca",
       "name": "@platos/context-files",
       "ociImageClosure": {
@@ -59985,7 +60013,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3087
+              "line": 3122
             },
             {
               "from": "packages/contexts/governance/README.md",
@@ -60350,6 +60378,18 @@
               "specifier": "@platos/context-governance/application/ports/index.js"
             },
             {
+              "file": "packages/adapters/postgres-tenancy/src/governance-scope.ts",
+              "from": "packages/adapters/postgres-tenancy",
+              "line": 81,
+              "specifier": "@platos/context-governance/application/ports/index.js"
+            },
+            {
+              "file": "packages/adapters/postgres-tenancy/src/governance-scope.ts",
+              "from": "packages/adapters/postgres-tenancy",
+              "line": 87,
+              "specifier": "@platos/context-governance/application/ports/index.js"
+            },
+            {
               "file": "packages/adapters/postgres-tenancy/src/governance-seam-activity.ts",
               "from": "packages/adapters/postgres-tenancy",
               "line": 67,
@@ -60459,6 +60499,10 @@
             ],
             [
               "packages/adapters/postgres-tenancy",
+              "packages/adapters/postgres-tenancy/src/governance-scope.ts"
+            ],
+            [
+              "packages/adapters/postgres-tenancy",
               "packages/adapters/postgres-tenancy/src/governance-seam-activity.ts"
             ],
             [
@@ -60504,6 +60548,11 @@
               "line": 35
             },
             {
+              "from": "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+              "kind": "reference",
+              "line": 54
+            },
+            {
               "from": "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
               "kind": "reference",
               "line": 36
@@ -60526,7 +60575,7 @@
             {
               "from": "packages/adapters/postgres-tenancy/src/governance-statements.integration.test.ts",
               "kind": "reference",
-              "line": 35
+              "line": 46
             },
             {
               "from": "packages/adapters/postgres-tenancy/src/governance-transaction.integration.test.ts",
@@ -60706,7 +60755,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1203
+              "line": 1227
             }
           ],
           "reversePaths": [
@@ -60729,6 +60778,10 @@
             [
               "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
               "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts"
+            ],
+            [
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
+              "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts"
             ],
             [
               "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
@@ -60901,6 +60954,7 @@
             "packages/adapters/postgres-tenancy/src/governance-conformance.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-constraints.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-eval-runs.integration.test.ts",
+            "packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-read-seams.integration.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-read-seams.test.ts",
             "packages/adapters/postgres-tenancy/src/governance-rows.test.ts",
@@ -61022,7 +61076,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "4f8666049f7b4dff417159cab575f9bcc9c976b097b403d82316484073879acb",
+      "evidenceSha256": "4d17f88e4a40159cbf5618dc85f069816fca8427811804e01d18cfbc4d475ec2",
       "manifestSha256": "2e4c46079d53cec680be1e27cbc15aed896688935706c604462aef1db775b330",
       "name": "@platos/context-governance",
       "ociImageClosure": {
@@ -61840,7 +61894,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3127
+              "line": 3162
             },
             {
               "from": "docs/v1-ledger-rules.json",
@@ -62721,7 +62775,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 669
+              "line": 676
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -63687,7 +63741,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "8b9cdad76473c5eb803a05090010a72624e17a1ca6738b567b8b02ab9092cbb6",
+      "evidenceSha256": "9e3d942d68eada1f4bd90295096f9a2c90f453eac0ebe788197d7d93afe8058a",
       "manifestSha256": "df554d7bb17a6aab26b8ff63eb9c6033d16e186a234ad9d69c52d1eca7edf146",
       "name": "@platos/context-identity-access",
       "ociImageClosure": {
@@ -64440,7 +64494,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1450
+              "line": 1463
             }
           ],
           "reversePaths": [
@@ -64735,7 +64789,7 @@
           "packages/contexts/jobs"
         ]
       },
-      "evidenceSha256": "63f597bfb207a36273a8f109dc8974b5a9bd030c959969aade6782f4a16c1dbf",
+      "evidenceSha256": "3fe6defaa69d1bb5c6d5016ef5062cfccc67274685d4f6e00283025fbbfbd301",
       "manifestSha256": "da3cc481236d02e85484094c0def2d6fc84c838c3c285f44efe4619a6c26e08c",
       "name": "@platos/context-jobs",
       "ociImageClosure": {
@@ -64942,7 +64996,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3167
+              "line": 3202
             },
             {
               "from": "packages/contexts/memory/README.md",
@@ -65590,7 +65644,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 970
+              "line": 989
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -65945,7 +65999,7 @@
           "packages/contexts/memory"
         ]
       },
-      "evidenceSha256": "72a3b8d93f07db5e24189d3b95619d42b0dacc2e5b48ae97f59c112ae1bf43f2",
+      "evidenceSha256": "5d7b4f932098a6143b8255933bc5b9e216d86e544fda5e4d97d3e87168429a14",
       "manifestSha256": "d596af2fb68e3e6c3622cf1cfb1683e20f46b5fac434d3f8cd6bf37df74d5b28",
       "name": "@platos/context-memory",
       "ociImageClosure": {
@@ -66525,7 +66579,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1071
+              "line": 1090
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -66768,7 +66822,7 @@
           "packages/contexts/observability"
         ]
       },
-      "evidenceSha256": "2ec44e2f5e4c9581fa86adae77f08d45d4ecd0521c36c8a3fb3bfb1950908131",
+      "evidenceSha256": "c218fd38057c937c615df6cf8b76f667f5f03445f2eb1533d46ec64d3d1d0871",
       "manifestSha256": "09d858b658a326451d6bdd026af44df9ba5d1b195ce0c71deffc0cb972afc6d7",
       "name": "@platos/context-observability",
       "ociImageClosure": {
@@ -67372,7 +67426,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1038
+              "line": 1057
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -67598,7 +67652,7 @@
           "packages/contexts/privacy"
         ]
       },
-      "evidenceSha256": "b101a067ff2ac6a7f573d23cee11f1ea4aa6324aeb81c21e0b523e9b381a05b7",
+      "evidenceSha256": "4647bedaca9b023040dffa86e785a22435a493d6bc1f9356d47eca180f2426f4",
       "manifestSha256": "8d9032044280327b5d3d795c13039f78e41ca275c9d6bce9f093b794a97473f1",
       "name": "@platos/context-privacy",
       "ociImageClosure": {
@@ -68020,7 +68074,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3175
+              "line": 3210
             },
             {
               "from": "packages/contexts/providers/README.md",
@@ -68970,7 +69024,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 770
+              "line": 777
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -69595,7 +69649,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "16026112cfb02707b67f6fd2ff20a5751a1b79b05c339e1fbb0d1b586a4c93b0",
+      "evidenceSha256": "6d88abe99754b30bcc5c71e6d91210322a55beff136448d551cfb43fd09700e3",
       "manifestSha256": "7462dcd3934c960646a6d3528915863411b9e195545de995cb54d10e6c43da83",
       "name": "@platos/context-providers",
       "ociImageClosure": {
@@ -70072,7 +70126,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3183
+              "line": 3218
             },
             {
               "from": "docs/v1-ledger-rules.json",
@@ -71603,7 +71657,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "1ed07dd826c56781ad390a32ac93f02f5e26d64c4d7bd1ff896917be8d666695",
+      "evidenceSha256": "1bf97cf921b7def367117a531ef00811b9be2b09b3c6f81fa7892651b9eab277",
       "manifestSha256": "03739f55f9812a44e47b5c9175c9ebb610f9448ba48bf906432c70796ecc3c03",
       "name": "@platos/context-secrets",
       "ociImageClosure": {
@@ -71834,7 +71888,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3239
+              "line": 3274
             },
             {
               "from": "packages/contexts/skills/README.md",
@@ -72395,7 +72449,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 813
+              "line": 826
             }
           ],
           "reversePaths": [
@@ -72709,7 +72763,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "040354e3f0dac3c1df06bd6b9dbdeff0d5806386e691a198ddeaabc398f93949",
+      "evidenceSha256": "ed79e44bc82555105005b415f83063efaeef128a2827dbb9b20c3f4767cef884",
       "manifestSha256": "f1e56a67ae6b3d846f0887d8a17048ad19d4e0356bf7f38d1056b58507a2e7e2",
       "name": "@platos/context-skills",
       "ociImageClosure": {
@@ -73376,7 +73430,7 @@
             {
               "from": "docs/error-taxonomy.json",
               "kind": "reference",
-              "line": 3247
+              "line": 3282
             },
             {
               "from": "packages/contexts/tenancy/README.md",
@@ -74639,7 +74693,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 708
+              "line": 715
             },
             {
               "from": "scripts/arch/transaction-outcome.test.mjs",
@@ -75509,7 +75563,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "0d8447977e8414f58aefdc43a37c1cef16e704ee4b103e261d5930d1fa583a84",
+      "evidenceSha256": "0b780d8ede79c9620da5ef7190613da6154e623add9656c05b22b76c8400d821",
       "manifestSha256": "552444b4f4df12b062f2eb788b926946ca8310d37b21721f111e9995e78b2a94",
       "name": "@platos/context-tenancy",
       "ociImageClosure": {
@@ -76326,7 +76380,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1142
+              "line": 1161
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -76336,7 +76390,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1312
+              "line": 1325
             }
           ],
           "reversePaths": [
@@ -76650,7 +76704,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "8deebb4ea6710585b70601730a1bc1eeea2dc9df700c19cd47bae7e61d06535a",
+      "evidenceSha256": "c5b27faebc99b89bf2d92415555399b0b519d9c712ef53eb17c6fc9cebb3b4d1",
       "manifestSha256": "87996481926b67e29a649aad1f8de452892ea7a0c07fa8f694e70a63420d490b",
       "name": "@platos/context-tools",
       "ociImageClosure": {
@@ -80914,13 +80968,13 @@
             {
               "file": "packages/contexts/governance/application/ports/index.ts",
               "from": "packages/contexts/governance",
-              "line": 141,
+              "line": 149,
               "specifier": "@platos/kernel"
             },
             {
               "file": "packages/contexts/governance/application/ports/index.ts",
               "from": "packages/contexts/governance",
-              "line": 157,
+              "line": 163,
               "specifier": "@platos/kernel"
             },
             {
@@ -89424,7 +89478,7 @@
           "packages/kernel"
         ]
       },
-      "evidenceSha256": "674f734fd4462dd9210addbc77dcad047be76bc0415a9bbc47d6f3a718ae2ead",
+      "evidenceSha256": "70c2e756fcde5ca682548a685f2800a7d00e620b3a1eb09b578036e4f221432c",
       "manifestSha256": "4f315c3595455a1866bf39b540a93c4e447888035d3c5a445fc0bbf836219212",
       "name": "@platos/kernel",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `570bad1406b0d61596bd89ec9d369d6b08be2eb0bbc8be82b914d085ede77572`
+Evidence SHA-256: `04d333367dbe0a2ba92dacecf5bc85d30e427b2f43c0b35efaae02bc4556c6f2`
 
 ## Baseline
 
@@ -47,15 +47,15 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/cache` | `@internal/cache` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9f2db1155272a42…` |
 | `internal-packages/compute` | `@internal/compute` | no | no | no | no | owner-review-repository-referenced | no | yes | `744fd4bd20e8d379…` |
 | `internal-packages/cost-rates` | `@internal/cost-rates` | no | no | no | no | owner-review-repository-referenced | no | yes | `6164efe052d457dc…` |
-| `internal-packages/database` | `@platos/database` | no | no | no | yes | owner-review-repository-referenced | no | yes | `b14b38b79bd335f6…` |
+| `internal-packages/database` | `@platos/database` | no | no | no | yes | owner-review-repository-referenced | no | yes | `82377f5198d6fa5e…` |
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
-| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `1e3056c354e5034e…` |
-| `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `a779e7c1e1979e30…` |
-| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `28aaf7f094925015…` |
+| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9ef3be1663e42d2…` |
+| `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `2a1a04bcb4c15a8f…` |
+| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f446c8903057171…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
-| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `67a220187f2f9487…` |
+| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `c4f895a4e871ac6a…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
 | `internal-packages/testcontainers` | `@internal/testcontainers` | no | no | no | yes | owner-review-repository-referenced | no | yes | `bb476fbe57da5a07…` |
 | `internal-packages/tracing` | `@internal/tracing` | no | no | no | no | owner-review-repository-referenced | no | yes | `e03f6256d2d15deb…` |
@@ -64,37 +64,37 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/adapters/channel-slack` | `@platos/adapter-channel-slack` | no | yes | yes | no | retain-application-deployable | no | no | `29b17950af01fa36…` |
 | `packages/adapters/clickhouse-observability` | `@platos/adapter-clickhouse-observability` | no | yes | yes | no | retain-application-deployable | no | no | `90b03e040b6b4b30…` |
 | `packages/adapters/durable-runtime` | `@platos/adapter-durable-runtime` | no | yes | yes | no | retain-application-deployable | no | no | `923006eb949fcddc…` |
-| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `a628e61d069bc9a1…` |
-| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `e96d9796e0fdbc55…` |
-| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `f1aa64dbaaa23286…` |
+| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `5e19b4c260ab9a0a…` |
+| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `976c64e1122e8f5d…` |
+| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `d3270e97663422d3…` |
 | `packages/adapters/notifier-email` | `@platos/adapter-notifier-email` | no | yes | yes | no | retain-application-deployable | no | no | `214dcdfb7915d520…` |
 | `packages/adapters/notifier-webhook` | `@platos/adapter-notifier-webhook` | no | yes | yes | no | retain-application-deployable | no | no | `fde9eb07ee1d6e4c…` |
 | `packages/adapters/objectstore-minio` | `@platos/adapter-objectstore-minio` | no | yes | yes | no | retain-application-deployable | no | no | `fb582cbf0e1ab339…` |
-| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `609c2782f0c37ad3…` |
-| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `03fd26bcb8fae7b8…` |
-| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `c0af8a0762b67a9a…` |
-| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `7a070e5ab8cf4668…` |
+| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `e0a3864c6aaa4291…` |
+| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `39f5e1b9a76fab30…` |
+| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `c50603b6486ec872…` |
+| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `c59f0e37275f2d5e…` |
 | `packages/adapters/redis-streams` | `@platos/adapter-redis-streams` | no | yes | yes | no | retain-application-deployable | no | no | `26a3c07d7a0ee3e3…` |
 | `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `372a7698ee7c8cad…` |
-| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `50c5692542347584…` |
-| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `1598f41685f72189…` |
-| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `78ea397fa4ea4b0b…` |
-| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `fb7dd276851263b2…` |
-| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `419ca1d8fccf4262…` |
-| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `e0c07220b7ad1cde…` |
-| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `4f8666049f7b4dff…` |
-| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `8b9cdad76473c5eb…` |
-| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `63f597bfb207a362…` |
-| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `72a3b8d93f07db5e…` |
-| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `2ec44e2f5e4c9581…` |
-| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `b101a067ff2ac6a7…` |
-| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `16026112cfb02707…` |
-| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `1ed07dd826c56781…` |
-| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `040354e3f0dac3c1…` |
-| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `0d8447977e8414f5…` |
-| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `8deebb4ea6710585…` |
+| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `3d58f06daa9a9c08…` |
+| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `380358cab25e56c3…` |
+| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `6c6257b39b22c0b6…` |
+| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `3a77057b0eeb0e30…` |
+| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `6a3165a9bf08aa40…` |
+| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `6c2b5c6c85588161…` |
+| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `4d17f88e4a40159c…` |
+| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `9e3d942d68eada1f…` |
+| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `3fe6defaa69d1bb5…` |
+| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `5d7b4f932098a614…` |
+| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `c218fd38057c937c…` |
+| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `4647bedaca9b0230…` |
+| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `6d88abe99754b30b…` |
+| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `1bf97cf921b7def3…` |
+| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `ed79e44bc8255510…` |
+| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `0b780d8ede79c962…` |
+| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `c5b27faebc99b89b…` |
 | `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `d1ae004000a14ce5…` |
-| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `674f734fd4462dd9…` |
+| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `70c2e756fcde5ca6…` |
 | `packages/platools-js` | `@platosdev/platools-sdk` | no | no | no | no | owner-review-public-boundary | yes | yes | `ef3c50af6c9cc907…` |
 | `packages/platos-client` | `@platosdev/client` | no | no | no | no | owner-review-public-boundary | yes | yes | `ccd54801378e667b…` |
 | `packages/platos-embed` | `@platosdev/embed` | no | no | no | no | owner-review-public-boundary | yes | yes | `26f83fd504a22a2c…` |

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "25d706263378d5420e162b8f891339362250f8432f59c18156f81c1d838ff269",
+      "sha256": "78b0eba2173fdca197f88592afbd9c173ef5431d89b1346f9f71c4469579ec3d",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "da10c2c0c75294317fde497d95b65fe8c2737639d9140980ae57d25b5d4164c3",
+      "sha256": "5c2e7c5ba61a23907a9693095096c0687566d76b1e78d56e067297577ecd79c1",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "a4e9e78239c5f8a79bcc14e14c72a3f67a937621631a12cff4d1fb2cac0a2b40",
+      "sha256": "727cdead92f0311c6533576571550e7bffd62b59aae4c8b26bd59436dd10a5d5",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "25d706263378d5420e162b8f891339362250f8432f59c18156f81c1d838ff269"
+      "sha256": "78b0eba2173fdca197f88592afbd9c173ef5431d89b1346f9f71c4469579ec3d"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1413,7 +1413,7 @@
     {
       "path": "docs/error-taxonomy.json",
       "mode": "100644",
-      "sha256": "546892e6766f29bf7a1e3812eeb3437d71b56a108c5c41def9cabacce3538852"
+      "sha256": "df31927f0a85460eefbe3f47be98b4b27fcae7731fc0554b086a81f9f2c4653a"
     },
     {
       "path": "docs/errors-retrying.mdx",
@@ -3483,7 +3483,7 @@
     {
       "path": "docs/v1-ledger-rules.json",
       "mode": "100644",
-      "sha256": "308f6ff87f7d4ea2b874da923e7993383e46e36d40b0847d7e6da443704be74d"
+      "sha256": "da460bd77194dc9d84ed4d29266dd476071e53fc800f45fb4fda4fcefc85d266"
     },
     {
       "path": "docs/v3-openapi.yaml",
@@ -3923,7 +3923,7 @@
     {
       "path": "scripts/v1-ledger.test.mjs",
       "mode": "100644",
-      "sha256": "dc08918658ba8dde11eb05a34d4236cd106a4c0752c2e89035f0f484c10305e9"
+      "sha256": "56e6ef47993224c28885d6d5957b394a44251c7669ef70f3e8957abda37e554a"
     },
     {
       "path": "scripts/verify-advisory-nonvacuity.mjs",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "da10c2c0c75294317fde497d95b65fe8c2737639d9140980ae57d25b5d4164c3"
+      "sha256": "5c2e7c5ba61a23907a9693095096c0687566d76b1e78d56e067297577ecd79c1"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "a4e9e78239c5f8a79bcc14e14c72a3f67a937621631a12cff4d1fb2cac0a2b40"
+      "sha256": "727cdead92f0311c6533576571550e7bffd62b59aae4c8b26bd59436dd10a5d5"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4729,8 +4729,8 @@
   "integration": {
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "b656de1214b801e8a8ef62237fcdfb544801a6cd32ceee3d2e79de601ee85c9d",
-    "ledgerRulesSha256": "308f6ff87f7d4ea2b874da923e7993383e46e36d40b0847d7e6da443704be74d",
-    "reachabilitySha256": "da10c2c0c75294317fde497d95b65fe8c2737639d9140980ae57d25b5d4164c3",
+    "ledgerRulesSha256": "da460bd77194dc9d84ed4d29266dd476071e53fc800f45fb4fda4fcefc85d266",
+    "reachabilitySha256": "5c2e7c5ba61a23907a9693095096c0687566d76b1e78d56e067297577ecd79c1",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/error-taxonomy.json
+++ b/docs/error-taxonomy.json
@@ -1185,6 +1185,13 @@
         "governance"
       ]
     },
+    "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED": {
+      "category": "internal",
+      "status": 500,
+      "contexts": [
+        "governance"
+      ]
+    },
     "GOVERNANCE_CRITERION_ALREADY_EXISTS": {
       "category": "conflict",
       "status": 409,
@@ -1248,6 +1255,13 @@
         "governance"
       ]
     },
+    "GOVERNANCE_EVALS_SCOPE_UNRESOLVED": {
+      "category": "internal",
+      "status": 500,
+      "contexts": [
+        "governance"
+      ]
+    },
     "GOVERNANCE_EVAL_NOT_FOUND": {
       "category": "not_found",
       "status": 404,
@@ -1258,6 +1272,13 @@
     "GOVERNANCE_EVAL_SELF_JUDGED": {
       "category": "conflict",
       "status": 409,
+      "contexts": [
+        "governance"
+      ]
+    },
+    "GOVERNANCE_GOLDEN_SETS_SCOPE_UNRESOLVED": {
+      "category": "internal",
+      "status": 500,
       "contexts": [
         "governance"
       ]
@@ -1339,6 +1360,13 @@
         "governance"
       ]
     },
+    "GOVERNANCE_RATINGS_SCOPE_UNRESOLVED": {
+      "category": "internal",
+      "status": 500,
+      "contexts": [
+        "governance"
+      ]
+    },
     "GOVERNANCE_RATING_ACTOR_FORBIDDEN": {
       "category": "forbidden",
       "status": 403,
@@ -1391,6 +1419,13 @@
     "GOVERNANCE_SAFETY_RULE_MALFORMED": {
       "category": "invalid_input",
       "status": 400,
+      "contexts": [
+        "governance"
+      ]
+    },
+    "GOVERNANCE_SAFETY_SCOPE_UNRESOLVED": {
+      "category": "internal",
+      "status": 500,
       "contexts": [
         "governance"
       ]

--- a/docs/v1-ledger-rules.json
+++ b/docs/v1-ledger-rules.json
@@ -2082,7 +2082,7 @@
     ]
   },
   "expected": {
-    "totalFiles": 5123,
+    "totalFiles": 5125,
     "areaCounts": {
       "apps-agent": 516,
       "apps-core-api": 72,
@@ -2090,7 +2090,7 @@
       "apps-webapp": 183,
       "docs-content": 737,
       "internal-packages": 1174,
-      "packages": 2138,
+      "packages": 2140,
       "root-infra": 295
     },
     "kindCounts": {
@@ -2102,14 +2102,14 @@
       "legal": 14,
       "lockfile": 3,
       "migration": 896,
-      "source": 2053,
-      "test": 1031
+      "source": 2054,
+      "test": 1032
     },
     "dispositionCounts": {
       "archive": 7,
       "move-refactor": 1632,
       "regenerate": 39,
-      "retain": 3443,
+      "retain": 3445,
       "unresolved": 2
     },
     "protectedCount": 1633,
@@ -2203,8 +2203,8 @@
       "packages.adapters.config": 58,
       "packages.adapters.doc": 15,
       "packages.adapters.fixture": 3,
-      "packages.adapters.source": 265,
-      "packages.adapters.test": 184,
+      "packages.adapters.source": 266,
+      "packages.adapters.test": 185,
       "packages.config.build": 28,
       "packages.contexts.config": 37,
       "packages.contexts.doc": 17,
@@ -2250,6 +2250,6 @@
       "root-infra.tooling.scripts": 92,
       "root-infra.tooling.workspace-reachability": 1
     },
-    "classificationSha256": "a40de887e36c5715ff7d0940ba7a0cc666c8dda746ca0587e244cda808deb6b5"
+    "classificationSha256": "c611b6750b4b1efbac8ba1be32f6c3a8064610c00131806af6356afda3c85e44"
   }
 }

--- a/packages/adapters/postgres-tenancy/mutations-governance.json
+++ b/packages/adapters/postgres-tenancy/mutations-governance.json
@@ -1,8 +1,8 @@
 {
   "$schema-note": "Hand-maintained. Data, not code: nothing under src/ imports this file.",
   "purpose": [
-    "The guard ledger for WIN-258 TRANCHE 5 \u2014 `governance`'s canonical store, the",
-    "SIXTH owner behind the one PostgreSQL client ADR M0.3 \u00a715 gives the ORM. One",
+    "The guard ledger for WIN-258 TRANCHE 5 — `governance`'s canonical store, the",
+    "SIXTH owner behind the one PostgreSQL client ADR M0.3 §15 gives the ORM. One",
     "entry per guard: per scope predicate, per vocabulary check that stands where",
     "no enum stands, per shape check that stands where a migration-only CHECK",
     "stands, per envelope decision that keeps a row an older binary wrote",
@@ -21,8 +21,8 @@
     "",
     "WHY THIS TRANCHE NEEDED ITS OWN SWEEP. Three of its guards protect facts the",
     "DATABASE does not hold at all. `SafetyEvent.detector`, `.action` and",
-    "`.severity` are plain `String` columns \u2014 the closed sets live only in",
-    "`domain/safety-event.ts` \u2014 so a store that CAST them would put a value",
+    "`.severity` are plain `String` columns — the closed sets live only in",
+    "`domain/safety-event.ts` — so a store that CAST them would put a value",
     "outside the union into `summarise`, whose histograms are keyed by the union,",
     "and the total would stop equalling the sum of the parts with no error",
     "anywhere. And three fields of `AdmittedSafetyEvent` have no column, so they",
@@ -38,7 +38,7 @@
     "`CHECK (\"rating\" IN (-1, 1))` behind a preflight block that refuses to build the",
     "database at all if any row holds 2, 3, 4 or 5. An adapter written against the",
     "FIRST reading refuses every thumbs-down the product emits and accepts four",
-    "values no database this migration builds can hold \u2014 wrong in both directions at",
+    "values no database this migration builds can hold — wrong in both directions at",
     "once, with `schema.prisma` showing neither constraint. M-G20 and M-G46 are the",
     "two halves of that guard, and the constraints suite stands them side by side."
   ],
@@ -64,19 +64,19 @@
     "RESULT, 2026-09-06, against PostgreSQL 16 in a container: 46 entries, 46",
     "KILLED, 0 SURVIVED, 0 VACUOUS. Every baseline suite set was green with a",
     "non-zero executed case count before its mutation was applied, and every",
-    "`from` matched its file exactly once \u2014 the driver refuses an entry whose",
+    "`from` matched its file exactly once — the driver refuses an entry whose",
     "anchor occurs zero times or more than once, so a sweep that silently changed",
     "nothing is not a state this can reach.",
     "",
     "THE FIRST SWEEP FOUND FOUR SURVIVORS AND THEY ARE WHY FOUR CASES EXIST.",
     "M-G18 survived because the three scope refusals were measured through",
-    "`criteria.remove` alone, and `append` \u2014 the ONE method here whose transaction",
-    "parameter is NULLABLE \u2014 was the one an implementation could plausibly have",
+    "`criteria.remove` alone, and `append` — the ONE method here whose transaction",
+    "parameter is NULLABLE — was the one an implementation could plausibly have",
     "resolved through `reader()` on both branches. M-G19 survived because the",
     "cross-environment flip used a rating the CHECK refuses, so the DATABASE was",
     "refusing the write the missing scope predicate should have. M-G23 survived",
-    "because an erasure that drops its subject predicate returns the right COUNT \u2014",
-    "the rows it destroyed are the rows it counted \u2014 and only somebody ELSE'S vote",
+    "because an erasure that drops its subject predicate returns the right COUNT —",
+    "the rows it destroyed are the rows it counted — and only somebody ELSE'S vote",
     "can see it. M-G27 survived because `\"agentId\" in query` and",
     "`query.agentId === undefined` differ only when the KEY IS PRESENT and the",
     "value is undefined, a third case the scenario did not ask for. Each is now a",
@@ -129,7 +129,7 @@
       "file": "src/governance-rows.ts",
       "from": "  if (metadata[SAFETY_METADATA_MARKER] === undefined) {",
       "to": "  if (false) {",
-      "note": "Without the marker check every stored object is read as an envelope, so a legacy attribute bag loses its whole body and a detector attribute named `principalId` becomes the ledger's subject \u2014 erasable on somebody else's behalf.",
+      "note": "Without the marker check every stored object is read as an envelope, so a legacy attribute bag loses its whole body and a detector attribute named `principalId` becomes the ledger's subject — erasable on somebody else's behalf.",
       "suites": [
         "src/governance-rows.test.ts",
         "src/governance-rules.integration.test.ts"
@@ -237,7 +237,7 @@
       "file": "src/governance-safety.ts",
       "from": "            : { toolName: { contains: query.search, mode: \"insensitive\" as const } }),",
       "to": "            : { toolName: { contains: query.search } }),",
-      "note": "Tool names are not normalised anywhere in the schema, so a case-sensitive search finds `web_fetch` and not `WEB_fetch` \u2014 the same tool, spelled by a different producer.",
+      "note": "Tool names are not normalised anywhere in the schema, so a case-sensitive search finds `web_fetch` and not `WEB_fetch` — the same tool, spelled by a different producer.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
       ],
@@ -248,8 +248,8 @@
     {
       "name": "M-G13 safety: a NULL subject matches NOTHING, without a statement",
       "file": "src/governance-safety.ts",
-      "from": "        if (selector.principalId === null) return ok(0);\n        const total = await transactions.reader().safetyEvent.count({",
-      "to": "        const total = await transactions.reader().safetyEvent.count({",
+      "from": "      const principalId = selector.principalId;\n      if (principalId === null) return ok(0);\n      return inGovernanceScope(",
+      "to": "      const principalId = selector.principalId as string;\n      return inGovernanceScope(",
       "note": "The port says an implementation MUST treat a null selector as matching nothing rather than as 'match everything'. Answered without a statement, so the rule holds even if the filter were wrong.",
       "suites": [
         "src/governance-conformance.integration.test.ts",
@@ -264,7 +264,7 @@
       "file": "src/governance-safety.ts",
       "from": "      { metadata: { path: [SAFETY_METADATA_MARKER], equals: 1 } },\n      { metadata: { path: [\"principalId\"], equals: principalId } },",
       "to": "      { metadata: { path: [\"principalId\"], equals: principalId } },",
-      "note": "A legacy row's metadata is the producer's raw attribute bag. Without the marker clause a detector that emitted a key called `principalId` has its attribute read as the ledger's subject \u2014 and anonymised on somebody else's behalf.",
+      "note": "A legacy row's metadata is the producer's raw attribute bag. Without the marker clause a detector that emitted a key called `principalId` has its attribute read as the ledger's subject — and anonymised on somebody else's behalf.",
       "suites": [
         "src/governance-rules.integration.test.ts"
       ],
@@ -275,8 +275,8 @@
     {
       "name": "M-G15 safety: anonymising OVERWRITES and never deletes",
       "file": "src/governance-safety.ts",
-      "from": "        const outcome = await client.safetyEvent.updateMany({\n          where: subjectWhere(selector, selector.principalId),\n          data: { detail: null, metadata: nullableJson(null), endUserId: null },\n        });",
-      "to": "        const outcome = await client.safetyEvent.deleteMany({\n          where: subjectWhere(selector, selector.principalId),\n        });",
+      "from": "          const outcome = await client.safetyEvent.updateMany({\n            where: subjectWhere(selector, selector.principalId),\n            data: { detail: null, metadata: nullableJson(null), endUserId: null },\n          });",
+      "to": "          const outcome = await client.safetyEvent.deleteMany({\n            where: subjectWhere(selector, selector.principalId),\n          });",
       "note": "A compliance ledger that can be emptied is not a compliance ledger. The detector, action, severity and instant must survive the erasure of who it was about.",
       "suites": [
         "src/governance-rules.integration.test.ts"
@@ -301,8 +301,8 @@
     {
       "name": "M-G17 safety: the two detector families the risk score divides by",
       "file": "src/governance-safety.ts",
-      "from": "          if (PII_DETECTORS.includes(detector)) bucket.pii += group._count._all;\n          if (INJECTION_DETECTORS.includes(detector)) bucket.injection += group._count._all;",
-      "to": "          if (INJECTION_DETECTORS.includes(detector)) bucket.pii += group._count._all;\n          if (PII_DETECTORS.includes(detector)) bucket.injection += group._count._all;",
+      "from": "            if (PII_DETECTORS.includes(detector)) bucket.pii += group._count._all;\n            if (INJECTION_DETECTORS.includes(detector)) bucket.injection += group._count._all;",
+      "to": "            if (INJECTION_DETECTORS.includes(detector)) bucket.pii += group._count._all;\n            if (PII_DETECTORS.includes(detector)) bucket.injection += group._count._all;",
       "note": "Swapped, every agent's PII rate is its injection rate and the risk band a canary decision is taken on is computed from the wrong numerator.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -314,9 +314,9 @@
     {
       "name": "M-G18 safety: a write carrying a scope goes through `writer`, which refuses three ways",
       "file": "src/governance-safety.ts",
-      "from": "        const client = transaction === null ? transactions.reader() : transactions.writer(transaction);\n        const written = await client.safetyEvent.createManyAndReturn({",
-      "to": "        const client = transactions.reader();\n        const written = await client.safetyEvent.createManyAndReturn({",
-      "note": "`writer(scope)` is what proves the token a write was handed is the transaction it is actually inside. `append` is the ONE method here whose transaction parameter is NULLABLE, so it is the one an implementation could plausibly have resolved through `reader()` on both branches \u2014 and a stale or foreign token would then be accepted.",
+      "from": "          const client = transaction === null ? transactions.reader() : transactions.writer(transaction);\n          const written = await client.safetyEvent.createManyAndReturn({",
+      "to": "          const client = transactions.reader();\n          const written = await client.safetyEvent.createManyAndReturn({",
+      "note": "`writer(scope)` is what proves the token a write was handed is the transaction it is actually inside. `append` is the ONE method here whose transaction parameter is NULLABLE, so it is the one an implementation could plausibly have resolved through `reader()` on both branches — and a stale or foreign token would then be accepted.",
       "suites": [
         "src/governance-transaction.integration.test.ts"
       ],
@@ -327,8 +327,8 @@
     {
       "name": "M-G19 ratings: the flip is keyed on the ENVIRONMENT as well as the pair",
       "file": "src/governance-ratings.ts",
-      "from": "          where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },\n          data: {",
-      "to": "          where: { turnId: write.turnId, endUserId: write.endUserId },\n          data: {",
+      "from": "            where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },\n            data: {",
+      "to": "            where: { turnId: write.turnId, endUserId: write.endUserId },\n            data: {",
       "note": "`@@unique([turnId, endUserId])` names no environment, so an update keyed on the pair alone reaches another tenant's row whenever the two ids collide.",
       "suites": [
         "src/governance-rules.integration.test.ts"
@@ -342,7 +342,7 @@
       "file": "src/governance-ratings.ts",
       "from": "        requireStorableRating(write.rating);",
       "to": "",
-      "note": "`MessageRating_rating_check` exists only in the migrations, and that file installs it TWICE: `BETWEEN 1 AND 5` at line 2799, then `IN (-1, 1)` at line 3802 after dropping the first. Let raise, the refusal is still reported \u2014 and PostgreSQL aborts the caller's transaction with it, so a use case that writes a rating and then anything else loses both.",
+      "note": "`MessageRating_rating_check` exists only in the migrations, and that file installs it TWICE: `BETWEEN 1 AND 5` at line 2799, then `IN (-1, 1)` at line 3802 after dropping the first. Let raise, the refusal is still reported — and PostgreSQL aborts the caller's transaction with it, so a use case that writes a rating and then anything else loses both.",
       "suites": [
         "src/governance-constraints.integration.test.ts"
       ],
@@ -367,8 +367,8 @@
     {
       "name": "M-G22 ratings: withdrawing a vote that was not there answers FALSE",
       "file": "src/governance-ratings.ts",
-      "from": "        return ok(outcome.count > 0);\n      }, \"ratings remove\");",
-      "to": "        return ok(true);\n      }, \"ratings remove\");",
+      "from": "          return ok(outcome.count > 0);\n        },\n      );\n    },\n\n    async tallyTurn(",
+      "to": "          return ok(true);\n        },\n      );\n    },\n\n    async tallyTurn(",
       "note": "The port's `remove` answers false when there was nothing to withdraw. Always-true makes a second withdrawal indistinguishable from a first.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -380,9 +380,9 @@
     {
       "name": "M-G23 ratings: a subject's rows are DESTROYED, and only that subject's",
       "file": "src/governance-ratings.ts",
-      "from": "        const outcome = await client.messageRating.deleteMany({\n          where: { endUserId: selector.endUserId, ...tenantWhere(selector.scope) },\n        });",
-      "to": "        const outcome = await client.messageRating.deleteMany({\n          where: { ...tenantWhere(selector.scope) },\n        });",
-      "note": "An erasure that dropped the subject predicate would destroy every rating in the scope, and the COUNT it returns would still look right \u2014 the rows it destroyed are the rows it counted. The only thing that sees the missing predicate is somebody ELSE'S vote, which is why the case seeds a second subject.",
+      "from": "          const outcome = await client.messageRating.deleteMany({\n            where: { endUserId: selector.endUserId, ...tenantWhere(selector.scope) },\n          });",
+      "to": "          const outcome = await client.messageRating.deleteMany({\n            where: { ...tenantWhere(selector.scope) },\n          });",
+      "note": "An erasure that dropped the subject predicate would destroy every rating in the scope, and the COUNT it returns would still look right — the rows it destroyed are the rows it counted. The only thing that sees the missing predicate is somebody ELSE'S vote, which is why the case seeds a second subject.",
       "suites": [
         "src/governance-rules.integration.test.ts"
       ],
@@ -393,8 +393,8 @@
     {
       "name": "M-G24 criteria: the duplicate insert does not RAISE",
       "file": "src/governance-criteria.ts",
-      "from": "          skipDuplicates: true,\n          select: CRITERION_COLUMNS,\n        });\n        const row = created[0];\n        if (row === undefined) {\n          return err(criterionAlreadyExists(scope.environmentId, criterion.name));",
-      "to": "          select: CRITERION_COLUMNS,\n        });\n        const row = created[0];\n        if (row === undefined) {\n          return err(criterionAlreadyExists(scope.environmentId, criterion.name));",
+      "from": "            skipDuplicates: true,\n            select: CRITERION_COLUMNS,\n          });\n          const row = created[0];\n          if (row === undefined) {\n            return err(criterionAlreadyExists(scope.environmentId, criterion.name));",
+      "to": "            select: CRITERION_COLUMNS,\n          });\n          const row = created[0];\n          if (row === undefined) {\n            return err(criterionAlreadyExists(scope.environmentId, criterion.name));",
       "note": "`ON CONFLICT DO NOTHING` is what lets the caller keep its transaction. A raised unique index reports the same refusal and puts the block in 25P02, so every later statement in it fails.",
       "suites": [
         "src/governance-rules.integration.test.ts"
@@ -406,8 +406,8 @@
     {
       "name": "M-G25 criteria: a name clash is the port's OWN code, not a store outage",
       "file": "src/governance-criteria.ts",
-      "from": "          return err(criterionAlreadyExists(scope.environmentId, criterion.name));\n        }\n        return ok(readCriterion(row as EvalCriterionRow));\n      }, \"criteria create\");",
-      "to": "          return err(ledgerUnavailable(\"criterion create wrote no row\"));\n        }\n        return ok(readCriterion(row as EvalCriterionRow));\n      }, \"criteria create\");",
+      "from": "          const row = created[0];\n          if (row === undefined) {\n            return err(criterionAlreadyExists(scope.environmentId, criterion.name));\n          }",
+      "to": "          const row = created[0];\n          if (row === undefined) {\n            return err(ledgerUnavailable(\"criterion create wrote no row\"));\n          }",
       "note": "The port says an implementation MUST map the constraint violation to `GOVERNANCE_CRITERION_ALREADY_EXISTS`. Reported as an outage, a caller retries a name that will never be free.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -419,8 +419,8 @@
     {
       "name": "M-G26 criteria: the update checks SCOPE before it checks the name",
       "file": "src/governance-criteria.ts",
-      "from": "        if (held === null) return err(ledgerUnavailable(\"criterion_not_in_scope\"));\n        const clash = await client.evalCriterion.findFirst({",
-      "to": "        const clash = await client.evalCriterion.findFirst({",
+      "from": "          if (held === null) return err(ledgerUnavailable(\"criterion_not_in_scope\"));\n          const clash = await client.evalCriterion.findFirst({",
+      "to": "          const clash = await client.evalCriterion.findFirst({",
       "note": "A criterion that is BOTH out of scope and name-clashing must report the same refusal from this store as from the double, or a cross-tenant probe is distinguishable from a typo by which error comes back.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -434,7 +434,7 @@
       "file": "src/governance-criteria.ts",
       "from": "  if (!(\"agentId\" in query)) return {};",
       "to": "  if (query.agentId === undefined) return {};",
-      "note": "`undefined` does not filter; an explicit `null` matches only the SHARED criteria. The two are told apart by `\"agentId\" in query`, and the difference is only reachable when the KEY IS PRESENT and the value is undefined \u2014 a third case the port's `agentId?: AgentId | null` permits and the double already handles.",
+      "note": "`undefined` does not filter; an explicit `null` matches only the SHARED criteria. The two are told apart by `\"agentId\" in query`, and the difference is only reachable when the KEY IS PRESENT and the value is undefined — a third case the port's `agentId?: AgentId | null` permits and the double already handles.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
       ],
@@ -471,9 +471,9 @@
     {
       "name": "M-G30 criteria: the name pre-check is EXACT, not case-folded",
       "file": "src/governance-criteria.ts",
-      "from": "          where: { name, ...scopedWhere(scope) },\n          select: CRITERION_COLUMNS,",
-      "to": "          where: { name: { equals: name, mode: \"insensitive\" as const }, ...scopedWhere(scope) },\n          select: CRITERION_COLUMNS,",
-      "note": "The unique index it pre-checks is case-SENSITIVE, so a folded pre-check answers 'taken' for a name `create` would then accept \u2014 a better error message that is not the guarantee, disagreeing with the guarantee.",
+      "from": "            where: { name, ...scopedWhere(scope) },\n            select: CRITERION_COLUMNS,",
+      "to": "            where: { name: { equals: name, mode: \"insensitive\" as const }, ...scopedWhere(scope) },\n            select: CRITERION_COLUMNS,",
+      "note": "The unique index it pre-checks is case-SENSITIVE, so a folded pre-check answers 'taken' for a name `create` would then accept — a better error message that is not the guarantee, disagreeing with the guarantee.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
       ],
@@ -484,8 +484,8 @@
     {
       "name": "M-G31 criteria: removing a criterion DELETES it",
       "file": "src/governance-criteria.ts",
-      "from": "        const outcome = await client.evalCriterion.deleteMany({\n          where: { id: criterionId, ...scopedWhere(scope) },\n        });\n        return ok(outcome.count > 0);\n      }, \"criteria remove\");",
-      "to": "        const outcome = await client.evalCriterion.updateMany({\n          where: { id: criterionId, ...scopedWhere(scope) },\n          data: { isActive: false },\n        });\n        return ok(outcome.count > 0);\n      }, \"criteria remove\");",
+      "from": "          const outcome = await client.evalCriterion.deleteMany({\n            where: { id: criterionId, ...scopedWhere(scope) },\n          });\n          return ok(outcome.count > 0);",
+      "to": "          const outcome = await client.evalCriterion.updateMany({\n            where: { id: criterionId, ...scopedWhere(scope) },\n            data: { isActive: false },\n          });\n          return ok(outcome.count > 0);",
       "note": "The port's `remove` destroys the criterion AND, through `onDelete: Cascade`, every eval taken against it. A soft delete leaves both, and a second `remove` then answers true forever.",
       "suites": [
         "src/governance-conformance.integration.test.ts",
@@ -512,8 +512,8 @@
     {
       "name": "M-G33 evals: an EMPTY version list means every version",
       "file": "src/governance-evals.ts",
-      "from": "            ...(query.versionIds.length === 0\n              ? {}\n              : { agentVersionId: { in: [...query.versionIds] } }),",
-      "to": "            ...{ agentVersionId: { in: [...query.versionIds] } },",
+      "from": "              ...(query.versionIds.length === 0\n                ? {}\n                : { agentVersionId: { in: [...query.versionIds] } }),",
+      "to": "              ...{ agentVersionId: { in: [...query.versionIds] } },",
       "note": "`IN ()` matches nothing, so a scorecard asked for all versions reads as an agent that has never been evaluated.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -525,8 +525,8 @@
     {
       "name": "M-G34 evals: the search covers the JUDGE MODEL as well as the rationale",
       "file": "src/governance-evals.ts",
-      "from": "                  { rationale: { contains: query.search, mode: \"insensitive\" as const } },\n                  { judgeModel: { contains: query.search, mode: \"insensitive\" as const } },",
-      "to": "                  { rationale: { contains: query.search, mode: \"insensitive\" as const } },",
+      "from": "                    { rationale: { contains: query.search, mode: \"insensitive\" as const } },\n                    { judgeModel: { contains: query.search, mode: \"insensitive\" as const } },",
+      "to": "                    { rationale: { contains: query.search, mode: \"insensitive\" as const } },",
       "note": "The port names both columns. Dropped, an operator can no longer find the evals a particular judge produced, which is the query an incident about a bad judge starts with.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -538,8 +538,8 @@
     {
       "name": "M-G35 evals: the baseline sample is ONE version's scores",
       "file": "src/governance-evals.ts",
-      "from": "            agentVersionId: query.agentVersionId,\n            createdAt: { gte: query.since },\n          },\n          select: REGRESSION_COLUMNS,",
-      "to": "            createdAt: { gte: query.since },\n          },\n          select: REGRESSION_COLUMNS,",
+      "from": "              agentVersionId: query.agentVersionId,\n              createdAt: { gte: query.since },\n            },\n            select: REGRESSION_COLUMNS,",
+      "to": "              createdAt: { gte: query.since },\n            },\n            select: REGRESSION_COLUMNS,",
       "note": "The baseline is the version a candidate is compared against. Widened to every version, the comparison is the agent against itself and a regression is averaged away.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -578,8 +578,8 @@
     {
       "name": "M-G38 goldenSets: the duplicate insert does not RAISE either",
       "file": "src/governance-golden-sets.ts",
-      "from": "          skipDuplicates: true,\n          select: GOLDEN_SET_COLUMNS,",
-      "to": "          select: GOLDEN_SET_COLUMNS,",
+      "from": "            skipDuplicates: true,\n            select: GOLDEN_SET_COLUMNS,",
+      "to": "            select: GOLDEN_SET_COLUMNS,",
       "note": "Same argument as M-G24 on the other table: a raised unique index takes the caller's transaction with the answer.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -591,8 +591,8 @@
     {
       "name": "M-G39 goldenSets: a name clash is the port's OWN code",
       "file": "src/governance-golden-sets.ts",
-      "from": "          return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));\n        }\n        return ok(readGoldenSet(row as GoldenSetRow));",
-      "to": "          return err(ledgerUnavailable(\"golden set create wrote no row\"));\n        }\n        return ok(readGoldenSet(row as GoldenSetRow));",
+      "from": "            return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));\n          }\n          return ok(readGoldenSet(row as GoldenSetRow));",
+      "to": "            return err(ledgerUnavailable(\"golden set create wrote no row\"));\n          }\n          return ok(readGoldenSet(row as GoldenSetRow));",
       "note": "The port says an implementation MUST map the violation to `GOVERNANCE_GOLDEN_SET_ALREADY_EXISTS` rather than letting a store exception escape or reporting an outage.",
       "suites": [
         "src/governance-conformance.integration.test.ts"
@@ -604,7 +604,7 @@
     {
       "name": "M-G40 goldenSets: the RENAME checks the name the double does not",
       "file": "src/governance-golden-sets.ts",
-      "from": "        if (clash !== null) {\n          return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));\n        }",
+      "from": "          if (clash !== null) {\n            return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));\n          }",
       "to": "",
       "note": "`InMemoryGoldenSetsRepository.update` performs no uniqueness check at all, so this guard has no counterpart in the double. Without it the rename raises `@@unique([environmentId, agentId, name])` and aborts the caller's transaction.",
       "suites": [
@@ -617,8 +617,8 @@
     {
       "name": "M-G41 goldenSets: a delete is narrowed to this environment",
       "file": "src/governance-golden-sets.ts",
-      "from": "        const outcome = await client.goldenSet.deleteMany({\n          where: { id: goldenSetId, ...scopedWhere(scope) },\n        });",
-      "to": "        const outcome = await client.goldenSet.deleteMany({\n          where: { id: goldenSetId },\n        });",
+      "from": "          const outcome = await client.goldenSet.deleteMany({\n            where: { id: goldenSetId, ...scopedWhere(scope) },\n          });",
+      "to": "          const outcome = await client.goldenSet.deleteMany({\n            where: { id: goldenSetId },\n          });",
       "note": "A golden set is addressed by a uuid a caller supplies. Unnarrowed, a caller holding another tenant's identifier destroys their regression sample and is told it worked.",
       "suites": [
         "src/governance-rules.integration.test.ts"
@@ -644,14 +644,14 @@
     {
       "name": "M-G43 criteria: `findMany` resolves the whole label set in ONE statement",
       "file": "src/governance-criteria.ts",
-      "from": "        const rows = await transactions.reader().evalCriterion.findMany({\n          where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },",
-      "to": "        for (const one of criterionIds) {\n          await transactions.reader().evalCriterion.findFirst({ where: { id: one } });\n        }\n        const rows = await transactions.reader().evalCriterion.findMany({\n          where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },",
-      "note": "THE EXACT SHAPE THE PORT EXISTS TO PREVENT, added back: a rollup resolving its criterion labels one at a time. The returned value does not change at all \u2014 only the statement count sees it, which is why the count is the contract.",
+      "from": "          const rows = await transactions.reader().evalCriterion.findMany({\n            where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },",
+      "to": "          for (const one of criterionIds) {\n            await transactions.reader().evalCriterion.findFirst({ where: { id: one } });\n          }\n          const rows = await transactions.reader().evalCriterion.findMany({\n            where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },",
+      "note": "THE EXACT SHAPE THE PORT EXISTS TO PREVENT, added back: a rollup resolving its criterion labels one at a time. The returned value does not change at all — only the statement count sees it, which is why the count is the contract.",
       "suites": [
         "src/governance-statements.integration.test.ts"
       ],
       "kills": [
-        "reads are a fixed number of statements, whatever the row count `CriteriaRepository.findMany` is one for the whole label set"
+        "reads are a fixed number of statements, whatever the row count `CriteriaRepository.findMany` is one read for the whole label set"
       ]
     },
     {
@@ -664,7 +664,7 @@
         "src/governance-statements.integration.test.ts"
       ],
       "kills": [
-        "reads are a fixed number of statements, whatever the row count `SafetyLedger.countByAgent` is one GROUP BY, not one read per agent"
+        "reads are a fixed number of statements, whatever the row count `SafetyLedger.countByAgent` is ONE GROUP BY beside the resolve, not one read per agent"
       ]
     },
     {
@@ -677,7 +677,7 @@
         "src/governance-statements.integration.test.ts"
       ],
       "kills": [
-        "the writes are a fixed number too `upsert` is TWO on both paths, so the count is a pin and not a path"
+        "the writes are a fixed number too `upsert` is THREE on both paths, so the count is a pin and not a path"
       ]
     },
     {
@@ -685,13 +685,143 @@
       "file": "src/governance-guards.ts",
       "from": "  if (value !== 1 && value !== -1) {",
       "to": "  if (value !== 1 && value !== -1 && value !== 3) {",
-      "note": "The inverse of M-G20: a guard WIDENED past the constraint the migration ends with lets a five-star value reach the column, where the CHECK raises and takes the caller's transaction. The refusal has to be exactly `IN (-1, 1)` \u2014 neither narrower nor wider.",
+      "note": "The inverse of M-G20: a guard WIDENED past the constraint the migration ends with lets a five-star value reach the column, where the CHECK raises and takes the caller's transaction. The refusal has to be exactly `IN (-1, 1)` — neither narrower nor wider.",
       "suites": [
         "src/governance-constraints.integration.test.ts"
       ],
       "kills": [
         "MessageRating_rating_check is the constraint the migration ENDS with the double stores a five-star `3`, and no database this migration builds can",
         "a refusal leaves the caller's transaction usable, which a raised CHECK would not"
+      ]
+    },
+    {
+      "name": "M-G47 safety: the store resolves its WHOLE scope, not only the environment",
+      "file": "src/governance-safety.ts",
+      "from": "        scope,\n        safetyScopeUnresolved,\n        \"safety page\",",
+      "to": "        { level: \"organization\", organizationId: scope.organizationId } as unknown as EnvironmentScope,\n        safetyScopeUnresolved,\n        \"safety page\",",
+      "note": "WIN-303. The mutation hands the resolver an ORGANIZATION scope built from the same grant, which asserts no relation and is therefore always admitted. Nothing else changes: the store's own `where` still narrows by `scope.environmentId`, so a caller presenting a legitimate environment beside somebody else's project is served in full again -- which is exactly the state this tranche found. No other suite in this package notices, because every other fixture builds a COHERENT scope, where the environment clause alone is enough.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a tampered triple is REFUSED by every one of the five stores `SafetyLedger` reads its own environment and refuses the forged ancestry"
+      ]
+    },
+    {
+      "name": "M-G48 ratings: the store resolves its WHOLE scope, not only the environment",
+      "file": "src/governance-ratings.ts",
+      "from": "        scope,\n        ratingsScopeUnresolved,\n        \"ratings upsert\",",
+      "to": "        { level: \"organization\", organizationId: scope.organizationId } as unknown as EnvironmentScope,\n        ratingsScopeUnresolved,\n        \"ratings upsert\",",
+      "note": "WIN-303. The mutation hands the resolver an ORGANIZATION scope built from the same grant, which asserts no relation and is therefore always admitted. Nothing else changes: the store's own `where` still narrows by `scope.environmentId`, so a caller presenting a legitimate environment beside somebody else's project is served in full again -- which is exactly the state this tranche found. No other suite in this package notices, because every other fixture builds a COHERENT scope, where the environment clause alone is enough.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a tampered triple is REFUSED by every one of the five stores `RatingsRepository` refuses, and the forged upsert moves NO row"
+      ]
+    },
+    {
+      "name": "M-G49 criteria: the store resolves its WHOLE scope, not only the environment",
+      "file": "src/governance-criteria.ts",
+      "from": "        scope,\n        criteriaScopeUnresolved,\n        \"criteria findById\",",
+      "to": "        { level: \"organization\", organizationId: scope.organizationId } as unknown as EnvironmentScope,\n        criteriaScopeUnresolved,\n        \"criteria findById\",",
+      "note": "WIN-303. The mutation hands the resolver an ORGANIZATION scope built from the same grant, which asserts no relation and is therefore always admitted. Nothing else changes: the store's own `where` still narrows by `scope.environmentId`, so a caller presenting a legitimate environment beside somebody else's project is served in full again -- which is exactly the state this tranche found. No other suite in this package notices, because every other fixture builds a COHERENT scope, where the environment clause alone is enough.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a tampered triple is REFUSED by every one of the five stores `CriteriaRepository` refuses, and the forged remove DELETES nothing"
+      ]
+    },
+    {
+      "name": "M-G50 evals: the store resolves its WHOLE scope, not only the environment",
+      "file": "src/governance-evals.ts",
+      "from": "        scope,\n        evalsScopeUnresolved,\n        \"evals sample\",",
+      "to": "        { level: \"organization\", organizationId: scope.organizationId } as unknown as EnvironmentScope,\n        evalsScopeUnresolved,\n        \"evals sample\",",
+      "note": "WIN-303. The mutation hands the resolver an ORGANIZATION scope built from the same grant, which asserts no relation and is therefore always admitted. Nothing else changes: the store's own `where` still narrows by `scope.environmentId`, so a caller presenting a legitimate environment beside somebody else's project is served in full again -- which is exactly the state this tranche found. No other suite in this package notices, because every other fixture builds a COHERENT scope, where the environment clause alone is enough.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a tampered triple is REFUSED by every one of the five stores `EvalsRepository` refuses, and the forged append WRITES nothing"
+      ]
+    },
+    {
+      "name": "M-G51 goldenSets: the store resolves its WHOLE scope, not only the environment",
+      "file": "src/governance-golden-sets.ts",
+      "from": "        scope,\n        goldenSetsScopeUnresolved,\n        \"goldenSets update\",",
+      "to": "        { level: \"organization\", organizationId: scope.organizationId } as unknown as EnvironmentScope,\n        goldenSetsScopeUnresolved,\n        \"goldenSets update\",",
+      "note": "WIN-303. The mutation hands the resolver an ORGANIZATION scope built from the same grant, which asserts no relation and is therefore always admitted. Nothing else changes: the store's own `where` still narrows by `scope.environmentId`, so a caller presenting a legitimate environment beside somebody else's project is served in full again -- which is exactly the state this tranche found. No other suite in this package notices, because every other fixture builds a COHERENT scope, where the environment clause alone is enough.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a tampered triple is REFUSED by every one of the five stores `GoldenSetsRepository` refuses, and the forged update MOVES nothing"
+      ]
+    },
+    {
+      "name": "M-G52 scope: the ORGANIZATION half of the ancestry comparison",
+      "file": "src/governance-scope.ts",
+      "from": "  if (resolved.projectId !== narrowed.projectId || resolved.organizationId !== narrowed.organizationId) {",
+      "to": "  if (resolved.projectId !== narrowed.projectId) {",
+      "note": "The half that is invisible everywhere else. Every fixture in this package seeds ONE chain, in which the right project is always under the right organization -- so a resolver that checked the project alone passes the whole suite, including the tampered-triple case, whose project half also disagrees. Only the scope with the organization forged ON ITS OWN separates them.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "each half of the ancestry comparison is refused on its own only the ORGANIZATION forged is still `foreign_ancestry`"
+      ]
+    },
+    {
+      "name": "M-G53 scope: the PROJECT half of the ancestry comparison",
+      "file": "src/governance-scope.ts",
+      "from": "  if (resolved.projectId !== narrowed.projectId || resolved.organizationId !== narrowed.organizationId) {",
+      "to": "  if (resolved.organizationId !== narrowed.organizationId) {",
+      "note": "The mirror of M-G52, and the reason both cases exist: a comparison with two terms needs two mutations, or one term can be dropped while the other keeps every assertion green.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "each half of the ancestry comparison is refused on its own only the PROJECT forged is `foreign_ancestry` too"
+      ]
+    },
+    {
+      "name": "M-G54 scope: an environment in NO row is refused, never admitted",
+      "file": "src/governance-scope.ts",
+      "from": "  if (resolved === undefined) {\n    return err(refusal(reasonFor(GOVERNANCE_SCOPE_UNKNOWN_ENVIRONMENT, operation, scope)));\n  }",
+      "to": "  if (resolved === undefined) {\n    return ok(true);\n  }",
+      "note": "An environment deleted since the grant was minted resolves to no row. Admitting it reads defensibly -- the reads that follow would find nothing anyway -- and it is the wrong answer: absence is what this context already says for another tenant's row, so a grant naming a dead environment would be reported for ever as a criterion that does not exist.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "each half of the ancestry comparison is refused on its own an environment in no row at all is `unknown_environment`, not absence"
+      ]
+    },
+    {
+      "name": "M-G55 scope: the uuid SHAPE check, which is what keeps the statement unsent",
+      "file": "src/governance-seam-guards.ts",
+      "from": "const UUID_SHAPE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;",
+      "to": "const UUID_SHAPE = /^.*$/u;",
+      "note": "Widened rather than deleted, because deleting it does not compile. With every string admitted, a malformed scope reaches a `@db.Uuid` column and the driver refuses the whole statement -- which on PostgreSQL ABORTS the enclosing transaction, so a caller mid-unit-of-work loses every later write. The case measures the statement COUNT, not only the code, so the mutation is caught by the fact that anything was sent at all.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "each half of the ancestry comparison is refused on its own a scope that is not uuid-shaped is refused with ZERO statements sent"
+      ]
+    },
+    {
+      "name": "M-G56 scope: a PROJECT-level tenant scope is held to its organization",
+      "file": "src/governance-scope.ts",
+      "from": "    if (resolved.organizationId !== scope.organizationId) {\n      return err(refusal(reasonFor(GOVERNANCE_SCOPE_FOREIGN_ANCESTRY, operation, scope)));\n    }",
+      "to": "",
+      "note": "`tenantWhere` narrows a project-level scope by the PROJECT alone, so this is the same hole one level up: the four subject methods take a tenant scope, and my project under their organization would otherwise count and erase my rows on their behalf. The organization-level branch above deliberately checks nothing, because a scope naming one identifier asserts no relation to contradict.",
+      "suites": [
+        "src/governance-isolation.integration.test.ts"
+      ],
+      "kills": [
+        "a TENANT scope is held to the ancestry it asserts, and to no more a PROJECT scope under a forged organization is refused, not counted"
       ]
     }
   ]

--- a/packages/adapters/postgres-tenancy/mutations-governance.json
+++ b/packages/adapters/postgres-tenancy/mutations-governance.json
@@ -329,7 +329,7 @@
       "file": "src/governance-ratings.ts",
       "from": "            where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },\n            data: {",
       "to": "            where: { turnId: write.turnId, endUserId: write.endUserId },\n            data: {",
-      "note": "`@@unique([turnId, endUserId])` names no environment, so an update keyed on the pair alone reaches another tenant's row whenever the two ids collide.",
+      "note": "`@@unique([turnId, endUserId])` names no environment, so an update keyed on the pair alone reaches another tenant's row whenever the two ids collide. WIN-303: this entry was VACUOUS until the case asserted WHICH refusal. The mutated statement does reach the other tenant's row and rewrite it, but the scoped read-back that follows then finds nothing and returns an error -- and `runResult` rolls the whole unit of work back, restoring the row. `flip.ok` was false and the observer saw the original either way. Confirmed still green on the BASE commit in a second worktree, so it is a pre-existing hole rather than one this tranche opened.",
       "suites": [
         "src/governance-rules.integration.test.ts"
       ],

--- a/packages/adapters/postgres-tenancy/src/governance-criteria.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-criteria.ts
@@ -43,11 +43,12 @@ import {
   criterionAlreadyExists,
   err,
   ledgerUnavailable,
+  criteriaScopeUnresolved,
   ok,
 } from "@platos/context-governance/application/ports/index.js";
 
 import { requireStorableScale, requireUuid } from "./governance-guards.js";
-import { refuse } from "./governance-refusal.js";
+import { inGovernanceScope } from "./governance-scope.js";
 import { readCriterion, scopedWhere, type EvalCriterionRow } from "./governance-rows.js";
 import type { TenancyTransactions } from "./transaction.js";
 
@@ -95,15 +96,82 @@ export function createCriteriaRepository(
       createdBy: ActorId,
       transaction: TransactionScope,
     ): Promise<Result<EvalCriterion>> {
-      return refuse(async () => {
-        requireUuid("EvalCriterion.agentId", criterion.agentId);
-        requireStorableScale(criterion.scoreScaleMin, criterion.scoreScaleMax);
-        const client = transactions.writer(transaction);
-        const at = now();
-        const created = await client.evalCriterion.createManyAndReturn({
-          data: [
-            {
-              environmentId: scope.environmentId,
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria create",
+        async () => {
+          requireUuid("EvalCriterion.agentId", criterion.agentId);
+          requireStorableScale(criterion.scoreScaleMin, criterion.scoreScaleMax);
+          const client = transactions.writer(transaction);
+          const at = now();
+          const created = await client.evalCriterion.createManyAndReturn({
+            data: [
+              {
+                environmentId: scope.environmentId,
+                agentId: criterion.agentId,
+                name: criterion.name,
+                description: criterion.description,
+                judgePrompt: criterion.judgePrompt,
+                rubric: criterion.rubric,
+                judgeModel: criterion.judgeModel,
+                scoreScaleMin: criterion.scoreScaleMin,
+                scoreScaleMax: criterion.scoreScaleMax,
+                isActive: true,
+                createdBy,
+                createdAt: at,
+                updatedAt: at,
+              },
+            ],
+            skipDuplicates: true,
+            select: CRITERION_COLUMNS,
+          });
+          const row = created[0];
+          if (row === undefined) {
+            return err(criterionAlreadyExists(scope.environmentId, criterion.name));
+          }
+          return ok(readCriterion(row as EvalCriterionRow));
+        },
+      );
+    },
+
+    async update(
+      scope: EnvironmentScope,
+      criterion: EvalCriterion,
+      transaction: TransactionScope,
+    ): Promise<Result<EvalCriterion>> {
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria update",
+        async () => {
+          requireUuid("EvalCriterion.id", criterion.evalCriterionId);
+          requireUuid("EvalCriterion.agentId", criterion.agentId);
+          requireStorableScale(criterion.scoreScaleMin, criterion.scoreScaleMax);
+          const client = transactions.writer(transaction);
+          const held = await client.evalCriterion.findFirst({
+            where: { id: criterion.evalCriterionId, ...scopedWhere(scope) },
+            select: { id: true },
+          });
+          if (held === null) return err(ledgerUnavailable("criterion_not_in_scope"));
+          const clash = await client.evalCriterion.findFirst({
+            where: {
+              ...scopedWhere(scope),
+              name: criterion.name,
+              id: { not: criterion.evalCriterionId },
+            },
+            select: { id: true },
+          });
+          if (clash !== null) return err(criterionAlreadyExists(scope.environmentId, criterion.name));
+          // Keyed on BOTH id AND environmentId even though the row was just read
+          // in scope: the read and the write are two statements, and a key that
+          // was narrow only in the first would let a concurrently-moved row be
+          // written by the second.
+          const outcome = await client.evalCriterion.updateMany({
+            where: { id: criterion.evalCriterionId, ...scopedWhere(scope) },
+            data: {
               agentId: criterion.agentId,
               name: criterion.name,
               description: criterion.description,
@@ -112,69 +180,14 @@ export function createCriteriaRepository(
               judgeModel: criterion.judgeModel,
               scoreScaleMin: criterion.scoreScaleMin,
               scoreScaleMax: criterion.scoreScaleMax,
-              isActive: true,
-              createdBy,
-              createdAt: at,
-              updatedAt: at,
+              isActive: criterion.isActive,
+              updatedAt: criterion.updatedAt,
             },
-          ],
-          skipDuplicates: true,
-          select: CRITERION_COLUMNS,
-        });
-        const row = created[0];
-        if (row === undefined) {
-          return err(criterionAlreadyExists(scope.environmentId, criterion.name));
-        }
-        return ok(readCriterion(row as EvalCriterionRow));
-      }, "criteria create");
-    },
-
-    async update(
-      scope: EnvironmentScope,
-      criterion: EvalCriterion,
-      transaction: TransactionScope,
-    ): Promise<Result<EvalCriterion>> {
-      return refuse(async () => {
-        requireUuid("EvalCriterion.id", criterion.evalCriterionId);
-        requireUuid("EvalCriterion.agentId", criterion.agentId);
-        requireStorableScale(criterion.scoreScaleMin, criterion.scoreScaleMax);
-        const client = transactions.writer(transaction);
-        const held = await client.evalCriterion.findFirst({
-          where: { id: criterion.evalCriterionId, ...scopedWhere(scope) },
-          select: { id: true },
-        });
-        if (held === null) return err(ledgerUnavailable("criterion_not_in_scope"));
-        const clash = await client.evalCriterion.findFirst({
-          where: {
-            ...scopedWhere(scope),
-            name: criterion.name,
-            id: { not: criterion.evalCriterionId },
-          },
-          select: { id: true },
-        });
-        if (clash !== null) return err(criterionAlreadyExists(scope.environmentId, criterion.name));
-        // Keyed on BOTH id AND environmentId even though the row was just read
-        // in scope: the read and the write are two statements, and a key that
-        // was narrow only in the first would let a concurrently-moved row be
-        // written by the second.
-        const outcome = await client.evalCriterion.updateMany({
-          where: { id: criterion.evalCriterionId, ...scopedWhere(scope) },
-          data: {
-            agentId: criterion.agentId,
-            name: criterion.name,
-            description: criterion.description,
-            judgePrompt: criterion.judgePrompt,
-            rubric: criterion.rubric,
-            judgeModel: criterion.judgeModel,
-            scoreScaleMin: criterion.scoreScaleMin,
-            scoreScaleMax: criterion.scoreScaleMax,
-            isActive: criterion.isActive,
-            updatedAt: criterion.updatedAt,
-          },
-        });
-        if (outcome.count === 0) return err(ledgerUnavailable("criterion_not_in_scope"));
-        return ok(criterion);
-      }, "criteria update");
+          });
+          if (outcome.count === 0) return err(ledgerUnavailable("criterion_not_in_scope"));
+          return ok(criterion);
+        },
+      );
     },
 
     async remove(
@@ -182,80 +195,110 @@ export function createCriteriaRepository(
       criterionId: EvalCriterionId,
       transaction: TransactionScope,
     ): Promise<Result<boolean>> {
-      return refuse(async () => {
-        const client = transactions.writer(transaction);
-        const outcome = await client.evalCriterion.deleteMany({
-          where: { id: criterionId, ...scopedWhere(scope) },
-        });
-        return ok(outcome.count > 0);
-      }, "criteria remove");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria remove",
+        async () => {
+          const client = transactions.writer(transaction);
+          const outcome = await client.evalCriterion.deleteMany({
+            where: { id: criterionId, ...scopedWhere(scope) },
+          });
+          return ok(outcome.count > 0);
+        },
+      );
     },
 
     async findById(
       scope: EnvironmentScope,
       criterionId: EvalCriterionId,
     ): Promise<Result<EvalCriterion | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().evalCriterion.findFirst({
-          where: { id: criterionId, ...scopedWhere(scope) },
-          select: CRITERION_COLUMNS,
-        });
-        return ok(row === null ? null : readCriterion(row as EvalCriterionRow));
-      }, "criteria findById");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria findById",
+        async () => {
+          const row = await transactions.reader().evalCriterion.findFirst({
+            where: { id: criterionId, ...scopedWhere(scope) },
+            select: CRITERION_COLUMNS,
+          });
+          return ok(row === null ? null : readCriterion(row as EvalCriterionRow));
+        },
+      );
     },
 
     async findByName(scope: EnvironmentScope, name: string): Promise<Result<EvalCriterion | null>> {
-      return refuse(async () => {
-        // EXACT, not case-folded, because the port says so and because the
-        // unique index it pre-checks is itself exact: a case-insensitive
-        // pre-check would answer "taken" for a name `create` would then accept.
-        const row = await transactions.reader().evalCriterion.findFirst({
-          where: { name, ...scopedWhere(scope) },
-          select: CRITERION_COLUMNS,
-        });
-        return ok(row === null ? null : readCriterion(row as EvalCriterionRow));
-      }, "criteria findByName");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria findByName",
+        async () => {
+          // EXACT, not case-folded, because the port says so and because the
+          // unique index it pre-checks is itself exact: a case-insensitive
+          // pre-check would answer "taken" for a name `create` would then accept.
+          const row = await transactions.reader().evalCriterion.findFirst({
+            where: { name, ...scopedWhere(scope) },
+            select: CRITERION_COLUMNS,
+          });
+          return ok(row === null ? null : readCriterion(row as EvalCriterionRow));
+        },
+      );
     },
 
     async page(scope: EnvironmentScope, query: CriterionQuery): Promise<Result<CriterionPage>> {
-      return refuse(async () => {
-        const where = {
-          ...scopedWhere(scope),
-          ...(query.activeOnly ? { isActive: true } : {}),
-          ...agentFilter(query),
-          ...(query.search === null
-            ? {}
-            : { name: { contains: query.search, mode: "insensitive" as const } }),
-        };
-        const reader = transactions.reader();
-        const rows = await reader.evalCriterion.findMany({
-          where,
-          select: CRITERION_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-          skip: query.offset,
-          take: query.limit,
-        });
-        const total = await reader.evalCriterion.count({ where });
-        return ok({ items: rows.map((row) => readCriterion(row as EvalCriterionRow)), total });
-      }, "criteria page");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria page",
+        async () => {
+          const where = {
+            ...scopedWhere(scope),
+            ...(query.activeOnly ? { isActive: true } : {}),
+            ...agentFilter(query),
+            ...(query.search === null
+              ? {}
+              : { name: { contains: query.search, mode: "insensitive" as const } }),
+          };
+          const reader = transactions.reader();
+          const rows = await reader.evalCriterion.findMany({
+            where,
+            select: CRITERION_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            skip: query.offset,
+            take: query.limit,
+          });
+          const total = await reader.evalCriterion.count({ where });
+          return ok({ items: rows.map((row) => readCriterion(row as EvalCriterionRow)), total });
+        },
+      );
     },
 
     async findMany(
       scope: EnvironmentScope,
       criterionIds: readonly EvalCriterionId[],
     ): Promise<Result<readonly EvalCriterion[]>> {
-      return refuse(async () => {
-        // ONE statement for the whole list, and the empty list is answered
-        // WITHOUT one. A rollup resolves its labels here, so a loop of
-        // `findById` would be the N+1 this port exists to prevent.
-        if (criterionIds.length === 0) return ok([]);
-        const rows = await transactions.reader().evalCriterion.findMany({
-          where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },
-          select: CRITERION_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(rows.map((row) => readCriterion(row as EvalCriterionRow)));
-      }, "criteria findMany");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        criteriaScopeUnresolved,
+        "criteria findMany",
+        async () => {
+          // ONE statement for the whole list, and the empty list is answered
+          // WITHOUT one. A rollup resolves its labels here, so a loop of
+          // `findById` would be the N+1 this port exists to prevent.
+          if (criterionIds.length === 0) return ok([]);
+          const rows = await transactions.reader().evalCriterion.findMany({
+            where: { id: { in: [...criterionIds] }, ...scopedWhere(scope) },
+            select: CRITERION_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(rows.map((row) => readCriterion(row as EvalCriterionRow)));
+        },
+      );
     },
   };
 }

--- a/packages/adapters/postgres-tenancy/src/governance-evals.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-evals.ts
@@ -51,13 +51,14 @@ import {
   asGovernanceIdentifier,
   err,
   ledgerUnavailable,
+  evalsScopeUnresolved,
   ok,
   type AgentVersionId,
   type EvalCriterionId,
 } from "@platos/context-governance/application/ports/index.js";
 
 import { guardEvalAppend } from "./governance-guards.js";
-import { refuse } from "./governance-refusal.js";
+import { inGovernanceScope } from "./governance-scope.js";
 import {
   readEval,
   scopedWhere,
@@ -114,158 +115,194 @@ export function createEvalsRepository(
       admitted: AdmittedEval,
       transaction: TransactionScope | null,
     ): Promise<Result<AgentEval>> {
-      return refuse(async () => {
-        guardEvalAppend(admitted);
-        // A null scope resolves through `reader()`, so an append issued inside
-        // an open transaction joins it rather than escaping to the pool — the
-        // same argument `governance-safety.ts` makes for the same nullable
-        // parameter.
-        const client = transaction === null ? transactions.reader() : transactions.writer(transaction);
-        const written = await client.agentEval.createManyAndReturn({
-          data: [
-            {
-              environmentId: scope.environmentId,
-              agentId: admitted.agentId,
-              agentVersionId: admitted.agentVersionId,
-              threadId: admitted.threadId,
-              turnId: admitted.turnId,
-              criterionId: admitted.criterionId,
-              criterionSnapshot: writeCriterionSnapshot(admitted.criterionSnapshot),
-              judgeModel: admitted.judgeModel,
-              judgePromptUsed: admitted.judgePromptUsed,
-              rawResponse: admitted.rawResponse,
-              score: admitted.score,
-              rationale: admitted.rationale,
-              passed: admitted.passed,
-              costCents: admitted.costCents,
-              latencyMs: admitted.latencyMs,
-              createdAt: now(),
-            },
-          ],
-          select: EVAL_COLUMNS,
-        });
-        const row = written[0];
-        if (row === undefined) return err(ledgerUnavailable("eval append wrote no row"));
-        // The ONLY place `rawResponseTruncated` is answered truthfully: the
-        // writer knows what it truncated, and the row it just wrote does not.
-        return ok({ ...readEval(row as AgentEvalRow), rawResponseTruncated: admitted.rawResponseTruncated });
-      }, "evals append");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals append",
+        async () => {
+          guardEvalAppend(admitted);
+          // A null scope resolves through `reader()`, so an append issued inside
+          // an open transaction joins it rather than escaping to the pool — the
+          // same argument `governance-safety.ts` makes for the same nullable
+          // parameter.
+          const client = transaction === null ? transactions.reader() : transactions.writer(transaction);
+          const written = await client.agentEval.createManyAndReturn({
+            data: [
+              {
+                environmentId: scope.environmentId,
+                agentId: admitted.agentId,
+                agentVersionId: admitted.agentVersionId,
+                threadId: admitted.threadId,
+                turnId: admitted.turnId,
+                criterionId: admitted.criterionId,
+                criterionSnapshot: writeCriterionSnapshot(admitted.criterionSnapshot),
+                judgeModel: admitted.judgeModel,
+                judgePromptUsed: admitted.judgePromptUsed,
+                rawResponse: admitted.rawResponse,
+                score: admitted.score,
+                rationale: admitted.rationale,
+                passed: admitted.passed,
+                costCents: admitted.costCents,
+                latencyMs: admitted.latencyMs,
+                createdAt: now(),
+              },
+            ],
+            select: EVAL_COLUMNS,
+          });
+          const row = written[0];
+          if (row === undefined) return err(ledgerUnavailable("eval append wrote no row"));
+          // The ONLY place `rawResponseTruncated` is answered truthfully: the
+          // writer knows what it truncated, and the row it just wrote does not.
+          return ok({ ...readEval(row as AgentEvalRow), rawResponseTruncated: admitted.rawResponseTruncated });
+        },
+      );
     },
 
     async findById(scope: EnvironmentScope, evalId: AgentEvalId): Promise<Result<AgentEval | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().agentEval.findFirst({
-          where: { id: evalId, ...scopedWhere(scope) },
-          select: EVAL_COLUMNS,
-        });
-        return ok(row === null ? null : readEval(row as AgentEvalRow));
-      }, "evals findById");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals findById",
+        async () => {
+          const row = await transactions.reader().agentEval.findFirst({
+            where: { id: evalId, ...scopedWhere(scope) },
+            select: EVAL_COLUMNS,
+          });
+          return ok(row === null ? null : readEval(row as AgentEvalRow));
+        },
+      );
     },
 
     async page(scope: EnvironmentScope, query: EvalQuery): Promise<Result<EvalPage>> {
-      return refuse(async () => {
-        const where = {
-          ...scopedWhere(scope),
-          createdAt: { gte: query.since },
-          ...(query.agentId === null ? {} : { agentId: query.agentId }),
-          ...(query.agentVersionId === null ? {} : { agentVersionId: query.agentVersionId }),
-          ...(query.criterionId === null ? {} : { criterionId: query.criterionId }),
-          ...(query.threadId === null ? {} : { threadId: query.threadId }),
-          // The port says the substring runs over the rationale AND the judge
-          // model, so it is one OR rather than two filters: a search that
-          // matched only the first would silently stop finding evals by the
-          // model that produced them.
-          ...(query.search === null
-            ? {}
-            : {
-                OR: [
-                  { rationale: { contains: query.search, mode: "insensitive" as const } },
-                  { judgeModel: { contains: query.search, mode: "insensitive" as const } },
-                ],
-              }),
-        };
-        const reader = transactions.reader();
-        const rows = await reader.agentEval.findMany({
-          where,
-          select: EVAL_COLUMNS,
-          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-          skip: query.offset,
-          take: query.limit,
-        });
-        const total = await reader.agentEval.count({ where });
-        return ok({ items: rows.map((row) => readEval(row as AgentEvalRow)), total });
-      }, "evals page");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals page",
+        async () => {
+          const where = {
+            ...scopedWhere(scope),
+            createdAt: { gte: query.since },
+            ...(query.agentId === null ? {} : { agentId: query.agentId }),
+            ...(query.agentVersionId === null ? {} : { agentVersionId: query.agentVersionId }),
+            ...(query.criterionId === null ? {} : { criterionId: query.criterionId }),
+            ...(query.threadId === null ? {} : { threadId: query.threadId }),
+            // The port says the substring runs over the rationale AND the judge
+            // model, so it is one OR rather than two filters: a search that
+            // matched only the first would silently stop finding evals by the
+            // model that produced them.
+            ...(query.search === null
+              ? {}
+              : {
+                  OR: [
+                    { rationale: { contains: query.search, mode: "insensitive" as const } },
+                    { judgeModel: { contains: query.search, mode: "insensitive" as const } },
+                  ],
+                }),
+          };
+          const reader = transactions.reader();
+          const rows = await reader.agentEval.findMany({
+            where,
+            select: EVAL_COLUMNS,
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            skip: query.offset,
+            take: query.limit,
+          });
+          const total = await reader.agentEval.count({ where });
+          return ok({ items: rows.map((row) => readEval(row as AgentEvalRow)), total });
+        },
+      );
     },
 
     async sample(
       scope: EnvironmentScope,
       query: EvalSampleQuery,
     ): Promise<Result<readonly EvalAggregateInput[]>> {
-      return refuse(async () => {
-        const rows = await transactions.reader().agentEval.findMany({
-          where: {
-            ...scopedWhere(scope),
-            agentId: query.agentId,
-            createdAt: { gte: query.since },
-            // EMPTY MEANS EVERY VERSION, which is the port's word and not a
-            // convenience: an empty `IN ()` would match nothing and a scorecard
-            // asked for "all versions" would read as an agent with no evals.
-            ...(query.versionIds.length === 0
-              ? {}
-              : { agentVersionId: { in: [...query.versionIds] } }),
-          },
-          select: AGGREGATE_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(
-          rows.map((row) => ({
-            criterionId: asGovernanceIdentifier<EvalCriterionId>(row.criterionId),
-            agentVersionId:
-              row.agentVersionId === null
-                ? null
-                : asGovernanceIdentifier<AgentVersionId>(row.agentVersionId),
-            score: row.score,
-            passed: row.passed,
-          })),
-        );
-      }, "evals sample");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals sample",
+        async () => {
+          const rows = await transactions.reader().agentEval.findMany({
+            where: {
+              ...scopedWhere(scope),
+              agentId: query.agentId,
+              createdAt: { gte: query.since },
+              // EMPTY MEANS EVERY VERSION, which is the port's word and not a
+              // convenience: an empty `IN ()` would match nothing and a scorecard
+              // asked for "all versions" would read as an agent with no evals.
+              ...(query.versionIds.length === 0
+                ? {}
+                : { agentVersionId: { in: [...query.versionIds] } }),
+            },
+            select: AGGREGATE_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(
+            rows.map((row) => ({
+              criterionId: asGovernanceIdentifier<EvalCriterionId>(row.criterionId),
+              agentVersionId:
+                row.agentVersionId === null
+                  ? null
+                  : asGovernanceIdentifier<AgentVersionId>(row.agentVersionId),
+              score: row.score,
+              passed: row.passed,
+            })),
+          );
+        },
+      );
     },
 
     async sampleByIds(
       scope: EnvironmentScope,
       evalIds: readonly AgentEvalId[],
     ): Promise<Result<readonly RegressionSample[]>> {
-      return refuse(async () => {
-        // The run grouping is NOT a column: a golden-set run identifies its own
-        // output by the SET of ids it wrote. One statement for the whole set, so
-        // a run of a thousand pairs is one read rather than a thousand.
-        if (evalIds.length === 0) return ok([]);
-        const rows = await transactions.reader().agentEval.findMany({
-          where: { id: { in: [...evalIds] }, ...scopedWhere(scope) },
-          select: REGRESSION_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(rows.map(toRegressionSample));
-      }, "evals sampleByIds");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals sampleByIds",
+        async () => {
+          // The run grouping is NOT a column: a golden-set run identifies its own
+          // output by the SET of ids it wrote. One statement for the whole set, so
+          // a run of a thousand pairs is one read rather than a thousand.
+          if (evalIds.length === 0) return ok([]);
+          const rows = await transactions.reader().agentEval.findMany({
+            where: { id: { in: [...evalIds] }, ...scopedWhere(scope) },
+            select: REGRESSION_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(rows.map(toRegressionSample));
+        },
+      );
     },
 
     async sampleBaseline(
       scope: EnvironmentScope,
       query: BaselineSampleQuery,
     ): Promise<Result<readonly RegressionSample[]>> {
-      return refuse(async () => {
-        const rows = await transactions.reader().agentEval.findMany({
-          where: {
-            ...scopedWhere(scope),
-            agentId: query.agentId,
-            agentVersionId: query.agentVersionId,
-            createdAt: { gte: query.since },
-          },
-          select: REGRESSION_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(rows.map(toRegressionSample));
-      }, "evals sampleBaseline");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        evalsScopeUnresolved,
+        "evals sampleBaseline",
+        async () => {
+          const rows = await transactions.reader().agentEval.findMany({
+            where: {
+              ...scopedWhere(scope),
+              agentId: query.agentId,
+              agentVersionId: query.agentVersionId,
+              createdAt: { gte: query.since },
+            },
+            select: REGRESSION_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(rows.map(toRegressionSample));
+        },
+      );
     },
   };
 }

--- a/packages/adapters/postgres-tenancy/src/governance-golden-sets.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-golden-sets.ts
@@ -41,11 +41,12 @@ import {
   err,
   goldenSetAlreadyExists,
   ledgerUnavailable,
+  goldenSetsScopeUnresolved,
   ok,
 } from "@platos/context-governance/application/ports/index.js";
 
 import { requireUuid } from "./governance-guards.js";
-import { refuse } from "./governance-refusal.js";
+import { inGovernanceScope } from "./governance-scope.js";
 import {
   readGoldenSet,
   scopedWhere,
@@ -78,21 +79,27 @@ export function createGoldenSetsRepository(
       createdBy: ActorId,
       transaction: TransactionScope,
     ): Promise<Result<GoldenSet>> {
-      return refuse(async () => {
-        requireUuid("GoldenSet.agentId", set.agentId);
-        const client = transactions.writer(transaction);
-        const at = now();
-        const created = await client.goldenSet.createManyAndReturn({
-          data: [{ ...writeGoldenSet(scope, set, createdBy), createdAt: at, updatedAt: at }],
-          skipDuplicates: true,
-          select: GOLDEN_SET_COLUMNS,
-        });
-        const row = created[0];
-        if (row === undefined) {
-          return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));
-        }
-        return ok(readGoldenSet(row as GoldenSetRow));
-      }, "goldenSets create");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets create",
+        async () => {
+          requireUuid("GoldenSet.agentId", set.agentId);
+          const client = transactions.writer(transaction);
+          const at = now();
+          const created = await client.goldenSet.createManyAndReturn({
+            data: [{ ...writeGoldenSet(scope, set, createdBy), createdAt: at, updatedAt: at }],
+            skipDuplicates: true,
+            select: GOLDEN_SET_COLUMNS,
+          });
+          const row = created[0];
+          if (row === undefined) {
+            return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));
+          }
+          return ok(readGoldenSet(row as GoldenSetRow));
+        },
+      );
     },
 
     async update(
@@ -100,41 +107,47 @@ export function createGoldenSetsRepository(
       set: GoldenSet,
       transaction: TransactionScope,
     ): Promise<Result<GoldenSet>> {
-      return refuse(async () => {
-        requireUuid("GoldenSet.id", set.goldenSetId);
-        requireUuid("GoldenSet.agentId", set.agentId);
-        const client = transactions.writer(transaction);
-        const held = await client.goldenSet.findFirst({
-          where: { id: set.goldenSetId, ...scopedWhere(scope) },
-          select: { id: true },
-        });
-        if (held === null) return err(ledgerUnavailable("golden_set_not_in_scope"));
-        const clash = await client.goldenSet.findFirst({
-          where: {
-            ...scopedWhere(scope),
-            agentId: set.agentId,
-            name: set.name,
-            id: { not: set.goldenSetId },
-          },
-          select: { id: true },
-        });
-        if (clash !== null) {
-          return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));
-        }
-        const outcome = await client.goldenSet.updateMany({
-          where: { id: set.goldenSetId, ...scopedWhere(scope) },
-          data: {
-            agentId: set.agentId,
-            name: set.name,
-            description: set.description,
-            threadIds: [...set.threadIds],
-            criterionIds: [...set.criterionIds],
-            updatedAt: set.updatedAt,
-          },
-        });
-        if (outcome.count === 0) return err(ledgerUnavailable("golden_set_not_in_scope"));
-        return ok(set);
-      }, "goldenSets update");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets update",
+        async () => {
+          requireUuid("GoldenSet.id", set.goldenSetId);
+          requireUuid("GoldenSet.agentId", set.agentId);
+          const client = transactions.writer(transaction);
+          const held = await client.goldenSet.findFirst({
+            where: { id: set.goldenSetId, ...scopedWhere(scope) },
+            select: { id: true },
+          });
+          if (held === null) return err(ledgerUnavailable("golden_set_not_in_scope"));
+          const clash = await client.goldenSet.findFirst({
+            where: {
+              ...scopedWhere(scope),
+              agentId: set.agentId,
+              name: set.name,
+              id: { not: set.goldenSetId },
+            },
+            select: { id: true },
+          });
+          if (clash !== null) {
+            return err(goldenSetAlreadyExists(scope.environmentId, set.agentId, set.name));
+          }
+          const outcome = await client.goldenSet.updateMany({
+            where: { id: set.goldenSetId, ...scopedWhere(scope) },
+            data: {
+              agentId: set.agentId,
+              name: set.name,
+              description: set.description,
+              threadIds: [...set.threadIds],
+              criterionIds: [...set.criterionIds],
+              updatedAt: set.updatedAt,
+            },
+          });
+          if (outcome.count === 0) return err(ledgerUnavailable("golden_set_not_in_scope"));
+          return ok(set);
+        },
+      );
     },
 
     async remove(
@@ -142,26 +155,38 @@ export function createGoldenSetsRepository(
       goldenSetId: GoldenSetId,
       transaction: TransactionScope,
     ): Promise<Result<boolean>> {
-      return refuse(async () => {
-        const client = transactions.writer(transaction);
-        const outcome = await client.goldenSet.deleteMany({
-          where: { id: goldenSetId, ...scopedWhere(scope) },
-        });
-        return ok(outcome.count > 0);
-      }, "goldenSets remove");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets remove",
+        async () => {
+          const client = transactions.writer(transaction);
+          const outcome = await client.goldenSet.deleteMany({
+            where: { id: goldenSetId, ...scopedWhere(scope) },
+          });
+          return ok(outcome.count > 0);
+        },
+      );
     },
 
     async findById(
       scope: EnvironmentScope,
       goldenSetId: GoldenSetId,
     ): Promise<Result<GoldenSet | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().goldenSet.findFirst({
-          where: { id: goldenSetId, ...scopedWhere(scope) },
-          select: GOLDEN_SET_COLUMNS,
-        });
-        return ok(row === null ? null : readGoldenSet(row as GoldenSetRow));
-      }, "goldenSets findById");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets findById",
+        async () => {
+          const row = await transactions.reader().goldenSet.findFirst({
+            where: { id: goldenSetId, ...scopedWhere(scope) },
+            select: GOLDEN_SET_COLUMNS,
+          });
+          return ok(row === null ? null : readGoldenSet(row as GoldenSetRow));
+        },
+      );
     },
 
     async findByName(
@@ -169,32 +194,44 @@ export function createGoldenSetsRepository(
       agentId: AgentId,
       name: string,
     ): Promise<Result<GoldenSet | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().goldenSet.findFirst({
-          where: { agentId, name, ...scopedWhere(scope) },
-          select: GOLDEN_SET_COLUMNS,
-        });
-        return ok(row === null ? null : readGoldenSet(row as GoldenSetRow));
-      }, "goldenSets findByName");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets findByName",
+        async () => {
+          const row = await transactions.reader().goldenSet.findFirst({
+            where: { agentId, name, ...scopedWhere(scope) },
+            select: GOLDEN_SET_COLUMNS,
+          });
+          return ok(row === null ? null : readGoldenSet(row as GoldenSetRow));
+        },
+      );
     },
 
     async page(scope: EnvironmentScope, query: GoldenSetQuery): Promise<Result<GoldenSetPage>> {
-      return refuse(async () => {
-        const where = {
-          ...scopedWhere(scope),
-          ...(query.agentId === null ? {} : { agentId: query.agentId }),
-        };
-        const reader = transactions.reader();
-        const rows = await reader.goldenSet.findMany({
-          where,
-          select: GOLDEN_SET_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-          skip: query.offset,
-          take: query.limit,
-        });
-        const total = await reader.goldenSet.count({ where });
-        return ok({ items: rows.map((row) => readGoldenSet(row as GoldenSetRow)), total });
-      }, "goldenSets page");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        goldenSetsScopeUnresolved,
+        "goldenSets page",
+        async () => {
+          const where = {
+            ...scopedWhere(scope),
+            ...(query.agentId === null ? {} : { agentId: query.agentId }),
+          };
+          const reader = transactions.reader();
+          const rows = await reader.goldenSet.findMany({
+            where,
+            select: GOLDEN_SET_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+            skip: query.offset,
+            take: query.limit,
+          });
+          const total = await reader.goldenSet.count({ where });
+          return ok({ items: rows.map((row) => readGoldenSet(row as GoldenSetRow)), total });
+        },
+      );
     },
   };
 }

--- a/packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-isolation.integration.test.ts
@@ -1,0 +1,450 @@
+// WIN-303 — THE TAMPERED SCOPE TRIPLE, against a real PostgreSQL holding two
+// tenants.
+//
+// WHAT WAS WRONG. A `governance` scope is a TRIPLE — organization, project,
+// environment — and the five canonical stores narrowed every read and every
+// write by the environment ALONE. So a caller presenting a LEGITIMATE
+// environment beside SOMEBODY ELSE'S project or organization was served, in
+// full, by all five: the two clauses that would have disagreed were never in the
+// statement. `governance-rules.integration.test.ts` already seeds a second
+// tenant and proves a COHERENT foreign scope reaches nothing — and it passes
+// either way, because the environment clause alone is enough for that case. The
+// forged triple is the case that separates them, and nothing measured it.
+//
+// WHY IT IS PROVED HERE AND NOT AGAINST A DOUBLE. The in-memory stores hold no
+// tenant tree. `InMemorySafetyLedger` and its four siblings compare
+// `resolvePath(scope)` against the one scope they were constructed with, so a
+// forged ancestry and a real one are the same VALUE to them — a double asked
+// whether an environment sits under a project can only answer whatever it was
+// told. `tools-scope.ts` states the same limit about the same shape of guard.
+// Every assertion below therefore runs against the container, and every one that
+// claims a row did not move reads it back on a SECOND client the adapter's pool
+// never touched.
+//
+// THE THREE FACTS ARE ASSERTED APART. `governance-scope.ts` refuses under one
+// code per store and one reason per fact, and the reasons are what make the
+// halves of the comparison separable:
+//
+//   `foreign_ancestry` with only the ORGANIZATION forged is the case that dies
+//   if the organization half of the comparison is deleted — and NO other case
+//   in this package notices, because every fixture seeds one whole chain, where
+//   the right project is always under the right organization.
+//
+//   `foreign_ancestry` with only the PROJECT forged is the mirror.
+//
+//   `unknown_environment` is a leaf in no row at all, and
+//   `unnarrowable_identifiers` is a scope no statement can even be sent for —
+//   pinned at ZERO statements, because a malformed uuid reaching a `@db.Uuid`
+//   column aborts the caller's whole transaction.
+//
+// Run by `pnpm test:postgres-tenancy:integration`. FAILS when Docker is absent.
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import type {
+  ActorId,
+  AgentId,
+  AgentVersionId,
+  EndUserId,
+  EnvironmentScope,
+  EvalCriterionId,
+  GoldenSetId,
+  SafetyEventId,
+  TurnId,
+} from "@platos/context-governance/application/ports/index.js";
+import {
+  asGovernanceIdentifier,
+  asIdentifier,
+  environmentScope,
+  runResult,
+} from "@platos/context-governance/application/ports/index.js";
+
+import type { TenancyDatabaseClient } from "./client.js";
+import {
+  conformanceCriterion,
+  conformanceGoldenSet,
+  conformanceSafetyEvent,
+  type GovernanceConformanceIds,
+} from "./governance-conformance.js";
+import type { GovernanceHarness, PeerChain } from "./governance-harness.js";
+import { startGovernanceHarness } from "./governance-harness.js";
+
+let harness: GovernanceHarness;
+/** The tenant that owns every row asserted below. */
+let mine: PeerChain;
+/** A whole second tenant, whose organization and project are the forgery. */
+let theirs: PeerChain;
+let ids: GovernanceConformanceIds;
+let observer: TenancyDatabaseClient;
+let criterionId: EvalCriterionId;
+let goldenSetId: GoldenSetId;
+
+const actor = asGovernanceIdentifier<ActorId>("operator-1");
+const SINCE = new Date("2026-01-01T00:00:00.000Z");
+/** A uuid of the right shape naming no row anywhere. */
+const ABSENT = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+/**
+ * The scope every case below is refused for: MY environment, THEIR ancestry.
+ *
+ * Not a typo and not a scope any legitimate grant can produce. It is what a
+ * grant looks like when it has been tampered with, or assembled by a bug in
+ * whatever resolved it, and it is precisely what the environment clause alone
+ * cannot see.
+ */
+function tampered(): EnvironmentScope {
+  return environmentScope(
+    asIdentifier(theirs.scope.organizationId),
+    asIdentifier(theirs.scope.projectId),
+    asIdentifier(mine.scope.environmentId),
+  );
+}
+
+/** MY environment and MY project, under THEIR organization. One clause wrong. */
+function organizationForged(): EnvironmentScope {
+  return environmentScope(
+    asIdentifier(theirs.scope.organizationId),
+    asIdentifier(mine.scope.projectId),
+    asIdentifier(mine.scope.environmentId),
+  );
+}
+
+/** MY environment and MY organization, under THEIR project. The other clause. */
+function projectForged(): EnvironmentScope {
+  return environmentScope(
+    asIdentifier(mine.scope.organizationId),
+    asIdentifier(theirs.scope.projectId),
+    asIdentifier(mine.scope.environmentId),
+  );
+}
+
+/** The code a store refused under, and the FACT its reason leads with. */
+function refusal(result: unknown): { readonly code: string; readonly fact: string } {
+  const outcome = result as {
+    readonly ok: boolean;
+    readonly error?: { readonly code?: string; readonly details?: Record<string, unknown> };
+  };
+  if (outcome.ok) return { code: "<accepted>", fact: "<accepted>" };
+  const reason = String(outcome.error?.details?.["reason"] ?? "<no reason>");
+  return { code: outcome.error?.code ?? "<no code>", fact: reason.split(":")[0] ?? reason };
+}
+
+beforeAll(async () => {
+  harness = await startGovernanceHarness();
+  mine = await harness.seedChain(await harness.freshScope());
+  theirs = await harness.foreignChain();
+  ids = {
+    agentId: mine.agentId,
+    agentVersionId: mine.agentVersionId,
+    secondAgentVersionId: mine.secondAgentVersionId,
+    endUserId: mine.endUserId,
+    threadId: mine.threadId,
+    turnId: mine.turnId,
+    secondTurnId: mine.secondTurnId,
+    absentId: ABSENT,
+  };
+  const created = await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+    harness.stores.criteria.create(mine.scope, conformanceCriterion(), actor, transaction),
+  );
+  if (!created.ok) throw new Error("the fixture criterion was refused");
+  criterionId = created.value.evalCriterionId;
+  const set = await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+    harness.stores.goldenSets.create(mine.scope, conformanceGoldenSet(ids), actor, transaction),
+  );
+  if (!set.ok) throw new Error("the fixture golden set was refused");
+  goldenSetId = set.value.goldenSetId;
+  await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+    harness.stores.ratings.upsert(
+      mine.scope,
+      {
+        turnId: asGovernanceIdentifier<TurnId>(mine.turnId),
+        agentId: asGovernanceIdentifier<AgentId>(mine.agentId),
+        agentVersionId: asGovernanceIdentifier<AgentVersionId>(mine.agentVersionId),
+        endUserId: asGovernanceIdentifier<EndUserId>(mine.endUserId),
+        rating: 1,
+        comment: "mine",
+        revision: 1,
+      },
+      transaction,
+    ),
+  );
+  await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+    harness.stores.safety.append(
+      mine.scope,
+      conformanceSafetyEvent(ids, { principalId: "subject-a" }),
+      transaction,
+    ),
+  );
+  const { PrismaClient } = await import("@platos/tenancy-database");
+  observer = new PrismaClient({
+    datasources: { db: { url: harness.base.databaseUrl } },
+  }) as TenancyDatabaseClient;
+}, 600_000);
+
+afterAll(async () => {
+  await observer?.$disconnect();
+  await harness?.stop();
+});
+
+describe("a tampered triple is REFUSED by every one of the five stores", () => {
+  // THE POSITIVE CONTROL IS IN EVERY CASE, and it is not decoration: a resolver
+  // that refused unconditionally would satisfy every refusal assertion in this
+  // file. Each case asks the SAME question twice — once with the honest scope,
+  // once with the forged one — so a store that stopped answering at all fails
+  // here as loudly as one that answers everybody.
+  test("`SafetyLedger` reads its own environment and refuses the forged ancestry", async () => {
+    const honest = await harness.stores.safety.page(mine.scope, {
+      since: SINCE,
+      limit: 10,
+      offset: 0,
+      detector: null,
+      severity: null,
+      agentId: null,
+      threadId: null,
+      search: null,
+    });
+    expect(honest.ok && honest.value.total).toBe(1);
+
+    const forged = await harness.stores.safety.page(tampered(), {
+      since: SINCE,
+      limit: 10,
+      offset: 0,
+      detector: null,
+      severity: null,
+      agentId: null,
+      threadId: null,
+      search: null,
+    });
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_SAFETY_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+
+    // And the row itself is not reachable by id either, which is the read a
+    // probe holding one identifier would actually make.
+    const byId = await harness.stores.safety.findById(
+      tampered(),
+      asGovernanceIdentifier<SafetyEventId>(ABSENT),
+    );
+    expect(refusal(byId).code).toBe("GOVERNANCE_SAFETY_SCOPE_UNRESOLVED");
+  });
+
+  test("`RatingsRepository` refuses, and the forged upsert moves NO row", async () => {
+    const honest = await harness.stores.ratings.findForTurn(
+      mine.scope,
+      asGovernanceIdentifier<TurnId>(mine.turnId),
+      asGovernanceIdentifier<EndUserId>(mine.endUserId),
+    );
+    expect(honest.ok && honest.value?.comment).toBe("mine");
+
+    const forged = await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+      harness.stores.ratings.upsert(
+        tampered(),
+        {
+          turnId: asGovernanceIdentifier<TurnId>(mine.turnId),
+          agentId: asGovernanceIdentifier<AgentId>(mine.agentId),
+          agentVersionId: asGovernanceIdentifier<AgentVersionId>(mine.agentVersionId),
+          endUserId: asGovernanceIdentifier<EndUserId>(mine.endUserId),
+          rating: -1,
+          comment: "flipped by a forged grant",
+          revision: 2,
+        },
+        transaction,
+      ),
+    );
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_RATINGS_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+    // READ BACK ON THE SECOND CLIENT. A flip the writer alone cannot see is not
+    // a flip that did not happen.
+    const held = await observer.messageRating.findFirst({
+      where: { turnId: mine.turnId, endUserId: mine.endUserId },
+      select: { rating: true, comment: true, revision: true },
+    });
+    expect(held).toEqual({ rating: 1, comment: "mine", revision: 1 });
+  });
+
+  test("`CriteriaRepository` refuses, and the forged remove DELETES nothing", async () => {
+    const honest = await harness.stores.criteria.findById(mine.scope, criterionId);
+    expect(honest.ok && honest.value !== null).toBe(true);
+
+    const forged = await harness.stores.criteria.findById(tampered(), criterionId);
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+
+    const removed = await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+      harness.stores.criteria.remove(tampered(), criterionId, transaction),
+    );
+    expect(refusal(removed).code).toBe("GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED");
+    expect(await observer.evalCriterion.count({ where: { id: criterionId } })).toBe(1);
+  });
+
+  test("`EvalsRepository` refuses, and the forged append WRITES nothing", async () => {
+    const before = await observer.agentEval.count({
+      where: { environmentId: mine.scope.environmentId },
+    });
+    const honest = await harness.stores.evals.page(mine.scope, {
+      since: SINCE,
+      limit: 10,
+      offset: 0,
+      agentId: null,
+      agentVersionId: null,
+      criterionId: null,
+      threadId: null,
+      search: null,
+    });
+    expect(honest.ok).toBe(true);
+
+    const forged = await harness.stores.evals.sample(tampered(), {
+      agentId: asGovernanceIdentifier<AgentId>(mine.agentId),
+      since: SINCE,
+      versionIds: [],
+    });
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_EVALS_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+    expect(
+      await observer.agentEval.count({ where: { environmentId: mine.scope.environmentId } }),
+    ).toBe(before);
+  });
+
+  test("`GoldenSetsRepository` refuses, and the forged update MOVES nothing", async () => {
+    const honest = await harness.stores.goldenSets.findById(mine.scope, goldenSetId);
+    expect(honest.ok && honest.value !== null).toBe(true);
+    if (!honest.ok || honest.value === null) return;
+    const stored = honest.value;
+
+    const forged = await runResult(harness.base.adapter.unitOfWork, (transaction) =>
+      harness.stores.goldenSets.update(
+        tampered(),
+        { ...stored, name: "renamed by a forged grant" },
+        transaction,
+      ),
+    );
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_GOLDEN_SETS_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+    const held = await observer.goldenSet.findFirst({
+      where: { id: goldenSetId },
+      select: { name: true },
+    });
+    expect(held).toEqual({ name: stored.name });
+  });
+});
+
+describe("each half of the ancestry comparison is refused on its own", () => {
+  // THE TWO CASES THAT KILL THE TWO HALVES. Deleting `project."organizationId"`
+  // from the resolver's comparison leaves the first of these green and only the
+  // second red; deleting the project half does the reverse. Neither is visible
+  // in any other suite in this package, because every fixture seeds ONE chain
+  // where the right project is always under the right organization.
+  test("only the ORGANIZATION forged is still `foreign_ancestry`", async () => {
+    const answer = await harness.stores.criteria.findById(organizationForged(), criterionId);
+    expect(refusal(answer)).toEqual({
+      code: "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+  });
+
+  test("only the PROJECT forged is `foreign_ancestry` too", async () => {
+    const answer = await harness.stores.criteria.findById(projectForged(), criterionId);
+    expect(refusal(answer)).toEqual({
+      code: "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+  });
+
+  test("an environment in no row at all is `unknown_environment`, not absence", async () => {
+    const answer = await harness.stores.criteria.findById(
+      environmentScope(
+        asIdentifier(mine.scope.organizationId),
+        asIdentifier(mine.scope.projectId),
+        asIdentifier(ABSENT),
+      ),
+      criterionId,
+    );
+    expect(refusal(answer)).toEqual({
+      code: "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+      fact: "unknown_environment",
+    });
+  });
+
+  test("a scope that is not uuid-shaped is refused with ZERO statements sent", async () => {
+    // The count is the assertion, not a detail of it. Every id here is bound to
+    // a `@db.Uuid` column: a malformed one makes the driver refuse the whole
+    // statement, and on PostgreSQL a refused statement ABORTS the enclosing
+    // transaction — so a caller mid-unit-of-work would lose every later write.
+    harness.base.resetStatements();
+    const answer = await harness.stores.criteria.findById(
+      environmentScope(
+        asIdentifier(mine.scope.organizationId),
+        asIdentifier(mine.scope.projectId),
+        asIdentifier("not-a-uuid"),
+      ),
+      criterionId,
+    );
+    const sent = harness.base
+      .statements()
+      .filter(
+        (statement) =>
+          !/^\s*(BEGIN|COMMIT|ROLLBACK|DEALLOCATE)\b/iu.test(statement) &&
+          !/^\s*SELECT\s+1\s*$/iu.test(statement),
+      );
+    expect({ ...refusal(answer), sent: sent.length }).toEqual({
+      code: "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+      fact: "unnarrowable_identifiers",
+      sent: 0,
+    });
+  });
+});
+
+describe("a TENANT scope is held to the ancestry it asserts, and to no more", () => {
+  test("a PROJECT scope under a forged organization is refused, not counted", async () => {
+    // `tenantWhere` narrows a project-level scope by the PROJECT alone, so this
+    // is the same hole one level up: my project, their organization, and a
+    // subject count that would otherwise have been served in full.
+    const honest = await harness.stores.safety.countSubject({
+      scope: { level: "project", organizationId: mine.scope.organizationId, projectId: mine.scope.projectId },
+      principalId: "subject-a",
+    });
+    expect(honest.ok && honest.value).toBe(1);
+
+    const forged = await harness.stores.safety.countSubject({
+      scope: {
+        level: "project",
+        organizationId: theirs.scope.organizationId,
+        projectId: mine.scope.projectId,
+      },
+      principalId: "subject-a",
+    });
+    expect(refusal(forged)).toEqual({
+      code: "GOVERNANCE_SAFETY_SCOPE_UNRESOLVED",
+      fact: "foreign_ancestry",
+    });
+  });
+
+  test("an ORGANIZATION scope asserts no relation, so it is answered without one", async () => {
+    // ONE identifier, no claim about the tree, nothing to contradict — and the
+    // rows it reaches are already narrowed through `Environment` and `Project`
+    // from that organization, so a forged one reaches none. A statement that
+    // could only ever answer "yes" would be a cost with no refusal behind it,
+    // and it would move the pin `governance-statements.integration.test.ts`
+    // takes here to catch a widening read of the tenant tree.
+    const answer = await harness.stores.safety.countSubject({
+      scope: { level: "organization", organizationId: mine.scope.organizationId },
+      principalId: "subject-a",
+    });
+    expect(answer.ok && answer.value).toBe(1);
+
+    const foreign = await harness.stores.safety.countSubject({
+      scope: { level: "organization", organizationId: theirs.scope.organizationId },
+      principalId: "subject-a",
+    });
+    expect(foreign.ok && foreign.value).toBe(0);
+  });
+});

--- a/packages/adapters/postgres-tenancy/src/governance-ratings.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-ratings.ts
@@ -50,6 +50,7 @@ import {
   err,
   ledgerUnavailable,
   ok,
+  ratingsScopeUnresolved,
   type AgentId,
   type AgentVersionId,
 } from "@platos/context-governance/application/ports/index.js";
@@ -59,7 +60,7 @@ import {
   requireStorableRevision,
   requireUuid,
 } from "./governance-guards.js";
-import { refuse } from "./governance-refusal.js";
+import { inGovernanceScope } from "./governance-scope.js";
 import { readMessageRating, scopedWhere, tenantWhere, type MessageRatingRow } from "./governance-rows.js";
 import type { TenancyTransactions } from "./transaction.js";
 
@@ -103,13 +104,19 @@ export function createRatingsRepository(
       turnId: TurnId,
       endUserId: EndUserId,
     ): Promise<Result<MessageRating | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().messageRating.findFirst({
-          where: { turnId, endUserId, ...scopedWhere(scope) },
-          select: RATING_COLUMNS,
-        });
-        return ok(row === null ? null : readMessageRating(row as MessageRatingRow));
-      }, "ratings findForTurn");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        ratingsScopeUnresolved,
+        "ratings findForTurn",
+        async () => {
+          const row = await transactions.reader().messageRating.findFirst({
+            where: { turnId, endUserId, ...scopedWhere(scope) },
+            select: RATING_COLUMNS,
+          });
+          return ok(row === null ? null : readMessageRating(row as MessageRatingRow));
+        },
+      );
     },
 
     async upsert(
@@ -117,68 +124,74 @@ export function createRatingsRepository(
       write: RatingWrite,
       transaction: TransactionScope,
     ): Promise<Result<MessageRating>> {
-      return refuse(async () => {
-        requireUuid("MessageRating.turnId", write.turnId);
-        requireUuid("MessageRating.agentId", write.agentId);
-        requireUuid("MessageRating.agentVersionId", write.agentVersionId);
-        requireUuid("MessageRating.endUserId", write.endUserId);
-        requireStorableRating(write.rating);
-        requireStorableRevision(write.revision);
+      return inGovernanceScope(
+        transactions,
+        scope,
+        ratingsScopeUnresolved,
+        "ratings upsert",
+        async () => {
+          requireUuid("MessageRating.turnId", write.turnId);
+          requireUuid("MessageRating.agentId", write.agentId);
+          requireUuid("MessageRating.agentVersionId", write.agentVersionId);
+          requireUuid("MessageRating.endUserId", write.endUserId);
+          requireStorableRating(write.rating);
+          requireStorableRevision(write.revision);
 
-        const client = transactions.writer(transaction);
-        const at = now();
-        // TWO statements on BOTH paths, which is what makes the count a pin
-        // rather than a coincidence of which path a fixture happened to take.
-        // The scoped update runs first because the flip is the common case and
-        // because an unscoped upsert would reach another environment's row.
-        const flipped = await client.messageRating.updateMany({
-          where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },
-          data: {
-            rating: write.rating,
-            comment: write.comment,
-            revision: write.revision,
-            agentVersionId: write.agentVersionId,
-            updatedAt: at,
-          },
-        });
-        if (flipped.count > 0) {
-          const row = await client.messageRating.findFirst({
+          const client = transactions.writer(transaction);
+          const at = now();
+          // TWO statements on BOTH paths, which is what makes the count a pin
+          // rather than a coincidence of which path a fixture happened to take.
+          // The scoped update runs first because the flip is the common case and
+          // because an unscoped upsert would reach another environment's row.
+          const flipped = await client.messageRating.updateMany({
             where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },
-            select: RATING_COLUMNS,
-          });
-          if (row === null) return err(ledgerUnavailable("rating vanished between update and read"));
-          return ok(readMessageRating(row as MessageRatingRow));
-        }
-        // `skipDuplicates` rather than a plain insert, because the unique key is
-        // installation-wide: a row for this `[turn, endUser]` in ANOTHER
-        // environment refuses this one, and a raised constraint would abort the
-        // caller's transaction instead of answering. A count of zero is that
-        // case, and it is reported as a refusal rather than as a flip that did
-        // not happen.
-        const created = await client.messageRating.createManyAndReturn({
-          data: [
-            {
-              environmentId: scope.environmentId,
-              turnId: write.turnId,
-              agentId: write.agentId,
-              agentVersionId: write.agentVersionId,
-              endUserId: write.endUserId,
+            data: {
               rating: write.rating,
-              revision: write.revision,
               comment: write.comment,
-              createdAt: at,
+              revision: write.revision,
+              agentVersionId: write.agentVersionId,
               updatedAt: at,
             },
-          ],
-          skipDuplicates: true,
-          select: RATING_COLUMNS,
-        });
-        const row = created[0];
-        if (row === undefined) {
-          return err(ledgerUnavailable("rating for this turn and end user exists in another environment"));
-        }
-        return ok(readMessageRating(row as MessageRatingRow));
-      }, "ratings upsert");
+          });
+          if (flipped.count > 0) {
+            const row = await client.messageRating.findFirst({
+              where: { turnId: write.turnId, endUserId: write.endUserId, ...scopedWhere(scope) },
+              select: RATING_COLUMNS,
+            });
+            if (row === null) return err(ledgerUnavailable("rating vanished between update and read"));
+            return ok(readMessageRating(row as MessageRatingRow));
+          }
+          // `skipDuplicates` rather than a plain insert, because the unique key is
+          // installation-wide: a row for this `[turn, endUser]` in ANOTHER
+          // environment refuses this one, and a raised constraint would abort the
+          // caller's transaction instead of answering. A count of zero is that
+          // case, and it is reported as a refusal rather than as a flip that did
+          // not happen.
+          const created = await client.messageRating.createManyAndReturn({
+            data: [
+              {
+                environmentId: scope.environmentId,
+                turnId: write.turnId,
+                agentId: write.agentId,
+                agentVersionId: write.agentVersionId,
+                endUserId: write.endUserId,
+                rating: write.rating,
+                revision: write.revision,
+                comment: write.comment,
+                createdAt: at,
+                updatedAt: at,
+              },
+            ],
+            skipDuplicates: true,
+            select: RATING_COLUMNS,
+          });
+          const row = created[0];
+          if (row === undefined) {
+            return err(ledgerUnavailable("rating for this turn and end user exists in another environment"));
+          }
+          return ok(readMessageRating(row as MessageRatingRow));
+        },
+      );
     },
 
     async remove(
@@ -187,75 +200,111 @@ export function createRatingsRepository(
       endUserId: EndUserId,
       transaction: TransactionScope,
     ): Promise<Result<boolean>> {
-      return refuse(async () => {
-        const client = transactions.writer(transaction);
-        const outcome = await client.messageRating.deleteMany({
-          where: { turnId, endUserId, ...scopedWhere(scope) },
-        });
-        return ok(outcome.count > 0);
-      }, "ratings remove");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        ratingsScopeUnresolved,
+        "ratings remove",
+        async () => {
+          const client = transactions.writer(transaction);
+          const outcome = await client.messageRating.deleteMany({
+            where: { turnId, endUserId, ...scopedWhere(scope) },
+          });
+          return ok(outcome.count > 0);
+        },
+      );
     },
 
     async tallyTurn(
       scope: EnvironmentScope,
       turnId: TurnId,
     ): Promise<Result<readonly SatisfactionInput[]>> {
-      return refuse(async () => {
-        const rows = await transactions.reader().messageRating.findMany({
-          where: { turnId, ...scopedWhere(scope) },
-          select: SAMPLE_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(rows.map(toSample));
-      }, "ratings tallyTurn");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        ratingsScopeUnresolved,
+        "ratings tallyTurn",
+        async () => {
+          const rows = await transactions.reader().messageRating.findMany({
+            where: { turnId, ...scopedWhere(scope) },
+            select: SAMPLE_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(rows.map(toSample));
+        },
+      );
     },
 
     async sample(
       scope: EnvironmentScope,
       query: RatingSampleQuery,
     ): Promise<Result<readonly SatisfactionInput[]>> {
-      return refuse(async () => {
-        const rows = await transactions.reader().messageRating.findMany({
-          where: {
-            ...scopedWhere(scope),
-            createdAt: { gte: query.since },
-            ...(query.agentId === null ? {} : { agentId: query.agentId }),
-          },
-          select: SAMPLE_COLUMNS,
-          orderBy: [{ createdAt: "asc" }, { id: "asc" }],
-        });
-        return ok(rows.map(toSample));
-      }, "ratings sample");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        ratingsScopeUnresolved,
+        "ratings sample",
+        async () => {
+          const rows = await transactions.reader().messageRating.findMany({
+            where: {
+              ...scopedWhere(scope),
+              createdAt: { gte: query.since },
+              ...(query.agentId === null ? {} : { agentId: query.agentId }),
+            },
+            select: SAMPLE_COLUMNS,
+            orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+          });
+          return ok(rows.map(toSample));
+        },
+      );
     },
 
     async countSubject(selector: RatingSubjectSelector): Promise<Result<number>> {
-      return refuse(async () => {
-        // A null subject matches NOTHING, and it is answered without a statement
-        // so the rule holds even if the filter below were wrong.
-        if (selector.endUserId === null) return ok(0);
-        const total = await transactions.reader().messageRating.count({
-          where: { endUserId: selector.endUserId, ...tenantWhere(selector.scope) },
-        });
-        return ok(total);
-      }, "ratings countSubject");
+      // A null subject matches NOTHING, and it is answered without a statement so
+      // the rule holds even if the filter below were wrong. WIN-303 kept it above
+      // the scope resolve for the reason `SafetyLedger.countSubject` gives: the
+      // answer is zero for a forged scope as well as a coherent one, so resolving
+      // first would spend a statement to reach the same value.
+      // Bound to a const rather than re-read inside the closure, for the reason
+      // `SafetyLedger.countSubject` states: narrowing does not cross a callback.
+      const endUserId = selector.endUserId;
+      if (endUserId === null) return ok(0);
+      return inGovernanceScope(
+        transactions,
+        selector.scope,
+        ratingsScopeUnresolved,
+        "ratings countSubject",
+        async () => {
+          const total = await transactions.reader().messageRating.count({
+            where: { endUserId, ...tenantWhere(selector.scope) },
+          });
+          return ok(total);
+        },
+      );
     },
 
     async eraseSubject(
       selector: RatingSubjectSelector,
       transaction: TransactionScope,
     ): Promise<Result<number>> {
-      return refuse(async () => {
-        const client = transactions.writer(transaction);
-        if (selector.endUserId === null) return ok(0);
-        // DESTROYED, not anonymised, unlike a safety event. A rating IS the
-        // subject's opinion — there is no compliance record left once the
-        // subject is removed from it — which is why the port names the two
-        // methods differently and why this one is a DELETE.
-        const outcome = await client.messageRating.deleteMany({
-          where: { endUserId: selector.endUserId, ...tenantWhere(selector.scope) },
-        });
-        return ok(outcome.count);
-      }, "ratings eraseSubject");
+      return inGovernanceScope(
+        transactions,
+        selector.scope,
+        ratingsScopeUnresolved,
+        "ratings eraseSubject",
+        async () => {
+          const client = transactions.writer(transaction);
+          if (selector.endUserId === null) return ok(0);
+          // DESTROYED, not anonymised, unlike a safety event. A rating IS the
+          // subject's opinion — there is no compliance record left once the
+          // subject is removed from it — which is why the port names the two
+          // methods differently and why this one is a DELETE.
+          const outcome = await client.messageRating.deleteMany({
+            where: { endUserId: selector.endUserId, ...tenantWhere(selector.scope) },
+          });
+          return ok(outcome.count);
+        },
+      );
     },
   };
 }

--- a/packages/adapters/postgres-tenancy/src/governance-rows.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-rows.ts
@@ -96,7 +96,28 @@ export const UNREADABLE_EVAL_COST = "governance.row.unreadable_eval_cost";
 /** The discriminator that tells an envelope from a legacy attribute bag. */
 export const SAFETY_METADATA_MARKER = "__governance";
 
-/** Restrict a read to one environment. Every read in the five stores uses it. */
+/**
+ * Restrict a read to one environment. Every read in the five stores uses it.
+ *
+ * THE LEAF ALONE, AND SINCE WIN-303 THAT IS SAFE RATHER THAN A HOLE. It used to
+ * be the hole: a scope is a TRIPLE, this checked one member of it, and a caller
+ * presenting a real environment beside somebody else's project or organization
+ * was served by every read and every write below. `governance-scope.ts` now
+ * resolves the whole triple against `Environment` and `Project` before any of
+ * the five stores sends a statement, and refuses a forged ancestry under a code
+ * of each store's own — so the identifier this function narrows by has already
+ * been proven to sit where the scope claims it does.
+ *
+ * IT IS DELIBERATELY NOT WIDENED TO REPEAT THAT CHECK. The `where`-clause
+ * spelling — `{ environmentId, environment: { project: { id, organizationId } } }`,
+ * which is what the three READ SEAMS use — would be a second copy of one fact,
+ * and the copy could never be turned red: the resolver refuses first, so no test
+ * could distinguish this function with the clauses from this function without
+ * them. A guard nothing can falsify is the same as no guard at all, and the two
+ * answers are not interchangeable anyway: a filter answers a tampered scope with
+ * an EMPTY SET, which this context has already spent on concealing whose row an
+ * id belongs to. `governance-scope.ts` carries the argument in full.
+ */
 export function scopedWhere(scope: EnvironmentScope): { readonly environmentId: string } {
   return { environmentId: scope.environmentId };
 }
@@ -110,6 +131,17 @@ export function scopedWhere(scope: EnvironmentScope): { readonly environmentId: 
  * `Project`, resolved by the database in the SAME statement — not a widening
  * read of the tree followed by an `IN` list, which is the N+1 this shape is easy
  * to write by accident.
+ *
+ * EACH LEVEL NAMES ONE CLAUSE, AND THE MEMBERS IT DROPS ARE CHECKED BEFORE IT
+ * RUNS. An environment-level tenant scope narrows by the environment alone and a
+ * project-level one by the project alone, which on its own would accept the same
+ * tampered triple `scopedWhere` used to. Since WIN-303 the four subject methods
+ * that use this — `SafetyLedger.countSubject`/`anonymizeSubject` and
+ * `RatingsRepository.countSubject`/`eraseSubject` — resolve their scope through
+ * `governance-scope.ts` first, which is where an environment under a foreign
+ * project, or a project under a foreign organization, is refused. An
+ * ORGANIZATION-level scope asserts no relation at all, so there is nothing to
+ * contradict and no statement is spent looking.
  */
 export function tenantWhere(scope: TenantScope): Record<string, unknown> {
   if (scope.level === "environment") return { environmentId: scope.environmentId };

--- a/packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts
@@ -509,21 +509,25 @@ describe("every read and every write is narrowed to ONE environment", () => {
         transaction,
       ),
     );
-    // The scoped update matches nothing, so the create path runs and the
-    // installation-wide unique index refuses it. Either way the other tenant's
-    // row is untouched.
+    // The scoped update matches nothing, so the create path runs — and it is the
+    // DATABASE that ends it: `MessageRating_ancestry` resolves the turn's thread
+    // against this environment and refuses a row that crosses it. Either way the
+    // other tenant's row is untouched.
     expect(flip.ok).toBe(false);
     // WHICH refusal, and this line is here because the case was VACUOUS without
     // it — on this branch and, checked against a second worktree, on the base as
     // well. `mutations-governance.json`'s M-G19 removes `scopedWhere` from the
     // flip's `updateMany`; the statement then reaches the other tenant's row and
-    // rewrites it, fails to read it back IN SCOPE, and returns an error — which
-    // `runResult` ROLLS BACK, restoring the row. So `flip.ok` is false and the
-    // observer sees the original either way, and the only thing that differs is
-    // the reason: the guarded path never matched anything and is refused by the
-    // installation-wide unique index, while the mutated one matched and then
-    // lost the row it had just written.
-    expect(reasonOf(flip)).toBe("rating for this turn and end user exists in another environment");
+    // rewrites it, fails to read it back IN SCOPE, and returns "rating vanished
+    // between update and read" — which `runResult` ROLLS BACK, restoring the
+    // row. So `flip.ok` is false and the observer sees the original either way,
+    // and the reason is the only thing that differs.
+    //
+    // JOINED TO THE MIGRATION AND NOT TO THIS FILE. The sentence below is the
+    // one `RAISE EXCEPTION '% crosses its canonical owner ancestry'` builds in
+    // `00000000000000_initial/migration.sql`, so the assertion is against the
+    // deployed rule rather than against a string this adapter chose.
+    expect(reasonOf(flip)).toContain("MessageRating crosses its canonical owner ancestry");
     const untouched = await observer.messageRating.findFirst({
       where: { turnId: foreign.turnId, endUserId: foreign.endUserId },
       select: { comment: true, revision: true },

--- a/packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts
@@ -513,6 +513,17 @@ describe("every read and every write is narrowed to ONE environment", () => {
     // installation-wide unique index refuses it. Either way the other tenant's
     // row is untouched.
     expect(flip.ok).toBe(false);
+    // WHICH refusal, and this line is here because the case was VACUOUS without
+    // it — on this branch and, checked against a second worktree, on the base as
+    // well. `mutations-governance.json`'s M-G19 removes `scopedWhere` from the
+    // flip's `updateMany`; the statement then reaches the other tenant's row and
+    // rewrites it, fails to read it back IN SCOPE, and returns an error — which
+    // `runResult` ROLLS BACK, restoring the row. So `flip.ok` is false and the
+    // observer sees the original either way, and the only thing that differs is
+    // the reason: the guarded path never matched anything and is refused by the
+    // installation-wide unique index, while the mutated one matched and then
+    // lost the row it had just written.
+    expect(reasonOf(flip)).toBe("rating for this turn and end user exists in another environment");
     const untouched = await observer.messageRating.findFirst({
       where: { turnId: foreign.turnId, endUserId: foreign.endUserId },
       select: { comment: true, revision: true },

--- a/packages/adapters/postgres-tenancy/src/governance-safety.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-safety.ts
@@ -49,12 +49,13 @@ import {
   INJECTION_DETECTORS,
   ledgerUnavailable,
   ok,
+  safetyScopeUnresolved,
   PII_DETECTORS,
 } from "@platos/context-governance/application/ports/index.js";
 
 import { nullableJson } from "./client.js";
 import { guardSafetyAppend } from "./governance-guards.js";
-import { refuse } from "./governance-refusal.js";
+import { inGovernanceScope } from "./governance-scope.js";
 import {
   readSafetyAction,
   readSafetyDetector,
@@ -115,174 +116,228 @@ export function createSafetyLedger(
       event: AdmittedSafetyEvent,
       transaction: TransactionScope | null,
     ): Promise<Result<SafetyEvent>> {
-      return refuse(async () => {
-        guardSafetyAppend(event);
-        // A null scope resolves through `reader()` rather than through the pool
-        // directly, so an append issued INSIDE an open transaction still joins
-        // it. `transaction.ts`'s header is the argument: a write that went to
-        // the pool from inside a transaction would be a row the caller's own
-        // rollback could not take back.
-        const client = transaction === null ? transactions.reader() : transactions.writer(transaction);
-        const written = await client.safetyEvent.createManyAndReturn({
-          data: [
-            {
-              environmentId: scope.environmentId,
-              agentId: event.agentId,
-              threadId: event.threadId,
-              turnId: event.turnId,
-              detector: event.detector,
-              action: event.action,
-              severity: event.severity,
-              detail: event.detail,
-              metadata: writeSafetyEnvelope(event),
-              toolName: event.toolName,
-              toolCallId: event.toolCallId,
-              createdAt: now(),
-            },
-          ],
-          select: SAFETY_COLUMNS,
-        });
-        const row = written[0];
-        if (row === undefined) return err(ledgerUnavailable("safety append wrote no row"));
-        return ok(readSafetyEvent(row as SafetyEventRow));
-      }, "safety append");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        safetyScopeUnresolved,
+        "safety append",
+        async () => {
+          guardSafetyAppend(event);
+          // A null scope resolves through `reader()` rather than through the pool
+          // directly, so an append issued INSIDE an open transaction still joins
+          // it. `transaction.ts`'s header is the argument: a write that went to
+          // the pool from inside a transaction would be a row the caller's own
+          // rollback could not take back.
+          const client = transaction === null ? transactions.reader() : transactions.writer(transaction);
+          const written = await client.safetyEvent.createManyAndReturn({
+            data: [
+              {
+                environmentId: scope.environmentId,
+                agentId: event.agentId,
+                threadId: event.threadId,
+                turnId: event.turnId,
+                detector: event.detector,
+                action: event.action,
+                severity: event.severity,
+                detail: event.detail,
+                metadata: writeSafetyEnvelope(event),
+                toolName: event.toolName,
+                toolCallId: event.toolCallId,
+                createdAt: now(),
+              },
+            ],
+            select: SAFETY_COLUMNS,
+          });
+          const row = written[0];
+          if (row === undefined) return err(ledgerUnavailable("safety append wrote no row"));
+          return ok(readSafetyEvent(row as SafetyEventRow));
+        },
+      );
     },
 
     async page(scope: EnvironmentScope, query: SafetyEventQuery): Promise<Result<SafetyEventPage>> {
-      return refuse(async () => {
-        const where = {
-          ...scopedWhere(scope),
-          createdAt: { gte: query.since },
-          ...(query.detector === null ? {} : { detector: query.detector }),
-          ...(query.severity === null ? {} : { severity: query.severity }),
-          ...(query.agentId === null ? {} : { agentId: query.agentId }),
-          ...(query.threadId === null ? {} : { threadId: query.threadId }),
-          // Over the TOOL NAME and never over `detail`, which the port states in
-          // as many words: `detail` is the one column that can hold whatever a
-          // detector saw, and a substring search over it is a way to read it.
-          ...(query.search === null
-            ? {}
-            : { toolName: { contains: query.search, mode: "insensitive" as const } }),
-        };
-        const reader = transactions.reader();
-        // TWO statements, and the same two for one row or ten thousand. The
-        // items and the total are read separately because a `findMany` cannot
-        // report the count of rows it did not return; they are not a per-row
-        // read, which is what `governance-statements.integration.test.ts` pins.
-        const rows = await reader.safetyEvent.findMany({
-          where,
-          select: SAFETY_COLUMNS,
-          // `id` breaks the tie, so the order is TOTAL. `createdAt` is
-          // millisecond-precision and two events can share one; a paged listing
-          // whose order is not total repeats rows on one page and drops them
-          // from the next.
-          orderBy: [{ createdAt: "desc" }, { id: "desc" }],
-          skip: query.offset,
-          take: query.limit,
-        });
-        const total = await reader.safetyEvent.count({ where });
-        return ok({ items: rows.map((row) => readSafetyEvent(row as SafetyEventRow)), total });
-      }, "safety page");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        safetyScopeUnresolved,
+        "safety page",
+        async () => {
+          const where = {
+            ...scopedWhere(scope),
+            createdAt: { gte: query.since },
+            ...(query.detector === null ? {} : { detector: query.detector }),
+            ...(query.severity === null ? {} : { severity: query.severity }),
+            ...(query.agentId === null ? {} : { agentId: query.agentId }),
+            ...(query.threadId === null ? {} : { threadId: query.threadId }),
+            // Over the TOOL NAME and never over `detail`, which the port states in
+            // as many words: `detail` is the one column that can hold whatever a
+            // detector saw, and a substring search over it is a way to read it.
+            ...(query.search === null
+              ? {}
+              : { toolName: { contains: query.search, mode: "insensitive" as const } }),
+          };
+          const reader = transactions.reader();
+          // TWO statements, and the same two for one row or ten thousand. The
+          // items and the total are read separately because a `findMany` cannot
+          // report the count of rows it did not return; they are not a per-row
+          // read, which is what `governance-statements.integration.test.ts` pins.
+          const rows = await reader.safetyEvent.findMany({
+            where,
+            select: SAFETY_COLUMNS,
+            // `id` breaks the tie, so the order is TOTAL. `createdAt` is
+            // millisecond-precision and two events can share one; a paged listing
+            // whose order is not total repeats rows on one page and drops them
+            // from the next.
+            orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+            skip: query.offset,
+            take: query.limit,
+          });
+          const total = await reader.safetyEvent.count({ where });
+          return ok({ items: rows.map((row) => readSafetyEvent(row as SafetyEventRow)), total });
+        },
+      );
     },
 
     async findById(
       scope: EnvironmentScope,
       safetyEventId: SafetyEventId,
     ): Promise<Result<SafetyEvent | null>> {
-      return refuse(async () => {
-        const row = await transactions.reader().safetyEvent.findFirst({
-          where: { id: safetyEventId, ...scopedWhere(scope) },
-          select: SAFETY_COLUMNS,
-        });
-        return ok(row === null ? null : readSafetyEvent(row as SafetyEventRow));
-      }, "safety findById");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        safetyScopeUnresolved,
+        "safety findById",
+        async () => {
+          const row = await transactions.reader().safetyEvent.findFirst({
+            where: { id: safetyEventId, ...scopedWhere(scope) },
+            select: SAFETY_COLUMNS,
+          });
+          return ok(row === null ? null : readSafetyEvent(row as SafetyEventRow));
+        },
+      );
     },
 
     async tally(scope: EnvironmentScope, since: Date): Promise<Result<readonly SafetyTally[]>> {
-      return refuse(async () => {
-        // THREE columns, not the row. The rollup folds by detector, action and
-        // severity and reads nothing else, and `detail` is the column that can
-        // carry what a detector saw — a rollup has no business selecting it.
-        const rows = await transactions.reader().safetyEvent.findMany({
-          where: { ...scopedWhere(scope), createdAt: { gte: since } },
-          select: { detector: true, action: true, severity: true },
-        });
-        return ok(
-          rows.map((row) => ({
-            detector: readSafetyDetector(row.detector),
-            action: readSafetyAction(row.action),
-            severity: readSafetySeverity(row.severity),
-          })),
-        );
-      }, "safety tally");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        safetyScopeUnresolved,
+        "safety tally",
+        async () => {
+          // THREE columns, not the row. The rollup folds by detector, action and
+          // severity and reads nothing else, and `detail` is the column that can
+          // carry what a detector saw — a rollup has no business selecting it.
+          const rows = await transactions.reader().safetyEvent.findMany({
+            where: { ...scopedWhere(scope), createdAt: { gte: since } },
+            select: { detector: true, action: true, severity: true },
+          });
+          return ok(
+            rows.map((row) => ({
+              detector: readSafetyDetector(row.detector),
+              action: readSafetyAction(row.action),
+              severity: readSafetySeverity(row.severity),
+            })),
+          );
+        },
+      );
     },
 
     async countByAgent(
       scope: EnvironmentScope,
       since: Date,
     ): Promise<Result<readonly AgentDetectorCounts[]>> {
-      return refuse(async () => {
-        // ONE grouped statement, not one read per agent. The two rates the risk
-        // score divides by are both counts of rows in the window, so the
-        // database counts them and this folds the two detector families the
-        // context publishes rather than re-listing them here.
-        const groups = await transactions.reader().safetyEvent.groupBy({
-          by: ["agentId", "detector"],
-          where: { ...scopedWhere(scope), createdAt: { gte: since }, agentId: { not: null } },
-          _count: { _all: true },
-        });
-        const counts = new Map<string, { pii: number; injection: number }>();
-        for (const group of groups) {
-          const agentId = group.agentId;
-          if (agentId === null) continue;
-          const detector = readSafetyDetector(group.detector);
-          const bucket = counts.get(agentId) ?? { pii: 0, injection: 0 };
-          if (PII_DETECTORS.includes(detector)) bucket.pii += group._count._all;
-          if (INJECTION_DETECTORS.includes(detector)) bucket.injection += group._count._all;
-          counts.set(agentId, bucket);
-        }
-        return ok(
-          [...counts.entries()].map(([agentId, bucket]) => ({
-            agentId: asGovernanceIdentifier<AgentId>(agentId),
-            piiEvents: bucket.pii,
-            injectionEvents: bucket.injection,
-          })),
-        );
-      }, "safety countByAgent");
+      return inGovernanceScope(
+        transactions,
+        scope,
+        safetyScopeUnresolved,
+        "safety countByAgent",
+        async () => {
+          // ONE grouped statement, not one read per agent. The two rates the risk
+          // score divides by are both counts of rows in the window, so the
+          // database counts them and this folds the two detector families the
+          // context publishes rather than re-listing them here.
+          const groups = await transactions.reader().safetyEvent.groupBy({
+            by: ["agentId", "detector"],
+            where: { ...scopedWhere(scope), createdAt: { gte: since }, agentId: { not: null } },
+            _count: { _all: true },
+          });
+          const counts = new Map<string, { pii: number; injection: number }>();
+          for (const group of groups) {
+            const agentId = group.agentId;
+            if (agentId === null) continue;
+            const detector = readSafetyDetector(group.detector);
+            const bucket = counts.get(agentId) ?? { pii: 0, injection: 0 };
+            if (PII_DETECTORS.includes(detector)) bucket.pii += group._count._all;
+            if (INJECTION_DETECTORS.includes(detector)) bucket.injection += group._count._all;
+            counts.set(agentId, bucket);
+          }
+          return ok(
+            [...counts.entries()].map(([agentId, bucket]) => ({
+              agentId: asGovernanceIdentifier<AgentId>(agentId),
+              piiEvents: bucket.pii,
+              injectionEvents: bucket.injection,
+            })),
+          );
+        },
+      );
     },
 
     async countSubject(selector: SafetySubjectSelector): Promise<Result<number>> {
-      return refuse(async () => {
-        // A NULL selector matches nothing, and the port says an implementation
-        // MUST treat it that way rather than as "match everything". It is
-        // answered without a statement, so a plan for an unknown subject cannot
-        // count somebody else's rows even if the filter below were wrong.
-        if (selector.principalId === null) return ok(0);
-        const total = await transactions.reader().safetyEvent.count({
-          where: subjectWhere(selector, selector.principalId),
-        });
-        return ok(total);
-      }, "safety countSubject");
+      // A NULL selector matches nothing, and the port says an implementation MUST
+      // treat it that way rather than as "match everything". It is answered
+      // without a statement, so a plan for an unknown subject cannot count
+      // somebody else's rows even if the filter below were wrong.
+      //
+      // WIN-303 KEPT IT ABOVE THE SCOPE RESOLVE, and that placement is the pin
+      // `a NULL subject is ZERO statements` measures. The answer is zero for
+      // every scope, coherent or forged, so resolving one first would buy no
+      // refusal and would cost the one read this method is documented not to
+      // make. Nothing about the subject or the tree leaves through it.
+      //
+      // BOUND TO A CONST, not re-read inside the closure: a property access
+      // cannot carry its narrowing across a callback boundary, and the
+      // alternative spelling — a non-null assertion — is the one that would
+      // still compile the day the field became nullable somewhere else.
+      const principalId = selector.principalId;
+      if (principalId === null) return ok(0);
+      return inGovernanceScope(
+        transactions,
+        selector.scope,
+        safetyScopeUnresolved,
+        "safety countSubject",
+        async () => {
+          const total = await transactions.reader().safetyEvent.count({
+            where: subjectWhere(selector, principalId),
+          });
+          return ok(total);
+        },
+      );
     },
 
     async anonymizeSubject(
       selector: SafetySubjectSelector,
       transaction: TransactionScope,
     ): Promise<Result<number>> {
-      return refuse(async () => {
-        const client = transactions.writer(transaction);
-        if (selector.principalId === null) return ok(0);
-        // OVERWRITE, NEVER DELETE. `detector`, `action`, `severity` and
-        // `createdAt` are untouched, so the compliance record of what the
-        // control saw survives the erasure of who it was about. The metadata
-        // column goes to SQL NULL rather than to the JSON scalar `null`, which
-        // `SafetyEvent_metadata_json_root` refuses.
-        const outcome = await client.safetyEvent.updateMany({
-          where: subjectWhere(selector, selector.principalId),
-          data: { detail: null, metadata: nullableJson(null), endUserId: null },
-        });
-        return ok(outcome.count);
-      }, "safety anonymizeSubject");
+      return inGovernanceScope(
+        transactions,
+        selector.scope,
+        safetyScopeUnresolved,
+        "safety anonymizeSubject",
+        async () => {
+          const client = transactions.writer(transaction);
+          if (selector.principalId === null) return ok(0);
+          // OVERWRITE, NEVER DELETE. `detector`, `action`, `severity` and
+          // `createdAt` are untouched, so the compliance record of what the
+          // control saw survives the erasure of who it was about. The metadata
+          // column goes to SQL NULL rather than to the JSON scalar `null`, which
+          // `SafetyEvent_metadata_json_root` refuses.
+          const outcome = await client.safetyEvent.updateMany({
+            where: subjectWhere(selector, selector.principalId),
+            data: { detail: null, metadata: nullableJson(null), endUserId: null },
+          });
+          return ok(outcome.count);
+        },
+      );
     },
   };
 }

--- a/packages/adapters/postgres-tenancy/src/governance-scope.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-scope.ts
@@ -1,0 +1,229 @@
+// WIN-303 — the tenant triple, RESOLVED against the tree before any of the five
+// canonical stores sends a statement.
+//
+// *** THE DEFECT THIS FILE CLOSES. *** `governance-rows.ts`' `scopedWhere` was
+// `{ environmentId }` and nothing else, so `SafetyLedger`, `RatingsRepository`,
+// `CriteriaRepository`, `EvalsRepository` and `GoldenSetsRepository` checked ONE
+// member of a three-member scope. A caller presenting a legitimate environment
+// beside SOMEBODY ELSE'S project or organization was served: every read, every
+// update and every delete matched, because the two clauses that would have
+// disagreed were never in the statement.
+//
+// `Environment.id` is a globally unique uuid, so the environment determines the
+// project and the organization and the other two members look redundant. THEY
+// ARE NOT, and the case they catch is the one worth having: a scope assembled
+// with a real environment and a foreign ancestry is not a typo. It is a scope
+// that has been tampered with, or built by a bug in whatever resolved the grant.
+// `apps/agent/src/evals/rating.service.ts` — byte-identical to `origin/main` —
+// refuses it, and so do the three read seams this context added last tranche
+// (`governance-seam-guards.ts` carries that citation in full).
+//
+// ---------------------------------------------------------------------------
+// WHY ONE STATEMENT AND NOT THREE CLAUSES ON EVERY READ.
+//
+// The obvious repair is to widen `scopedWhere` to
+// `{ environmentId, environment: { project: { id, organizationId } } }` — the
+// shape the read seams use — and send nothing extra. It is one statement fewer
+// and it is the WRONG shape here, for the reason `tools-scope.ts` already gives
+// about the same database: a filter answers a tampered scope with an EMPTY SET,
+// and this context has already spent absence on concealment. `errors.ts` says it
+// outright — a criterion in another environment and a criterion that does not
+// exist answer identically "because telling them apart is exactly the probe" —
+// so a store that also answered absence for a forged ancestry would be reporting
+// a broken grant as a clean miss, for ever, with nothing anywhere to notice.
+//
+// So the ancestry is resolved ONCE, in its own statement, and a scope that does
+// not join up is REFUSED under a code of the store's own. `scopedWhere` and
+// `tenantWhere` stay as they are, narrowing by identifiers this file has already
+// proven coherent, and there is exactly ONE mechanism enforcing the triple —
+// which is what makes it falsifiable. A second copy in the `where` clause could
+// never be turned red by any test, because this guard would refuse first: a
+// guard nothing can falsify is the same as no guard at all.
+//
+// ---------------------------------------------------------------------------
+// FIVE CODES, THREE REASONS.
+//
+// The CODE says which store refused, so a resolver dropped from one of the five
+// cannot hide behind the other four. The REASON says which of three facts it
+// was, and the three are genuinely different operational events:
+//
+//   `unnarrowable_identifiers` — a member of the scope is not uuid-shaped. NO
+//   STATEMENT IS SENT, and that is the point rather than an optimisation: every
+//   id below is bound to a `@db.Uuid` column, a malformed one makes the driver
+//   refuse the whole statement with "Error creating UUID, invalid character",
+//   and on PostgreSQL a refused statement ABORTS THE ENCLOSING TRANSACTION.
+//   Four of this context's five ports take the caller's `TransactionScope`, so a
+//   scope check that raised would leave the caller unable to write anything
+//   else. Same finding, same answer, as `governance-guards.ts` and
+//   `governance-seam-guards.ts`.
+//
+//   `unknown_environment` / `unknown_project` — the leaf resolves to no row. An
+//   environment deleted since the grant was minted looks like this.
+//
+//   `foreign_ancestry` — the leaf EXISTS, under a project or an organization
+//   other than the one the scope claims. This is the tampered triple, and it is
+//   the only one of the three that a store narrowing by the leaf alone served.
+//
+// AN ORGANIZATION SCOPE SENDS NO STATEMENT EITHER, AND THAT IS NOT AN OMISSION.
+// It names ONE identifier, so it asserts no relation and there is nothing for
+// the tree to contradict; the erasure paths that take one already narrow through
+// `Environment` and `Project` from that organization, so a non-existent
+// organization reaches no row. A statement that could only ever answer "yes"
+// would be a cost with no refusal behind it — and it would break the pin
+// `governance-statements.integration.test.ts` takes at an organization scope,
+// which exists to catch a widening read of the tenant tree.
+//
+// THE SQL IS A STATIC TAGGED TEMPLATE WITH ONE INTERPOLATED VALUE, so
+// `scripts/arch/sole-writer.mjs` can attribute it: it names two tables, both
+// `tenancy`'s, and reads them — which §1 permits, since the cutting rule
+// restricts WRITES.
+
+import type {
+  DomainError,
+  EnvironmentScope,
+  Result,
+  TenantScope,
+} from "@platos/context-governance/application/ports/index.js";
+import { err, ok, resolvePath } from "@platos/context-governance/application/ports/index.js";
+
+import { refuse } from "./governance-refusal.js";
+import { isNarrowableIdentifier, narrowableScope } from "./governance-seam-guards.js";
+import type { TenancyTransactions } from "./transaction.js";
+
+/** A scope member is not the shape a `@db.Uuid` column accepts. No statement sent. */
+export const GOVERNANCE_SCOPE_UNNARROWABLE = "unnarrowable_identifiers";
+
+/** The scope names an environment that is in no row of the tree. */
+export const GOVERNANCE_SCOPE_UNKNOWN_ENVIRONMENT = "unknown_environment";
+
+/** The scope names a project that is in no row of the tree. */
+export const GOVERNANCE_SCOPE_UNKNOWN_PROJECT = "unknown_project";
+
+/** The leaf exists, under a different parent than the scope claims. THE TAMPER. */
+export const GOVERNANCE_SCOPE_FOREIGN_ANCESTRY = "foreign_ancestry";
+
+/**
+ * One store's own refusal constructor.
+ *
+ * Passed in rather than switched on inside, so the five codes are chosen at the
+ * five call sites and a store that forgot to pass its own would not compile.
+ */
+export type GovernanceScopeRefusal = (reason: string) => DomainError;
+
+/** One row: the environment's parent, and its parent's parent. */
+interface ResolvedEnvironment {
+  readonly projectId: string;
+  readonly organizationId: string;
+}
+
+/** One row: the project's parent. */
+interface ResolvedProject {
+  readonly organizationId: string;
+}
+
+/**
+ * The reason string a refusal carries.
+ *
+ * The FACT leads, then the operation, then the scope path. An operator greps for
+ * `foreign_ancestry` across every store; the path is what tells them which grant
+ * produced it, and `resolvePath` is the kernel's own canonical spelling of a
+ * scope rather than a fourth local one.
+ */
+function reasonFor(fact: string, operation: string, scope: TenantScope): string {
+  return `${fact}: ${operation}: ${resolvePath(scope)}`;
+}
+
+/**
+ * Resolve a scope against the tenant tree, or refuse under the store's own code.
+ *
+ * ZERO STATEMENTS for an organization scope and for a scope whose identifiers
+ * are not uuid-shaped; ONE for a project or an environment scope. Never more:
+ * the environment case reaches its organization through a JOIN rather than
+ * through a second read, because the client loads a relation as its own query
+ * and this sits on the front of every method of five ports.
+ */
+export async function requireGovernanceScope(
+  transactions: TenancyTransactions,
+  scope: TenantScope,
+  refusal: GovernanceScopeRefusal,
+  operation: string,
+): Promise<Result<true>> {
+  if (scope.level === "organization") {
+    // Nothing asserted, nothing to contradict. See the header.
+    return isNarrowableIdentifier(scope.organizationId)
+      ? ok(true)
+      : err(refusal(reasonFor(GOVERNANCE_SCOPE_UNNARROWABLE, operation, scope)));
+  }
+
+  if (scope.level === "project") {
+    if (!isNarrowableIdentifier(scope.organizationId) || !isNarrowableIdentifier(scope.projectId)) {
+      return err(refusal(reasonFor(GOVERNANCE_SCOPE_UNNARROWABLE, operation, scope)));
+    }
+    const rows = await transactions.reader().$queryRaw<readonly ResolvedProject[]>`
+      SELECT project."organizationId" AS "organizationId"
+        FROM "public"."Project" project
+       WHERE project."id" = ${scope.projectId}::uuid`;
+    const resolved = rows[0];
+    if (resolved === undefined) {
+      return err(refusal(reasonFor(GOVERNANCE_SCOPE_UNKNOWN_PROJECT, operation, scope)));
+    }
+    if (resolved.organizationId !== scope.organizationId) {
+      return err(refusal(reasonFor(GOVERNANCE_SCOPE_FOREIGN_ANCESTRY, operation, scope)));
+    }
+    return ok(true);
+  }
+
+  // `narrowableScope` is the READ SEAMS' guard, imported rather than copied:
+  // same context, same three columns, same RFC 4122 fact. The seams' header
+  // explains why it does NOT import `agents-guards.ts`' copy — different tables,
+  // different owners — and neither reason applies between these two.
+  const narrowed = narrowableScope(scope as EnvironmentScope);
+  if (narrowed === null) {
+    return err(refusal(reasonFor(GOVERNANCE_SCOPE_UNNARROWABLE, operation, scope)));
+  }
+  const rows = await transactions.reader().$queryRaw<readonly ResolvedEnvironment[]>`
+    SELECT environment."projectId" AS "projectId", project."organizationId" AS "organizationId"
+      FROM "public"."Environment" environment
+      JOIN "public"."Project" project ON project."id" = environment."projectId"
+     WHERE environment."id" = ${narrowed.environmentId}::uuid`;
+  const resolved = rows[0];
+  if (resolved === undefined) {
+    return err(refusal(reasonFor(GOVERNANCE_SCOPE_UNKNOWN_ENVIRONMENT, operation, scope)));
+  }
+  // BOTH halves, and the organization one is the half a mutation removes without
+  // any other suite noticing: an environment under the right project is under
+  // the right organization in every fixture that seeds one chain. The tampered
+  // triple `governance-isolation.integration.test.ts` builds is the case that
+  // separates them.
+  if (resolved.projectId !== narrowed.projectId || resolved.organizationId !== narrowed.organizationId) {
+    return err(refusal(reasonFor(GOVERNANCE_SCOPE_FOREIGN_ANCESTRY, operation, scope)));
+  }
+  return ok(true);
+}
+
+/**
+ * Resolve the scope, then run one store method — the single entry point the five
+ * stores use in place of a bare `refuse`.
+ *
+ * THE RESOLVE RUNS INSIDE `refuse`, unlike `tools-scope.ts`' `inScope` where it
+ * runs outside. The ports say "every method returns `Result`; a rejected promise
+ * is a defect, not an outcome", and the resolve sends a statement — so a genuine
+ * infrastructure fault during it would otherwise reject the promise this method
+ * promised never to reject. Inside, it is folded into
+ * `GOVERNANCE_LEDGER_UNAVAILABLE`, which is what a table being down actually is,
+ * while a `TransactionScopeError` still rethrows for the reason
+ * `governance-refusal.ts` gives.
+ */
+export async function inGovernanceScope<Value>(
+  transactions: TenancyTransactions,
+  scope: TenantScope,
+  refusal: GovernanceScopeRefusal,
+  operation: string,
+  work: () => Promise<Result<Value>>,
+): Promise<Result<Value>> {
+  return refuse(async () => {
+    const resolved = await requireGovernanceScope(transactions, scope, refusal, operation);
+    if (!resolved.ok) return err(resolved.error);
+    return work();
+  }, operation);
+}

--- a/packages/adapters/postgres-tenancy/src/governance-seam-guards.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-seam-guards.ts
@@ -51,6 +51,21 @@ import type { EnvironmentScope } from "@platos/context-governance/application/po
 const UUID_SHAPE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/u;
 
 /**
+ * That shape, as a predicate — the ONE definition the three seams and the five
+ * canonical stores share.
+ *
+ * WIN-303. `governance-scope.ts` has to check the members of an ORGANIZATION and
+ * a PROJECT scope, which `narrowableScope` below cannot express because it takes
+ * the whole environment triple. It imports this rather than carrying a third
+ * copy of the expression: unlike `agents-guards.ts`, that file guards the SAME
+ * three columns for the SAME owner as this one, so neither reason the paragraph
+ * above gives for a second copy applies between them.
+ */
+export function isNarrowableIdentifier(value: string): boolean {
+  return UUID_SHAPE.test(value);
+}
+
+/**
  * The WHOLE tenant triple this read may narrow by, or `null` when it is not
  * usable.
  *
@@ -71,15 +86,22 @@ const UUID_SHAPE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}
  * the environment clause alone this reader would serve it. The oracle refuses
  * it, so these do.
  *
- * THE FIVE CANONICAL STORES BESIDE THESE DO NOT. `governance-rows.ts`'
- * `scopedWhere` is `{ environmentId }` and nothing more, so `SafetyLedger`,
+ * THE FIVE CANONICAL STORES BESIDE THESE NOW DO TOO, AND THIS PARAGRAPH USED TO
+ * SAY THEY DID NOT. WIN-267 G2 reported the divergence rather than repairing it
+ * — `scopedWhere` was `{ environmentId }` and nothing more, so `SafetyLedger`,
  * `RatingsRepository`, `CriteriaRepository`, `EvalsRepository` and
- * `GoldenSetsRepository` accept a mismatched triple where these three refuse it.
- * That divergence is REPORTED rather than silently repaired: widening it is a
- * change to five ports this tranche does not own, and narrowing these three to
- * match the weaker convention would be choosing the tree's habit over the
- * oracle's behaviour. The read seams are the ones answering questions about
- * OTHER contexts' rows, which is where a malformed grant costs most.
+ * `GoldenSetsRepository` accepted a mismatched triple where these three refused
+ * it. WIN-303 closed it. The five resolve their whole scope through
+ * `governance-scope.ts` before any statement, and refuse a forged ancestry under
+ * a code of each store's own.
+ *
+ * THE TWO ANSWERS STILL DIFFER, AND THE DIFFERENCE IS DELIBERATE. These three
+ * fold the triple into the `where` and answer ABSENCE for a mismatched one,
+ * because absence is already what they answer for another tenant's row and
+ * `read-seams.ts` requires a probe and a typo to be indistinguishable. The five
+ * stores REFUSE instead, in a statement of their own, because absence there
+ * would make a broken grant indistinguishable from a criterion that does not
+ * exist — see `governance-scope.ts`, which carries the argument in full.
  *
  * `null` is the signal to REFUSE with the calling seam's own constructor. It is
  * never a licence to read wider: no caller in this package treats `null` as

--- a/packages/adapters/postgres-tenancy/src/governance-statements.integration.test.ts
+++ b/packages/adapters/postgres-tenancy/src/governance-statements.integration.test.ts
@@ -16,6 +16,17 @@
 // N+1 in the tenant tree rather than in the rows, and it is measured here at an
 // ORGANIZATION scope precisely so the widening cannot hide.
 //
+// EVERY SCOPED PIN CARRIES ONE RESOLVE, AND WIN-303 IS WHY. `governance-scope.ts`
+// resolves the whole tenant triple against `Environment` and `Project` before a
+// store sends anything, so a forged ancestry is REFUSED rather than answered
+// with an empty set. That is one statement, once, on the front of every method
+// that takes an environment scope — so every count below rose by exactly one and
+// none of them grew with the fixture, which is the property this file measures.
+// Two pins did NOT move and both say something: an ORGANIZATION scope asserts no
+// relation, so nothing is resolved and nothing is spent; and a NULL subject is
+// still answered without any statement at all, because the answer is zero for a
+// forged scope and a coherent one alike.
+//
 // THE PROBE PATTERN IS ANCHORED, and this is tranche 3's trap rather than a
 // precaution. Its advisory lock projected `SELECT 1`, which is exactly the shape
 // the statement suites strip to discard the driver's connection probe, so the
@@ -178,8 +189,8 @@ async function pin(
 }
 
 describe("reads are a fixed number of statements, whatever the row count", () => {
-  test("`SafetyLedger.page` is two: the page and its total", async () => {
-    await pin("safety.page", 2, (fixture) =>
+  test("`SafetyLedger.page` is three: the scope resolve, the page and its total", async () => {
+    await pin("safety.page", 3, (fixture) =>
       harness.stores.safety.page(fixture.scope, {
         since: SINCE,
         limit: 10,
@@ -193,23 +204,23 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`SafetyLedger.tally` is one, folding every row in the window", async () => {
-    await pin("safety.tally", 1, (fixture) => harness.stores.safety.tally(fixture.scope, SINCE));
+  test("`SafetyLedger.tally` is two, folding every row in the window", async () => {
+    await pin("safety.tally", 2, (fixture) => harness.stores.safety.tally(fixture.scope, SINCE));
   });
 
-  test("`SafetyLedger.countByAgent` is one GROUP BY, not one read per agent", async () => {
-    await pin("safety.countByAgent", 1, (fixture) =>
+  test("`SafetyLedger.countByAgent` is ONE GROUP BY beside the resolve, not one read per agent", async () => {
+    await pin("safety.countByAgent", 2, (fixture) =>
       harness.stores.safety.countByAgent(fixture.scope, SINCE),
     );
   });
 
-  test("`SafetyLedger.countSubject` is one at an ENVIRONMENT scope", async () => {
-    await pin("safety.countSubject.environment", 1, (fixture) =>
+  test("`SafetyLedger.countSubject` is the resolve and one count at an ENVIRONMENT scope", async () => {
+    await pin("safety.countSubject.environment", 2, (fixture) =>
       harness.stores.safety.countSubject({ scope: fixture.scope, principalId: "subject-a" }),
     );
   });
 
-  test("and one at an ORGANIZATION scope, where the tree is joined not walked", async () => {
+  test("and still ONE at an ORGANIZATION scope, which asserts no ancestry to resolve", async () => {
     await pin("safety.countSubject.organization", 1, (fixture) =>
       harness.stores.safety.countSubject({
         scope: { level: "organization", organizationId: fixture.scope.organizationId },
@@ -224,8 +235,8 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`EvalsRepository.page` is two", async () => {
-    await pin("evals.page", 2, (fixture) =>
+  test("`EvalsRepository.page` is three", async () => {
+    await pin("evals.page", 3, (fixture) =>
       harness.stores.evals.page(fixture.scope, {
         since: SINCE,
         limit: 10,
@@ -239,10 +250,10 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`EvalsRepository.sampleByIds` is one for the whole run", async () => {
+  test("`EvalsRepository.sampleByIds` is one read for the whole run, beside the resolve", async () => {
     // The run grouping is not a column; a run is the SET of ids it wrote. The
     // large fixture asks for forty of them in one statement.
-    await pin("evals.sampleByIds", 1, (fixture) =>
+    await pin("evals.sampleByIds", 2, (fixture) =>
       harness.stores.evals.sampleByIds(
         fixture.scope,
         fixture.evalIds.map((value) => asGovernanceIdentifier(value)),
@@ -250,8 +261,8 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`EvalsRepository.sample` is one", async () => {
-    await pin("evals.sample", 1, (fixture) =>
+  test("`EvalsRepository.sample` is one read beside the resolve", async () => {
+    await pin("evals.sample", 2, (fixture) =>
       harness.stores.evals.sample(fixture.scope, {
         agentId: asGovernanceIdentifier<AgentId>(fixture.ids.agentId),
         since: SINCE,
@@ -260,14 +271,14 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`CriteriaRepository.findMany` is one for the whole label set", async () => {
-    await pin("criteria.findMany", 1, (fixture) =>
+  test("`CriteriaRepository.findMany` is one read for the whole label set", async () => {
+    await pin("criteria.findMany", 2, (fixture) =>
       harness.stores.criteria.findMany(fixture.scope, [fixture.criterionId]),
     );
   });
 
-  test("`CriteriaRepository.page` is two", async () => {
-    await pin("criteria.page", 2, (fixture) =>
+  test("`CriteriaRepository.page` is three", async () => {
+    await pin("criteria.page", 3, (fixture) =>
       harness.stores.criteria.page(fixture.scope, {
         limit: 10,
         offset: 0,
@@ -277,16 +288,17 @@ describe("reads are a fixed number of statements, whatever the row count", () =>
     );
   });
 
-  test("`RatingsRepository.sample` is one", async () => {
-    await pin("ratings.sample", 1, (fixture) =>
+  test("`RatingsRepository.sample` is one read beside the resolve", async () => {
+    await pin("ratings.sample", 2, (fixture) =>
       harness.stores.ratings.sample(fixture.scope, { since: SINCE, agentId: null }),
     );
   });
 });
 
 describe("the writes are a fixed number too", () => {
-  test("`upsert` is TWO on both paths, so the count is a pin and not a path", async () => {
-    // The CREATE path: a scoped update that matches nothing, then the insert.
+  test("`upsert` is THREE on both paths, so the count is a pin and not a path", async () => {
+    // The CREATE path: the ancestry resolve, a scoped update that matches
+    // nothing, then the insert.
     const created = await measure(() =>
       runResult(harness.base.adapter.unitOfWork, (transaction) =>
         harness.stores.ratings.upsert(
@@ -304,7 +316,8 @@ describe("the writes are a fixed number too", () => {
         ),
       ),
     );
-    // The FLIP path: the same scoped update, matching, then the read back.
+    // The FLIP path: the same resolve, the same scoped update, matching, then
+    // the read back.
     const flipped = await measure(() =>
       runResult(harness.base.adapter.unitOfWork, (transaction) =>
         harness.stores.ratings.upsert(
@@ -322,11 +335,12 @@ describe("the writes are a fixed number too", () => {
         ),
       ),
     );
-    expect({ created: created.counted, flipped: flipped.counted }).toEqual({ created: 2, flipped: 2 });
+    expect({ created: created.counted, flipped: flipped.counted }).toEqual({ created: 3, flipped: 3 });
   });
 
-  test("`anonymizeSubject` is ONE update, however many rows it rewrites", async () => {
-    // Two rows in the small fixture, forty in the large, one statement in both.
+  test("`anonymizeSubject` is ONE update beside the resolve, however many rows it rewrites", async () => {
+    // Two rows in the small fixture, forty in the large, one UPDATE in both —
+    // beside the one resolve every environment-scoped method carries.
     const smallResult = await measure(() =>
       runResult(harness.base.adapter.unitOfWork, (transaction) =>
         harness.stores.safety.anonymizeSubject(
@@ -343,10 +357,10 @@ describe("the writes are a fixed number too", () => {
         ),
       ),
     );
-    expect({ small: smallResult.counted, large: largeResult.counted }).toEqual({ small: 1, large: 1 });
+    expect({ small: smallResult.counted, large: largeResult.counted }).toEqual({ small: 2, large: 2 });
   });
 
-  test("`criteria.update` is THREE, and the order is scope, name, write", async () => {
+  test("`criteria.update` is FOUR: the ancestry, the scope, the name, the write", async () => {
     const found = await harness.stores.criteria.findById(small.scope, small.criterionId);
     expect(found.ok && found.value).not.toBeNull();
     if (!found.ok || found.value === null) return;
@@ -359,6 +373,6 @@ describe("the writes are a fixed number too", () => {
         ),
       ),
     );
-    expect(measured.counted).toBe(3);
+    expect(measured.counted).toBe(4);
   });
 });

--- a/packages/contexts/governance/application/ports/index.ts
+++ b/packages/contexts/governance/application/ports/index.ts
@@ -140,7 +140,13 @@ export { parseJudgeModel } from "../../domain/index.js";
 // in every method above, and an adapter reaching for `@platos/kernel` directly
 // would be a second import edge into the kernel from a package whose only
 // declared dependency is the context whose ports it satisfies.
-export type { EnvironmentScope, JsonValue, NotResult, Result, TenantScope, TransactionScope } from "@platos/kernel";
+// WIN-303 adds `DomainError`. The five stores' scope resolver is handed the
+// refusal constructor it must use, one per store, so the five codes are chosen
+// at the five call sites rather than switched on inside a shared helper — and a
+// function type over those constructors has to be able to name what they
+// return. It is the type every constructor in `domain/errors.ts` already
+// answers with, so publishing it adds no surface the port did not have.
+export type { DomainError, EnvironmentScope, JsonValue, NotResult, Result, TenantScope, TransactionScope } from "@platos/kernel";
 // WIN-260 (M2.5): `runResult` joins them, and `NotResult` beside it.
 // `UnitOfWork.run` REFUSES a callback whose answer is a `Result` — such a
 // callback RESOLVES, and a resolved callback COMMITS, which is the defect
@@ -213,4 +219,18 @@ export {
   PII_DETECTORS,
   ratingTargetUnreadable,
   transcriptUnreadable,
+  // WIN-303 — one scope refusal per canonical store, published for the same
+  // reason the three above are: an adapter narrowing by the environment alone
+  // serves a tampered triple, and the code it must refuse under is a property of
+  // the CONTRACT rather than of whichever adapter happens to notice. Five and
+  // not one so a resolver dropped from a single store cannot hide behind the
+  // other four. `governance-scope.ts` is the only implementation today, and the
+  // in-memory doubles deliberately raise none of them: a double holds no tenant
+  // tree, so a forged ancestry and a real one are the same value to it — the
+  // argument `tools-scope.ts` makes about its own two refusals.
+  criteriaScopeUnresolved,
+  evalsScopeUnresolved,
+  goldenSetsScopeUnresolved,
+  ratingsScopeUnresolved,
+  safetyScopeUnresolved,
 } from "../../domain/index.js";

--- a/packages/contexts/governance/contracts/index.test.ts
+++ b/packages/contexts/governance/contracts/index.test.ts
@@ -64,7 +64,7 @@ describe("the published error codes", () => {
     expect(new Set(GOVERNANCE_ERROR_CODES).size).toBe(GOVERNANCE_ERROR_CODES.length);
   });
 
-  it("publishes one code per distinguishable refusal — 36 of them", () => {
+  it("publishes one code per distinguishable refusal — 41 of them", () => {
     // Pinned as a literal so a code merged into another, which is how two guards
     // become indistinguishable, cannot pass unnoticed.
     //
@@ -74,7 +74,13 @@ describe("the published error codes", () => {
     // the activity seam's failure rather than refusing, so a shared code would
     // leave the one failure an operator cannot see indistinguishable from the
     // two they can.
-    expect(GOVERNANCE_ERROR_CODES).toHaveLength(36);
+    //
+    // WIN-303: 36 -> 41. One per CANONICAL STORE, for a scope that does not
+    // join up in the tenant tree. Five and not one for the same reason the three
+    // above are three: the guard is instantiated once per store, over five
+    // different sets of tables, and a resolver dropped from a SINGLE store must
+    // not be able to hide behind the other four still refusing.
+    expect(GOVERNANCE_ERROR_CODES).toHaveLength(41);
   });
 
   it("keeps the four golden-set refusals apart from each other", () => {

--- a/packages/contexts/governance/domain/errors.test.ts
+++ b/packages/contexts/governance/domain/errors.test.ts
@@ -9,8 +9,10 @@ import {
   criterionNotFound,
   criterionPromptInvalid,
   criterionRubricInvalid,
+  criteriaScopeUnresolved,
   criterionScaleInvalid,
   erasurePlanForeign,
+  evalsScopeUnresolved,
   evalNotFound,
   evalSelfJudged,
   evalsDisabled,
@@ -20,6 +22,7 @@ import {
   goldenSetTooManyCriteria,
   goldenSetTooManyPairs,
   goldenSetTooManyThreads,
+  goldenSetsScopeUnresolved,
   activityUnreadable,
   judgeModelInvalid,
   judgeUnavailable,
@@ -28,12 +31,14 @@ import {
   queueUnavailable,
   ratingActorForbidden,
   ratingCommentTooLong,
+  ratingsScopeUnresolved,
   ratingTargetNotFound,
   ratingTargetUnreadable,
   ratingValueInvalid,
   safetyActionUnknown,
   safetyDetectorUnknown,
   safetyRuleMalformed,
+  safetyScopeUnresolved,
   safetySeverityUnknown,
   scopeMismatch,
   transcriptNotFound,
@@ -51,6 +56,16 @@ const EVERY_CONSTRUCTOR = [
   ratingTargetUnreadable("no environment"),
   transcriptUnreadable("no environment"),
   activityUnreadable("no environment"),
+  // WIN-303 — the five canonical stores' own scope refusals. FIVE constructors
+  // and not one, for the reason the three above are three: this guard is
+  // instantiated once per store, and a resolver dropped from ONE of them must
+  // not be able to hide behind the other four still refusing. The uniqueness
+  // assertion below is what holds that.
+  safetyScopeUnresolved("foreign_ancestry"),
+  ratingsScopeUnresolved("foreign_ancestry"),
+  criteriaScopeUnresolved("foreign_ancestry"),
+  evalsScopeUnresolved("foreign_ancestry"),
+  goldenSetsScopeUnresolved("foreign_ancestry"),
   pageRequestInvalid("bad"),
   safetyRuleMalformed("nope"),
   safetyDetectorUnknown("nope"),
@@ -127,6 +142,25 @@ describe("the catalogue", () => {
 describe("categories carry the decision, not just the sentence", () => {
   it("a cross-scope grant is FORBIDDEN — the grant resolved, elsewhere", () => {
     expect(scopeMismatch("a", "b").category).toBe("forbidden");
+  });
+
+  it("a scope that does not join up in the tree is INTERNAL, never retryable", () => {
+    // The same argument the three read-seam codes carry: an incoherent scope is
+    // a defect in whatever built the grant, so the call will fail identically
+    // for ever. `unavailable` would attach `retryAfterSeconds` and the transport
+    // would repeat that lie on every attempt.
+    for (const error of [
+      safetyScopeUnresolved("foreign_ancestry"),
+      ratingsScopeUnresolved("foreign_ancestry"),
+      criteriaScopeUnresolved("foreign_ancestry"),
+      evalsScopeUnresolved("foreign_ancestry"),
+      goldenSetsScopeUnresolved("foreign_ancestry"),
+    ]) {
+      expect({ category: error.category, retryAfterSeconds: error.retryAfterSeconds }).toEqual({
+        category: "internal",
+        retryAfterSeconds: null,
+      });
+    }
   });
 
   it("an operator writing an end user's rating is FORBIDDEN, not invalid input", () => {

--- a/packages/contexts/governance/domain/errors.test.ts
+++ b/packages/contexts/governance/domain/errors.test.ts
@@ -148,7 +148,7 @@ describe("categories carry the decision, not just the sentence", () => {
     // The same argument the three read-seam codes carry: an incoherent scope is
     // a defect in whatever built the grant, so the call will fail identically
     // for ever. `unavailable` would attach `retryAfterSeconds` and the transport
-    // would repeat that lie on every attempt.
+    // would repeat that lie on every call.
     for (const error of [
       safetyScopeUnresolved("foreign_ancestry"),
       ratingsScopeUnresolved("foreign_ancestry"),

--- a/packages/contexts/governance/domain/errors.ts
+++ b/packages/contexts/governance/domain/errors.ts
@@ -53,6 +53,11 @@ export const GOVERNANCE_ERROR_CODES = [
   "GOVERNANCE_RATING_TARGET_UNREADABLE",
   "GOVERNANCE_TRANSCRIPT_UNREADABLE",
   "GOVERNANCE_ACTIVITY_UNREADABLE",
+  "GOVERNANCE_SAFETY_SCOPE_UNRESOLVED",
+  "GOVERNANCE_RATINGS_SCOPE_UNRESOLVED",
+  "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+  "GOVERNANCE_EVALS_SCOPE_UNRESOLVED",
+  "GOVERNANCE_GOLDEN_SETS_SCOPE_UNRESOLVED",
   "GOVERNANCE_PAGE_REQUEST_INVALID",
   "GOVERNANCE_SAFETY_RULE_MALFORMED",
   "GOVERNANCE_SAFETY_DETECTOR_UNKNOWN",
@@ -199,6 +204,103 @@ export function activityUnreadable(reason: string): DomainError {
     "GOVERNANCE_ACTIVITY_UNREADABLE",
     "internal",
     "activity reader could not resolve its environment",
+    { details: { reason } },
+  );
+}
+
+// --- the five canonical stores' own refusals ------------------------------------
+//
+// WIN-303. FIVE CODES FOR ONE SENTENCE, AND THE SENTENCE IS "THIS STORE WAS
+// HANDED A SCOPE THAT DOES NOT JOIN UP IN THE TENANT TREE".
+//
+// THE DEFECT THEY CLOSE. A scope is a TRIPLE — organization, project,
+// environment — and until now the five canonical stores narrowed every read and
+// every write by the environment ALONE. `Environment.id` is a globally unique
+// uuid, so the environment determines the other two and the extra members look
+// redundant; they are not, and the case they catch is the one worth having: a
+// grant assembled with a REAL environment and SOMEBODY ELSE'S project or
+// organization. That scope is not a typo. It is a scope that has been tampered
+// with, or built by a bug in whatever resolved the grant, and a store narrowing
+// by the leaf alone SERVES IT. The three read seams already refuse exactly this
+// (see `activityUnreadable` above and `governance-seam-guards.ts`); these five
+// are the same rejection at the stores this context owns the rows of.
+//
+// WHY FIVE AND NOT ONE. Lesson 5, and the shape this catalogue's own header
+// gives it: two guards sharing a code cannot be told apart in a log, and this
+// guard is instantiated FIVE times — once per store — over five different sets
+// of tables written by five different call paths. An operator holding one code
+// would know a governance scope was refused and not which port refused it, so a
+// resolver silently dropped from ONE store would be invisible beside the other
+// four still refusing. They are also what makes the mutation ledger's five
+// entries separable: deleting the safety resolver must turn a case red that the
+// ratings resolver cannot turn green.
+//
+// WHY NOT `ledgerUnavailable`, WHICH IS WHAT THE STORES REACH FOR OTHERWISE.
+// That code is `unavailable` and carries `retryAfterSeconds: 5`. An incoherent
+// scope will fail the same way for ever, so telling the caller to retry in five
+// seconds is a lie the transport would repeat — the same argument the three
+// seam codes above are built on, and the reason all eight are `internal`.
+//
+// WHY NOT `GOVERNANCE_SCOPE_MISMATCH`, WHICH SOUNDS LIKE IT. That one is the
+// AUTHORIZATION layer's: `authorization.ts` raises it when a grant resolves to a
+// different place in the tree than the caller asked for, and the caller's own
+// request is what disagrees. These five are raised BELOW that, in the adapter,
+// about a scope that has already been authorized and still does not exist as a
+// path in the database. Collapsing them would put "your grant is for another
+// project" and "the grant you were given is incoherent" under one code.
+//
+// EACH CARRIES A `reason` NAMING WHICH OF THREE FACTS IT IS: the scope's
+// identifiers are not uuid-shaped and no statement could be sent at all; the
+// environment resolves to no row; or the environment exists under a project or
+// an organization other than the one claimed. `governance-scope.ts` mints the
+// three strings, once.
+
+/** The `SafetyLedger` was handed a scope that does not resolve in the tree. */
+export function safetyScopeUnresolved(reason: string): DomainError {
+  return domainError(
+    "GOVERNANCE_SAFETY_SCOPE_UNRESOLVED",
+    "internal",
+    "safety ledger could not resolve its scope in the tenant tree",
+    { details: { reason } },
+  );
+}
+
+/** The `RatingsRepository` was handed a scope that does not resolve in the tree. */
+export function ratingsScopeUnresolved(reason: string): DomainError {
+  return domainError(
+    "GOVERNANCE_RATINGS_SCOPE_UNRESOLVED",
+    "internal",
+    "ratings repository could not resolve its scope in the tenant tree",
+    { details: { reason } },
+  );
+}
+
+/** The `CriteriaRepository` was handed a scope that does not resolve in the tree. */
+export function criteriaScopeUnresolved(reason: string): DomainError {
+  return domainError(
+    "GOVERNANCE_CRITERIA_SCOPE_UNRESOLVED",
+    "internal",
+    "criteria repository could not resolve its scope in the tenant tree",
+    { details: { reason } },
+  );
+}
+
+/** The `EvalsRepository` was handed a scope that does not resolve in the tree. */
+export function evalsScopeUnresolved(reason: string): DomainError {
+  return domainError(
+    "GOVERNANCE_EVALS_SCOPE_UNRESOLVED",
+    "internal",
+    "evals repository could not resolve its scope in the tenant tree",
+    { details: { reason } },
+  );
+}
+
+/** The `GoldenSetsRepository` was handed a scope that does not resolve in the tree. */
+export function goldenSetsScopeUnresolved(reason: string): DomainError {
+  return domainError(
+    "GOVERNANCE_GOLDEN_SETS_SCOPE_UNRESOLVED",
+    "internal",
+    "golden sets repository could not resolve its scope in the tenant tree",
     { details: { reason } },
   );
 }

--- a/scripts/arch/arch-boundaries.test.mjs
+++ b/scripts/arch/arch-boundaries.test.mjs
@@ -1230,7 +1230,12 @@ describe("ADR M0.3 boundary enforcement — each rule catches a violation and pa
     // the first file this programme has added under `apps/core-api/src/` that is
     // an integration suite, and it lands in this census for the reason G1's did:
     // the scan does not exclude them. 1620 + 1 = 1621.
-    assert.equal(result.fileCount, 1621, "the generated V1 source census must stay exact");
+    // WIN-303 1621 + 2 = 1623: `governance-scope.ts` and
+    // `governance-isolation.integration.test.ts`, the same two files
+    // `env-access.mjs`'s EXPECTED_FILE_COUNT and `max-file-lines.test.mjs`'s
+    // adapters term move by — one scan, three pins, so a file that arrived in
+    // one and not the others could not pass all three.
+    assert.equal(result.fileCount, 1623, "the generated V1 source census must stay exact");
     assert.equal(result.fileCount, 397 + 44 + 55 + 51 + 77 + 63 + 48 + 48 + 67 + 56 + 42 + 83 + 8 + 34 + 18 + 74 + 12 + 22 + 11 + 9 + 6 + 18 + 16 + 16 + 1 + 15 + 18 + 19 + 16 + 20 + 17 + 21 + 14 + 17 + 18 + 12 + 14 + 7 + 3 + 4 + 2 + 9 + 1 +
       // projection 10, lifecycle 24, errors-and-idempotency 23,
       // outbox/transaction-outcome 8.
@@ -1257,7 +1262,10 @@ describe("ADR M0.3 boundary enforcement — each rule catches a violation and pa
       6 +
       // WIN-267 integration: the operator-authentication suite in
       // `apps/core-api/src/composition/`.
-      1);
+      1 +
+      // WIN-303: postgres-tenancy 2 -- `governance-scope.ts`, the tenant-triple
+      // resolver, and `governance-isolation.integration.test.ts` beside it.
+      2);
     assert.equal(result.violations.length, 0, "the current tree must have zero boundary violations");
   });
 });

--- a/scripts/arch/env-access.mjs
+++ b/scripts/arch/env-access.mjs
@@ -458,8 +458,21 @@ export const VIOLATION_CODES = Object.freeze({
  * so no variable is READ from `process.env` and no new door is opened. A suite
  * that had reached for the ambient environment instead would move this table and
  * fail the gate. 1620 + 1 = 1621.
+ *
+ * WIN-303 ADDS TWO, AND THE DECLARED TABLE IS UNMOVED BY BOTH.
+ * `packages/adapters/postgres-tenancy/src/governance-scope.ts` resolves the
+ * tenant triple against `Environment` and `Project` before the five canonical
+ * stores send anything; it reads a DATABASE, not an environment, and its client
+ * arrives through `TenancyTransactions` from the composition root exactly as
+ * every other file in that directory's does. 1621 + 1 = 1622.
+ *
+ * And `governance-isolation.integration.test.ts`, the two-tenant proof beside
+ * it, which reaches the container only through `governance-harness.ts` — the
+ * file `env-access.mjs` already declares as one of the harnesses entitled to
+ * read the ambient environment. A second reader in a suite would be an
+ * undeclared door and would move this table. 1622 + 1 = 1623.
  */
-export const EXPECTED_FILE_COUNT = 1621;
+export const EXPECTED_FILE_COUNT = 1623;
 
 function listSourceFiles(root) {
   const found = [];

--- a/scripts/arch/max-file-lines.test.mjs
+++ b/scripts/arch/max-file-lines.test.mjs
@@ -853,9 +853,10 @@ test("the live selectors scan an exact nonzero source census", () => {
   // six are under the 400 warning band -- and the split into four source files
   // rather than one is what keeps them there, since a single
   // `governance-read-seams.ts` holding all three seams would have been 260.
+  // WIN-303 1580 -> 1582: two files in `packages/adapters`, itemised below.
   // SUMMED FOR THE INTEGRATION: 1572 + 2 (G1) + 6 (G2) = 1580, and the
   // ADAPTERS term is still the only one that moves.
-  assert.equal(result.fileCount, 1580);
+  assert.equal(result.fileCount, 1582);
   // Written out so a DELETION CANNOT HIDE INSIDE AN ADDITION: adoption replaces
   // a context's four placeholders in place and adds the rest, so this number
   // only ever grows and a fall in it is always a finding.
@@ -888,7 +889,14 @@ test("the live selectors scan an exact nonzero source census", () => {
       // long-standing selector, and adding nothing to any other term: the three
       // ports were already declared by the context and the composition root's
       // rows are edits.
-      6
+      6 +
+      // WIN-303: TWO under `packages/adapters/postgres-tenancy/src/` --
+      // `governance-scope.ts`, the tenant-triple resolver the five canonical
+      // stores now sit behind, and `governance-isolation.integration.test.ts`,
+      // its two-tenant proof. Newly WRITTEN, inside the same long-standing
+      // selector, and adding nothing to any other term: the five stores,
+      // `governance-rows.ts` and `governance-seam-guards.ts` are edits.
+      2
   );
   // The adapters row of the four-way disjoint scan carries every tranche, and
   // tranche 5 contributes FIVE times because it landed four canonical stores in
@@ -1037,9 +1045,14 @@ test("the live selectors scan an exact nonzero source census", () => {
   // the composition root's rows are all EDITS to files that already existed and
   // move no count.
   // SUMMED: 441 + 2 (G1) + 6 (G2) = 449.
-  //   ADAPTERS        449
-  // 27 + 1075 + 449 + 13 + 16 = 1580.
-  assert.equal(result.fileCount, 27 + 1075 + 449 + 13 + 16);
+  // WIN-303 449 -> 451: `governance-scope.ts` and
+  // `governance-isolation.integration.test.ts`. The five stores,
+  // `governance-rows.ts`, `governance-seam-guards.ts` and the statements suite
+  // are edits and move no count — though the stores do grow, which is why the
+  // warning band is re-read rather than assumed.
+  //   ADAPTERS        451
+  // 27 + 1075 + 451 + 13 + 16 = 1582.
+  assert.equal(result.fileCount, 27 + 1075 + 451 + 13 + 16);
   assert.deepEqual(result.errors, []);
   assert.equal(result.findings.filter((finding) => finding.severity === "error").length, 0);
   // Stricter than the gate, on purpose. `audit:max-file-lines` exits 0 on a
@@ -1154,7 +1167,7 @@ test("the live selectors scan an exact nonzero source census", () => {
   //   cost-constraints.integration.test.ts          453 -> 454  (+1)
   //   files-scope.integration.test.ts               467 -> 468  (+1)
   //   governance-conformance.ts                     418 -> 420  (+2)
-  //   governance-rules.integration.test.ts          424 -> 425  (+1)
+  //   governance-rules.integration.test.ts          424 -> 425  (+1); WIN-303 -> 426
   //   memory-constraints.integration.test.ts        406 -> 409  (+3)
   //   providers-conformance.ts                      421 -> 423  (+2)
   //   secrets-rules.integration.test.ts             439 -> 441  (+2)
@@ -1223,7 +1236,13 @@ test("the live selectors scan an exact nonzero source census", () => {
     },
     {
       path: "packages/adapters/postgres-tenancy/src/governance-rules.integration.test.ts",
-      effectiveLines: 425,
+      // WIN-303 425 -> 426: ONE assertion added to an existing case, naming
+      // WHICH refusal the cross-tenant flip produces. `mutations-governance.json`
+      // M-G19 was vacuous without it -- the mutated statement rewrites the other
+      // tenant's row and the unit of work then ROLLS IT BACK, so every other
+      // assertion in that case stayed green. No new case, so the test-case
+      // census does not move for it.
+      effectiveLines: 426,
       severity: "warning",
     },
     {

--- a/scripts/arch/test-case-census.mjs
+++ b/scripts/arch/test-case-census.mjs
@@ -2547,7 +2547,20 @@ export const EXPECTED = Object.freeze({
   // SUMMED FOR THE INTEGRATION: 136 + 1 (G1) + 2 (G2) = 139 files,
   // 1506 + 13 (G1) + 28 (G2) = 1547 cases. Neither branch could state this
   // row and neither is right on its own.
-  "packages/adapters/postgres-tenancy": { files: 139, cases: 1547 },
+  //
+  // WIN-303: 139 + 1 = 140 files, 1547 + 11 = 1558 cases. ONE file,
+  // `governance-isolation.integration.test.ts`, and every one of its eleven
+  // cases needs TWO tenants in a container — which is the only shape in which a
+  // TAMPERED scope triple exists at all. Five cases are one per canonical store
+  // (a forged ancestry refused under that store's own code, with the honest
+  // scope answered in the same case so an unconditional refusal fails too, and
+  // the row read back on a second client); four separate the three FACTS the
+  // resolver reports, including the two that kill the organization half and the
+  // project half of the comparison ON THEIR OWN; two hold a TENANT scope to the
+  // ancestry it asserts and to no more. `governance-statements.integration.test.ts`
+  // is widened rather than added to — fifteen pins move by the one resolve and
+  // not one case is new, so this row gains a file and not two.
+  "packages/adapters/postgres-tenancy": { files: 140, cases: 1558 },
   // WIN-260 adopts this project and gives it its first suites.
   //
   // WIN-267 A3 4 -> 6 files, 65 -> 84 cases: `providers`' `ProviderProbeCache`
@@ -2595,7 +2608,14 @@ export const EXPECTED = Object.freeze({
   "packages/contexts/cost-monitoring": { files: 21, cases: 352 },
   "packages/contexts/eventing": { files: 15, cases: 157 },
   "packages/contexts/files": { files: 15, cases: 134 },
-  "packages/contexts/governance": { files: 31, cases: 609 },
+  // WIN-303: 609 -> 610 cases, files unmoved. ONE case in `domain/errors.test.ts`
+  // — the five new store-scope codes are `internal` and carry no
+  // `retryAfterSeconds`, which is the difference from `ledgerUnavailable` beside
+  // them and the reason they are not it: an incoherent scope will fail the same
+  // way for ever, so a retry hint would be a lie the transport repeats. The five
+  // constructors themselves move the EXISTING uniqueness case's list rather than
+  // adding one, which is not a new case.
+  "packages/contexts/governance": { files: 31, cases: 610 },
   "packages/contexts/identity-access": { files: 23, cases: 318 },
   "packages/contexts/jobs": { files: 16, cases: 386 },
   "packages/contexts/memory": { files: 28, cases: 605 },
@@ -3429,8 +3449,22 @@ export const EXPECTED = Object.freeze({
  * 545 + 1 + 2 = 548 files, all forty-one cases on the ONE
  * `packages/adapters/postgres-tenancy` row. READ BACK from
  * `node scripts/arch/test-case-census.mjs`, not trusted from this sum.
+ *
+ * WIN-303 DELTA, the tampered scope triple. TWO rows move, and 12 = 11 + 1:
+ *
+ *   packages/adapters/postgres-tenancy 139 -> 140 files, 1547 -> 1558 cases
+ *   packages/contexts/governance        31 ->  31 files,  609 ->  610 cases
+ *
+ * ELEVEN of the twelve carry `.integration.` in the name and need a container,
+ * because a tampered triple is a scope only TWO seeded tenants can express. The
+ * twelfth is a category assertion in `domain/errors.test.ts` and runs anywhere.
+ *
+ * 8112 + 12 = 8124 over 548 + 1 = 549 files, READ BACK from
+ * `node scripts/arch/test-case-census.mjs` rather than trusted from this sum.
+ * Two sibling branches move these pins in the same window, so the integrator
+ * SUMS the deltas rather than taking any one branch's total.
  */
-export const EXPECTED_RUNTIME_TOTAL = 8112;
+export const EXPECTED_RUNTIME_TOTAL = 8124;
 
 /** Every case-declaring package directory, in byte order. */
 export function listPackages(root = repositoryRoot) {

--- a/scripts/arch/test-case-census.test.mjs
+++ b/scripts/arch/test-case-census.test.mjs
@@ -441,7 +441,11 @@ test("the census is not vacuous — it reads the real suites", () => {
   // 545 + 1 = 546.
   // WIN-267 G2 adds TWO more: `governance-read-seams.test.ts` and
   // `governance-read-seams.integration.test.ts`. SUMMED: 545 + 1 + 2 = 548.
-  assert.equal(live.totalFiles, 548);
+  // WIN-303 548 -> 549: ONE more on the same row,
+  // `governance-isolation.integration.test.ts`, the eleven-case two-tenant
+  // proof that a TAMPERED scope triple is refused rather than served. 548 + 1
+  // = 549.
+  assert.equal(live.totalFiles, 549);
   // The sum is written out beside the literal so a file that vanished while
   // governance's 31, the prerequisite's 4, the adapter's 17 and conversations'
   // 29 arrived cannot reach the same total. Each dimension appends its own
@@ -452,7 +456,9 @@ test("the census is not vacuous — it reads the real suites", () => {
   // of the new `node-crypto-digest`, and the seven of the new
   // `tokenmint-totp`. G1 appends `+ 1`, postgres-tenancy's eval-run queue suite;
   // G2 appends `+ 2`, the two read-seam suites on the same row. SUMMED: `+ 3`.
-  assert.equal(live.totalFiles, 88 + 14 + 20 + 16 + 28 + 21 + 15 + 15 + 25 + 19 + 15 + 31 + 4 + 2 + 15 + 29 + 1 + 2 + 4 + 3 + 4 + 7 + 5 + 4 + 4 + 6 + 6 + 6 + 1 + 6 + 6 + 9 + 7 + 8 + 6 + 7 + 6 + 7 + 7 + 5 + 6 + 3 + 6 + 3 + 1 + 1 + 2 + 1 + 2 + 6 + 2 + 1 + 3 + 1 + 3 + 1 + 2 + 1 + 1 + 1 + 2 + 7 + 3 + 2 + 3);
+  // WIN-303 appends `+ 1`, `governance-isolation.integration.test.ts`, on that
+  // same postgres-tenancy row and on no other.
+  assert.equal(live.totalFiles, 88 + 14 + 20 + 16 + 28 + 21 + 15 + 15 + 25 + 19 + 15 + 31 + 4 + 2 + 15 + 29 + 1 + 2 + 4 + 3 + 4 + 7 + 5 + 4 + 4 + 6 + 6 + 6 + 1 + 6 + 6 + 9 + 7 + 8 + 6 + 7 + 6 + 7 + 7 + 5 + 6 + 3 + 6 + 3 + 1 + 1 + 2 + 1 + 2 + 6 + 2 + 1 + 3 + 1 + 3 + 1 + 2 + 1 + 1 + 1 + 2 + 7 + 3 + 2 + 3 + 1);
   assert.equal(live.nonExecuting, 0);
   assert.deepEqual(live.refusals, []);
   assert.ok(listPackages().includes("packages/kernel"));
@@ -641,8 +647,9 @@ test("the pinned rows sum to the pinned runtime total", () => {
   // WIN-267 G1 545 -> 546: ONE suite in `postgres-tenancy`, the eval-run
   // queue's. WIN-267 G2 546 -> 548: TWO more on the same row, the read
   // seams' schema join and their two-tenant proof. SUMMED: 545 + 3 = 548.
-  assert.equal(files, 548);
-  assert.equal(files, 503 + 6 + 12 + 5 + (2 + 1 + 1) + (1 + 2) + 7 + 3 + 2 + 3);
+  // WIN-303 548 -> 549, the tampered-triple proof. 545 + 4 = 549.
+  assert.equal(files, 549);
+  assert.equal(files, 503 + 6 + 12 + 5 + (2 + 1 + 1) + (1 + 2) + 7 + 3 + 2 + 3 + 1);
 });
 
 test("the split the 2026-09-02 verification reproduced is pinned per package", () => {
@@ -795,7 +802,13 @@ test("the providers context is pinned at what vitest prints", () => {
   // re-derivations below carries the same term, which is the property this
   // file exists for — a sum stated once can be edited once, and a sum stated
   // eleven ways cannot.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  // WIN-303 appends `+ 11 + 1` to every one of the TWELVE re-derivations in
+  // this file: eleven cases in `governance-isolation.integration.test.ts` on
+  // the postgres-tenancy row, and ONE category case on `governance`'s own
+  // row. Two terms because two rows move — which is the property this file
+  // exists for, since a sum stated twelve ways cannot be edited in one place
+  // and a term dropped from one of them shows up here rather than in the pin.
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the skills adoption is pinned, and moved nothing else", () => {
@@ -932,7 +945,13 @@ test("the skills adoption is pinned, and moved nothing else", () => {
     // above is: `untouched` carries CONTEXT rows, and `governance` gained no
     // case at all -- its three error constructors and three port re-exports
     // are asserted where they are USED, in the adapter's own 28.
-    sum + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 1 + 1 + 71 + 12 + 5 + 8 + 5 + 9 + 40 + 25 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28,
+    // WIN-303 appends `+ 11`, the tampered-triple proof, as a trailing term for
+    // the same reason -- and moves the `governance` term 609 -> 610 IN PLACE,
+    // because unlike its three predecessors this tranche DID add a case to the
+    // context: the five new store-scope codes are held to `internal` with no
+    // retry hint in `domain/errors.test.ts`. The two halves land in different
+    // places in this sum, which is the whole reason it is written out.
+    sum + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 610 + 198 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 1 + 1 + 71 + 12 + 5 + 8 + 5 + 9 + 40 + 25 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11,
     EXPECTED_RUNTIME_TOTAL,
   );
 });
@@ -969,7 +988,7 @@ test("the memory context is pinned at what vitest prints", () => {
   // alone; here the identity only closes with every adoption's term present.
   assert.equal(EXPECTED["packages/contexts/memory"].files, 28);
   assert.equal(EXPECTED["packages/contexts/memory"].cases, 605);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the cost-monitoring context is pinned at what vitest prints", () => {
@@ -999,7 +1018,7 @@ test("the cost-monitoring context is pinned at what vitest prints", () => {
   // with every adoption's term present.
   assert.equal(EXPECTED["packages/contexts/cost-monitoring"].files, 21);
   assert.equal(EXPECTED["packages/contexts/cost-monitoring"].cases, 352);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the privacy context is pinned at what vitest prints", () => {
@@ -1037,7 +1056,7 @@ test("the privacy context is pinned at what vitest prints", () => {
   // observability's 288 and agents' 515 included.
   assert.equal(EXPECTED["packages/contexts/privacy"].cases, 240 + 12 + 2);
   assert.equal(EXPECTED["packages/contexts/privacy"].files, 15, "the file count did NOT move; the case count did");
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the observability context is pinned at what vitest prints", () => {
@@ -1070,7 +1089,7 @@ test("the observability context is pinned at what vitest prints", () => {
   // agents' 515 included.
   assert.equal(EXPECTED["packages/contexts/observability"].files, 15);
   assert.equal(EXPECTED["packages/contexts/observability"].cases, 281 + 6 + 1);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the agents context is pinned at what vitest prints", () => {
@@ -1113,7 +1132,7 @@ test("the agents context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/agents"].files, 25);
   assert.equal(EXPECTED["packages/contexts/agents"].cases, 515);
   assert.equal(EXPECTED["packages/contexts/agents"].cases, 513 + 4 - 3 - 1 + 2);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the tools context is pinned at what vitest prints", () => {
@@ -1142,7 +1161,7 @@ test("the tools context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/tools"].files, 19);
   assert.equal(EXPECTED["packages/contexts/tools"].cases, 362);
   assert.equal(EXPECTED["packages/contexts/tools"].cases, 325 + 29 + 6 + 2);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the channels context is pinned at what vitest prints", () => {
@@ -1177,7 +1196,7 @@ test("the channels context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/channels"].files, 15);
   assert.equal(EXPECTED["packages/contexts/channels"].cases, 269);
   assert.equal(EXPECTED["packages/contexts/channels"].cases, 263 + 4 + 1 + 1);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the governance context is pinned at what vitest prints", () => {
@@ -1200,10 +1219,15 @@ test("the governance context is pinned at what vitest prints", () => {
   // was right alone — it branched from the agents branch, so agents' 515 was
   // the only other adoption it could see. Here the identity only closes with
   // every adoption's term present, and 2124 would be short by 3376.
+  // WIN-303 609 -> 610: ONE case in `domain/errors.test.ts`, holding the five
+  // new store-scope codes to `internal` with no `retryAfterSeconds` — the
+  // difference from `ledgerUnavailable` beside them, and the reason they are not
+  // it. The five constructors themselves widen the EXISTING uniqueness case's
+  // list, which is not a new case.
   assert.equal(EXPECTED["packages/contexts/governance"].files, 31);
-  assert.equal(EXPECTED["packages/contexts/governance"].cases, 609);
-  assert.equal(EXPECTED["packages/contexts/governance"].cases, 586 + 1 + 22);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED["packages/contexts/governance"].cases, 610);
+  assert.equal(EXPECTED["packages/contexts/governance"].cases, 586 + 1 + 22 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
   assert.equal(
     EXPECTED_RUNTIME_TOTAL,
     Object.values(EXPECTED).reduce((total, row) => total + row.cases, 0)
@@ -1229,7 +1253,7 @@ test("the model-router adapter is pinned at what vitest prints", () => {
   // caught it at 5525 against an actual 5875.
   assert.equal(EXPECTED["packages/adapters/model-router-providers"].files, 15);
   assert.equal(EXPECTED["packages/adapters/model-router-providers"].cases, 198);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the WIN-257 identity-access contract suite is pinned at what vitest prints", () => {
@@ -1319,7 +1343,7 @@ test("the conversations context is pinned at what vitest prints", () => {
   // above do NOT move for any of them: all four implement ports that already
   // existed and all four had their port entry point widened in place, which is
   // what this census distinguishes from an addition.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 5525 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 5525 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
 });
 
 test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
@@ -1589,7 +1613,14 @@ test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
     // exclusivity under real concurrency, redelivery after a lease expires, and
     // an error `Result` rolling a unit of work back -- need their own container
     // lifetime and their own seeded runs.
-    2 + 2 + 1 + 6 + 1 + 4 + 4 + 6 + 6 + 6 + 1 + 6 + 6 + 9 + 7 + 8 + 6 + 7 + 6 + 7 + 7 + 5 + 6 + 3 + 6 + 3 + 1 + 1 + 2 + 1 + 1 + 2,
+    // WIN-303 adds the last term: ONE file,
+    // `governance-isolation.integration.test.ts`. A NEW file rather than a
+    // widening of `governance-rules.integration.test.ts` for the reason G1's
+    // was, and for one more: that file's cross-environment control uses a
+    // COHERENT foreign scope, which the environment clause alone already
+    // refuses. A TAMPERED triple needs both tenants' identifiers mixed into ONE
+    // scope, and it sits at 426 effective lines already.
+    2 + 2 + 1 + 6 + 1 + 4 + 4 + 6 + 6 + 6 + 1 + 6 + 6 + 9 + 7 + 8 + 6 + 7 + 6 + 7 + 7 + 5 + 6 + 3 + 6 + 3 + 1 + 1 + 2 + 1 + 1 + 2 + 1,
     // WIN-267 G2 adds the last term: TWO files, `governance-read-seams.test.ts`
     // and `governance-read-seams.integration.test.ts` -- the three inverted read
     // seams' schema/migration join and their two-tenant proof.
@@ -1650,7 +1681,16 @@ test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
       // the oracle was read (a REAL environment under a FOREIGN project is a
       // scope one tenant cannot build) and ONE because a mutation survived
       // without it.
-      9 + 19,
+      9 + 19 +
+      // WIN-303: the ELEVEN cases of the tampered-triple proof, every one of
+      // them against TWO tenants because a forged ancestry is a scope one tenant
+      // cannot build. FIVE are one per canonical store, each pairing the honest
+      // scope with the forged one so an unconditional refusal fails the case
+      // too; FOUR separate the three FACTS the resolver reports, including the
+      // two that kill the organization half and the project half of the
+      // comparison ON THEIR OWN; TWO hold a TENANT scope to the ancestry it
+      // asserts and to no more.
+      11,
   );
   // M2 INTEGRATION: 1483 + 14 (the two WIN-259 dimensions) + 9 (the correlation
   // suite) = 1506, of which 429 still run in `pnpm test:v1-packages` and
@@ -1661,7 +1701,11 @@ test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
   // 1090 need a Docker daemon.
   // WIN-267 G2: 1519 + 28 = 1547, and NINETEEN of its twenty-eight are on the
   // container side too. SUMMED: 1506 + 13 + 28 = 1547.
-  assert.equal(EXPECTED["packages/adapters/postgres-tenancy"].cases, 1547);
+  // WIN-303: 1547 + 11 = 1558, and ALL ELEVEN are on the container side -- a
+  // tampered triple only exists once TWO tenants have been seeded, so there is
+  // no unit-test form of any of them. The runnable 429 is unmoved; the Docker
+  // side goes 1090 + 28 + 11 = 1129.
+  assert.equal(EXPECTED["packages/adapters/postgres-tenancy"].cases, 1558);
   // 429 of the 1506 run in `pnpm test:v1-packages`; the other 1077 need a Docker
   // daemon and run in the `postgres-tenancy-repository` CI job. A pin that
   // 429 of the 1495 run in `pnpm test:v1-packages`; the other 1066 need a Docker
@@ -1675,7 +1719,7 @@ test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
   // `24 + 17 + 3 + 4` is four cases added to `agents-rows.test.ts`, a file this
   // row already counted, which is why that dimension's file tail gains 3 while
   // its case tail gains 48.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 5875 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 5875 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
   assert.equal(
     EXPECTED_RUNTIME_TOTAL,
     Object.values(EXPECTED).reduce((total, row) => total + row.cases, 0)

--- a/scripts/v1-ledger.test.mjs
+++ b/scripts/v1-ledger.test.mjs
@@ -1246,7 +1246,20 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // match all six.
     //
     // SUMMED FOR THE INTEGRATION: 1493 + 2 (G1) + 6 (G2) = 1501.
-    packages: 1501,
+    //
+    // WIN-303 +2, and BOTH are in `packages/adapters/postgres-tenancy`: ONE
+    // source, `governance-scope.ts`, which resolves the whole tenant triple
+    // against `Environment` and `Project` before any of the five canonical
+    // stores sends a statement, and ONE test,
+    // `governance-isolation.integration.test.ts`, the two-tenant proof that a
+    // forged ancestry is refused. TWO and not more because the five stores,
+    // `governance-rows.ts`, `governance-seam-guards.ts`, `governance`'s
+    // `errors.ts`, its ports barrel, its contracts suite, the statements suite
+    // and `mutations-governance.json` are all WIDENED rather than added — and
+    // `docs/error-taxonomy.json`, which gains the five new codes, is tracked
+    // already. No ledger rule is new: `packages.adapters.source` and `.test`
+    // match both. 1501 + 2 = 1503.
+    packages: 1503,
     // WIN-254 added four reviewed docs; WIN-252 legal provenance adds five
     // exact evidence files under docs/audits/sbom.
     //
@@ -1654,7 +1667,17 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
   // SUMMED FOR THE INTEGRATION: 1640 + 5 (G1) + 7 (G2) + 1 (G3) = 1653, and the
   // integration's own operator-authentication suite makes it 1654. Every one of
   // the fourteen is additive: no ledger rule changed and no project was adopted.
-  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1654);
+  //
+  // WIN-303 1654 -> 1656. TWO files, BOTH in `packages` and both itemised on
+  // that area's delta above, so the two halves of this case are the same
+  // arithmetic: `governance-scope.ts` and
+  // `governance-isolation.integration.test.ts`. Nothing lands in `root-infra`
+  // — this tranche's guard entries go into the EXISTING
+  // `packages/adapters/postgres-tenancy/mutations-governance.json` rather than
+  // into a new manifest, because they are more guards on the same port surface
+  // that file already covers. Sibling branches move this same delta in the same
+  // window, so the integrator SUMS rather than taking any one branch's total.
+  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1656);
   assert.deepEqual(
     Object.fromEntries(
       Object.entries(summary.areaCounts).map(([area, count]) => [area, count - rulesDocument.baseline.areaCounts[area]])
@@ -1792,7 +1815,7 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // one file is `apps/core-api/mutations-win267-g3.json`, in `apps-core-api`,
     // matching that area's 57 -> 58; it ADOPTS NO PROJECT and CHANGES NO LEDGER
     // RULE, so this delta too is purely additive: 1640 + 1 = 1641.
-    rulesDocument.baseline.totalFiles + 1654
+    rulesDocument.baseline.totalFiles + 1656
   );
 });
 


### PR DESCRIPTION
## What was wrong

`governance-rows.ts`'s `scopedWhere` was `{ environmentId }`. A scope is a
TRIPLE — organization, project, environment — so `SafetyLedger`,
`RatingsRepository`, `CriteriaRepository`, `EvalsRepository` and
`GoldenSetsRepository` checked ONE member of it. A caller presenting a
**legitimate environment beside somebody else's project or organization** was
served, in full, by every read and every write: the two clauses that would have
disagreed were never in the statement.

`governance-rules.integration.test.ts` already seeds a second tenant, and it
passes either way — its foreign scope is COHERENT, which the environment clause
alone already refuses. The forged triple is the case that separates them and
nothing measured it.

## What this does

`governance-scope.ts` resolves the whole triple against `Environment` and
`Project` in ONE statement before any of the five sends anything, and refuses a
scope that does not join up under **a code of each store's own**. Five codes
because the guard is instantiated five times and a resolver dropped from one
store must not hide behind the other four; `internal` and not `unavailable`
because an incoherent scope will fail identically for ever and a retry hint
would be a lie the transport repeats.

Three reasons, told apart in `details.reason`: `unnarrowable_identifiers` (no
statement sent at all — a malformed uuid reaching a `@db.Uuid` column aborts the
caller's transaction), `unknown_environment`/`unknown_project`, and
`foreign_ancestry` — the tamper.

It is a REFUSAL and not an empty set. This context has already spent absence on
concealing whose row an id belongs to, so a filter would report a broken grant
as a criterion that does not exist, for ever, with nothing to notice. That is
`tools-scope.ts`'s argument about the same database, applied to the same shape
of defect. `scopedWhere` therefore keeps its body: a second copy of the check in
the `where` clause could never be turned red, because the resolver refuses first.

## Evidence

- `governance-isolation.integration.test.ts` — 11 cases against a real
  PostgreSQL with TWO seeded tenants. Every case pairs the honest scope with the
  forged one, so a store that refused unconditionally fails too; every "no row
  moved" claim is read back on a second client the adapter's pool never touched.
- 11 mutation-ledger entries, each killed by a NAMED case, run on the mini.
  Two of them exist only to kill the organization half and the project half of
  the ancestry comparison **separately** — no other fixture in the package can,
  because they all seed one chain where the right project is under the right
  organization.
- Full `pnpm test:postgres-tenancy:integration`: **116 files / 1120 cases green**
  on real PostgreSQL 16.
- 27/27 arch audits and 46/48 `scripts/**/*.test.mjs` green in a fresh mini
  worktree; the 2 remaining fail identically at the base.

**A PR onto this branch gets no hosted CI** — `ci.yml` declares
`on: pull_request: branches: [main, v1]`. The mini sweep is the evidence.

## Findings carried, not fixed

- `mutations-governance.json`'s **M-G19 was vacuous** — checked green at the
  base in a second worktree. Made falsifiable here.
- `EvalRun` has **no erasure or retention path**, and
  `governance-erasure-target.ts` still says "All five owned models are named"
  while `table-ownership.mjs` gives `governance` SIX.
- The **eval-run queue's consumer half has no dispatcher**; rows accumulate as
  QUEUED.
- `apps/core-api` comments and a test name still say **419 canonical codes**;
  the taxonomy held 423 before this branch and holds 428 after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzDWyb7YEERRegYTvNwzRp