### PR TITLE
WIN-267 W3: server-side sign-out, and the unscanned terminal route

### DIFF
--- a/apps/core-api/src/composition/identity-rest.integration.test.ts
+++ b/apps/core-api/src/composition/identity-rest.integration.test.ts
@@ -109,6 +109,9 @@ const OUTSIDER_TOKEN = "win267-r1-outsider-session-token";
 const EXPIRED_TOKEN = "win267-r1-expired-session-token";
 const REVOKED_TOKEN = "win267-r1-revoked-session-token";
 const IMPERSONATION_TOKEN = "win267-r1-impersonation-session-token";
+/** W3's own session. It is signed out during the run, so nothing else may hold it. */
+const SIGN_OUT_TOKEN = "win267-w3-sign-out-session-token";
+const SIGN_OUT_SESSION = "bbbbbbbb-1006-4000-8000-000000000006";
 
 let postgres: StartedPostgreSqlContainer;
 let redis: StartedRedisContainer;
@@ -260,6 +263,11 @@ beforeAll(async () => {
   await store.operatorSessions.save(
     session("bbbbbbbb-1004-4000-8000-000000000004", REVOKED_TOKEN, { revokedAt: AT }),
   );
+  // W3'S SESSION, SEEDED LIVE AND ENDED BY THE ROUTE UNDER TEST. It is separate
+  // from ADMIN_TOKEN because every other case in this file needs that one to stay
+  // usable, and a sign-out suite that shared it would make its neighbours depend
+  // on execution order.
+  await store.operatorSessions.save(session(SIGN_OUT_SESSION, SIGN_OUT_TOKEN, {}));
   // AN IMPERSONATING SESSION: the ADMIN acting AS the OUTSIDER. It is the fixture
   // that separates `actorUserId` from `effectiveUserId`, and without it a route
   // that used the wrong one would pass every other case in this file.
@@ -634,5 +642,120 @@ describe("WIN-267 R1 — the BFF sets bytes and nothing else", () => {
     const cookie = String(answer.headers.get("set-cookie"));
     expect(cookie).toContain("Max-Age=0");
     expect(cookie).toContain("platos_operator_session=;");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WIN-267 W3 — SIGNING OUT ENDS THE SESSION ON THE SERVER
+//
+// The route above used to clear a cookie and stop. The cookie is a COPY of the
+// credential, so deleting the copy in the one browser that asked left the
+// session valid — for days, on this install — for every other copy of it. The
+// case that matters is therefore not "the header says Max-Age=0"; it is that the
+// EXACT SAME COOKIE BYTES, replayed afterwards, are refused, and that the row in
+// PostgreSQL says why.
+//
+// THE ROW IS READ BY `psql` INSIDE THE CONTAINER, which shares no pool, driver or
+// transaction with the adapter that wrote it — the banner at the top of this file
+// explains why that matters. And it is read as `id, revokedAt` rather than as a
+// count, because "the session is gone from the cache" and "the session is ended
+// in the database" are two different claims and only the second one is a
+// sign-out. A DELETE that had removed the row would pass a `SELECT count(*) = 0`
+// and would be a different, worse bug: an audit trail with the evidence deleted.
+describe("WIN-267 W3 — a sign-out ends the session on the SERVER, not only in the browser", () => {
+  /** `id|revokedAt` for one session, straight out of the container. */
+  async function sessionRow(id: string): Promise<string[]> {
+    return observe(
+      `SELECT "id", COALESCE("revokedAt"::text, 'NULL') FROM "OperatorSession" WHERE "id" = '${id}'`,
+    );
+  }
+
+  it("REFUSES THE REPLAYED COOKIE, and the row says SESSION_REVOKED rather than expiry", async () => {
+    // 1. The browser gets the credential the way a browser gets it.
+    const exchanged = await call("POST", `${API_VERSION_PREFIX}/bff/session`, {
+      body: { token: SIGN_OUT_TOKEN },
+    });
+    expect(exchanged.status, exchanged.text).toBe(200);
+    const cookie = String(exchanged.headers.get("set-cookie")).split(";")[0] ?? "";
+    expect(cookie).not.toBe("");
+
+    // 2. IT IS LIVE. Without this the refusal in step 5 would also be produced by
+    // a session that never worked, which is the shape a broken fixture takes.
+    const before = await call("GET", `${API_VERSION_PREFIX}/identity/session`, { cookie });
+    expect(before.status, before.text).toBe(200);
+    expect(await sessionRow(SIGN_OUT_SESSION)).toEqual([`${SIGN_OUT_SESSION}|NULL`]);
+
+    // 3. Sign out, presenting the cookie the way a browser presents it.
+    const out = await call("DELETE", `${API_VERSION_PREFIX}/bff/session`, { cookie });
+    expect(out.status, out.text).toBe(204);
+    expect(String(out.headers.get("set-cookie"))).toContain("Max-Age=0");
+
+    // 4. THE ROW, READ BACK. It still EXISTS and it now carries a revocation
+    // instant: the session was ended, not evicted, not merely forgotten by a
+    // cache this process happens to hold.
+    const rows = await sessionRow(SIGN_OUT_SESSION);
+    expect(rows).toHaveLength(1);
+    const revokedAt = String(rows[0]).split("|")[1];
+    expect(revokedAt, "the sign-out wrote a revocation instant").not.toBe("NULL");
+
+    // 5. THE REPLAY. The same bytes, on a request that ignores the Set-Cookie the
+    // sign-out returned — which is exactly what a thief holding a copied cookie
+    // does, and what the old handler could not refuse.
+    const replay = await call("GET", `${API_VERSION_PREFIX}/identity/session`, { cookie });
+    expect(replay.status).toBe(committedStatus("SESSION_REVOKED"));
+    // AND THE CODE IS THE ONE THAT TELLS THE OPERATOR STORY. A session somebody
+    // ENDED and a session that ran out of time are two different events with two
+    // different follow-ups, and this route now produces the first.
+    expect(errorCode(replay)).toBe("SESSION_REVOKED");
+    const lapsed = await call("GET", `${API_VERSION_PREFIX}/identity/session`, {
+      token: EXPIRED_TOKEN,
+    });
+    expect(errorCode(lapsed)).toBe("SESSION_EXPIRED");
+    expect(new Set([errorCode(replay), errorCode(lapsed)]).size).toBe(2);
+  });
+
+  it("signs out again without re-stamping the revocation", async () => {
+    // The instant is evidence. A second sign-out that moved `revokedAt` forward
+    // would answer "when was this session ended?" with the time of the retry,
+    // and the domain rule that forbids it (`revoked` refuses a session that
+    // already carries one) is only worth having if it reaches the database.
+    const [firstRow] = await sessionRow(SIGN_OUT_SESSION);
+    const again = await call("DELETE", `${API_VERSION_PREFIX}/bff/session`, {
+      token: SIGN_OUT_TOKEN,
+    });
+    expect(again.status).toBe(204);
+    expect(await sessionRow(SIGN_OUT_SESSION)).toEqual([firstRow]);
+  });
+
+  it("answers an ALREADY-ENDED token, an unknown token and no token IDENTICALLY", async () => {
+    // The route must not become an oracle for whether a token is real. It is the
+    // one route on this surface that takes a credential and declines to
+    // authenticate it, so the only thing keeping that safe is that every answer
+    // is the same answer — 204, the same bytes, no body. The three cases below
+    // reach three DIFFERENT branches inside the handler (SESSION_REVOKED,
+    // UNAUTHENTICATED/no-session, UNAUTHENTICATED/no-token) and are
+    // indistinguishable from outside, which is the property being measured.
+    const ended = await call("DELETE", `${API_VERSION_PREFIX}/bff/session`, {
+      token: SIGN_OUT_TOKEN,
+    });
+    const unknown = await call("DELETE", `${API_VERSION_PREFIX}/bff/session`, {
+      token: "win267-w3-not-a-real-token",
+    });
+    const anonymous = await call("DELETE", `${API_VERSION_PREFIX}/bff/session`);
+    expect([ended.status, unknown.status, anonymous.status]).toEqual([204, 204, 204]);
+    expect(unknown.headers.get("set-cookie")).toBe(anonymous.headers.get("set-cookie"));
+    expect(ended.headers.get("set-cookie")).toBe(anonymous.headers.get("set-cookie"));
+    expect([ended.text, unknown.text]).toEqual([anonymous.text, anonymous.text]);
+    // AND THE UNKNOWN TOKEN ENDED NOTHING: no other seeded session moved. The
+    // ADMIN's is the one every case above depends on, so a sign-out that revoked
+    // by anything other than the presented digest would be caught here.
+    expect(await sessionRow("bbbbbbbb-1001-4000-8000-000000000001")).toEqual([
+      "bbbbbbbb-1001-4000-8000-000000000001|NULL",
+    ]);
+  });
+
+  it("leaves the ADMIN session usable, which is what makes the revocation targeted", async () => {
+    const answer = await call("GET", `${API_VERSION_PREFIX}/identity/session`, { token: ADMIN_TOKEN });
+    expect(answer.status, answer.text).toBe(200);
   });
 });

--- a/apps/core-api/src/transports/bff/session.controller.ts
+++ b/apps/core-api/src/transports/bff/session.controller.ts
@@ -201,6 +201,14 @@ export class BffSessionController {
    * IT STILL REVEALS NOTHING. A live token, an unknown token and no token at all
    * get the same 204 and the same bytes, so the route cannot be used to ask
    * whether a token is real.
+   *
+   * AND IT GAINS NO ROW IN `http/idempotency-policy.ts`, WHICH IS A DECISION NOW
+   * THAT IT WRITES. The revocations already in that table are `exempt`, and the
+   * reasoning transfers exactly — "naturally idempotent, and it returns no
+   * secret". What does not transfer is the cost of being wrong: `exempt` DROPS an
+   * `Idempotency-Key` a caller sent in good faith, and the default `accepted`
+   * honours it. For a route whose whole job is to make sure something happened
+   * once, honouring the key is the safer of the two, so the default stands.
    */
   @Delete()
   @HttpCode(HttpStatus.NO_CONTENT)

--- a/apps/core-api/src/transports/bff/session.controller.ts
+++ b/apps/core-api/src/transports/bff/session.controller.ts
@@ -36,7 +36,8 @@
 // `composition-root.test.mjs` goes red; the mutation ledger records the run.
 //
 // The exchange therefore reaches exactly two contract methods —
-// `authenticateOperator` and `issueSessionCookie` — and the sign-out reaches one.
+// `authenticateOperator` and `issueSessionCookie` — and the sign-out reaches two,
+// `revokeOperatorSession` and `clearSessionCookie`.
 
 import { Body, Controller, Delete, HttpCode, HttpStatus, Inject, Post, Req, Res } from "@nestjs/common";
 
@@ -56,6 +57,7 @@ import {
 import {
   authenticateOperator,
   isSecureTransport,
+  presentedOperatorToken,
   requireIdentityAccess,
   type InboundOperatorRequest,
 } from "../rest/operator.js";
@@ -161,28 +163,56 @@ export class BffSessionController {
   }
 
   /**
-   * End the session in the browser.
+   * End the session — on the SERVER first, then in the browser.
    *
-   * IT DOES NOT AUTHENTICATE, AND THAT IS THE POINT. A browser holding a cookie
-   * for a session that is already expired or revoked is exactly the browser that
-   * most needs the cookie cleared, and a sign-out that answered 401 would strand
-   * it there — one dead credential the user cannot get rid of without opening
-   * developer tools. The route reveals nothing: the directive it writes is the
-   * same bytes for every caller, authenticated or not.
+   * WIN-267 W3. Until this tranche the handler wrote one header and stopped, and
+   * the comment that stood here said so in as many words: "IT REVOKES NOTHING
+   * EITHER ... this route clears the browser and the session dies of its own
+   * expiry." That is now closed, because a sign-out that only clears a cookie is
+   * a sign-out that tells the user something untrue. The cookie is a COPY of the
+   * credential; deleting the copy in the one browser that asked leaves every
+   * other copy — the one in a proxy log, the one an attacker pasted into their
+   * own client — valid for the rest of the session's lifetime, which for this
+   * install is days. `revokeOperatorSession` ends the row, and
+   * `identity-rest.integration.test.ts` replays the exact same cookie afterwards
+   * against a real PostgreSQL and reads the row back to prove it.
    *
-   * IT REVOKES NOTHING EITHER, and the contract is why: `revokeOperatorSession`
-   * lives in `application/` and is not published, so a BFF cannot end the SERVER
-   * side of a session. That is a real gap and it is named here rather than papered
-   * over — until the contract publishes a revocation, this route clears the
-   * browser and the session dies of its own expiry.
+   * THE ORDER IS NOT INTERCHANGEABLE. The revocation happens BEFORE the header
+   * is written, so a store that cannot be reached refuses the sign-out instead of
+   * answering 204 over a session that is still live. Clearing first and revoking
+   * second would produce exactly the lie this change exists to remove, with the
+   * added twist that the user would no longer hold the cookie needed to try
+   * again.
+   *
+   * IT STILL DOES NOT AUTHENTICATE, AND THAT IS STILL THE POINT. A browser
+   * holding a cookie for a session that is already expired, already revoked, or
+   * that no row matches is exactly the browser that most needs the cookie
+   * cleared, and a 401 would strand it there. So every refusal in the
+   * `unauthenticated` CATEGORY — no token, no such session, already ended — means
+   * "there was nothing left to end", and the route goes on to clear the browser
+   * and answer 204. The branch is written against the kernel's category rather
+   * than a list of codes copied into this file, so a fourth way for a credential
+   * to be unestablishable does not need a transport edit to be handled.
+   *
+   * ANYTHING ELSE IS RAISED. In practice that is `IDENTITY_STORE_UNAVAILABLE` at
+   * 503: the server could not end the session, and the honest answer is to say
+   * so rather than to clear the cookie and call it done.
+   *
+   * IT STILL REVEALS NOTHING. A live token, an unknown token and no token at all
+   * get the same 204 and the same bytes, so the route cannot be used to ask
+   * whether a token is real.
    */
   @Delete()
   @HttpCode(HttpStatus.NO_CONTENT)
-  signOut(
+  async signOut(
     @Req() request: InboundOperatorRequest,
     @Res({ passthrough: true }) response: CookieResponse,
-  ): void {
+  ): Promise<void> {
     const identityAccess = requireIdentityAccess(this.application.app);
+    const ended = await identityAccess.revokeOperatorSession({
+      presentedToken: presentedOperatorToken(identityAccess, request),
+    });
+    if (!ended.ok && ended.error.category !== "unauthenticated") raise(ended.error);
     const directive = identityAccess.clearSessionCookie({ secure: isSecureTransport(request) });
     if (!directive.ok) raise(directive.error);
     response.setHeader("Set-Cookie", serializeSetCookie(this.onlyTheBytes(directive.value)));

--- a/apps/core-api/src/transports/rest/identity-rest.test.ts
+++ b/apps/core-api/src/transports/rest/identity-rest.test.ts
@@ -15,15 +15,21 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { FieldViolation } from "@platos/kernel";
+import { domainError, err, type DomainError, type FieldViolation } from "@platos/kernel";
+import {
+  IDENTITY_ACCESS_ERROR_CODES,
+  type IdentityAccessContract,
+} from "@platos/context-identity-access";
 
 import {
   createIdentityAccessService,
   testPorts,
 } from "@platos/context-identity-access/application/index.js";
 
-import { serializeSetCookie } from "../bff/session.controller.js";
+import type { AppModule } from "../../app.module.js";
+import { BffSessionController, serializeSetCookie } from "../bff/session.controller.js";
 import { exchangeSessionValidator } from "../bff/session.controller.js";
+import { domainErrorOf } from "./fault.js";
 import { BodyReader, jsonBody } from "./body.js";
 import { encodeCursor, wholeCollection } from "./envelope.js";
 import {
@@ -239,6 +245,71 @@ describe("WIN-267 R1 — the cookie the BFF writes is the contract's", () => {
     expect(readCookie(request, "platos_operator_session")).toBe("tok en");
     expect(readCookie(request, "platos_operator")).toBeNull();
     expect(readCookie({ headers: {} }, "platos_operator_session")).toBeNull();
+  });
+});
+
+describe("WIN-267 W3 — a sign-out that could not end the session says so", () => {
+  /**
+   * A REAL `IdentityAccessContract` with ONE method replaced.
+   *
+   * Everything the handler does apart from the revocation — asking for the cookie
+   * name, minting the clear directive, handing it back to `verifySessionCookie` —
+   * runs against `createIdentityAccessService`, so this measures the handler's
+   * branch and not a contract invented for the occasion.
+   */
+  function signOutAgainst(refusal: DomainError): {
+    readonly run: () => Promise<void>;
+    readonly written: readonly string[];
+  } {
+    const identityAccess: IdentityAccessContract = {
+      ...createIdentityAccessService(testPorts()),
+      revokeOperatorSession: () => Promise.resolve(err(refusal)),
+    };
+    const written: string[] = [];
+    const controller = new BffSessionController({
+      app: { contexts: { identityAccess } } as unknown as AppModule,
+    });
+    return {
+      written,
+      run: () =>
+        controller.signOut({ headers: {} }, { setHeader: (_name, value) => written.push(value) }),
+    };
+  }
+
+  /** A code the CONTRACT publishes, never one invented here. */
+  function published(code: (typeof IDENTITY_ACCESS_ERROR_CODES)[number]): string {
+    if (!IDENTITY_ACCESS_ERROR_CODES.includes(code)) throw new Error(`${code} is not published`);
+    return code;
+  }
+
+  it("RAISES when the store could not be reached, and writes no cookie", async () => {
+    // THE WHOLE POINT OF THE ORDER. If the header went out first, or if every
+    // refusal were swallowed, this caller would be told 204 — "you are signed
+    // out" — over a session that is still live because nothing could end it. The
+    // branch is on the kernel CATEGORY rather than on a list of codes copied into
+    // the transport, so a new way for the store to be unreachable is handled
+    // without a transport edit.
+    const attempt = signOutAgainst(
+      domainError(published("IDENTITY_STORE_UNAVAILABLE"), "unavailable", "Identity store is unavailable", {
+        retryAfterSeconds: 1,
+      }),
+    );
+    const thrown = await attempt.run().catch((error: unknown) => error);
+    expect(domainErrorOf(thrown)?.code).toBe("IDENTITY_STORE_UNAVAILABLE");
+    expect(attempt.written, "a sign-out that did not happen must not clear the browser").toEqual([]);
+  });
+
+  it("CLEARS the browser anyway when there was simply nothing left to end", async () => {
+    // The other side of the same branch, and the property the route had before
+    // W3: a browser holding a dead credential is the one that most needs it
+    // cleared. Every `unauthenticated` refusal — no token, no such session,
+    // already ended — reaches here.
+    for (const code of ["UNAUTHENTICATED", "SESSION_REVOKED"] as const) {
+      const attempt = signOutAgainst(domainError(published(code), "unauthenticated", "refused"));
+      await attempt.run();
+      expect(attempt.written, code).toHaveLength(1);
+      expect(String(attempt.written[0]), code).toContain("Max-Age=0");
+    }
   });
 });
 

--- a/apps/core-api/src/transports/rest/identity-rest.test.ts
+++ b/apps/core-api/src/transports/rest/identity-rest.test.ts
@@ -289,14 +289,14 @@ describe("WIN-267 W3 — a sign-out that could not end the session says so", () 
     // branch is on the kernel CATEGORY rather than on a list of codes copied into
     // the transport, so a new way for the store to be unreachable is handled
     // without a transport edit.
-    const attempt = signOutAgainst(
+    const handler = signOutAgainst(
       domainError(published("IDENTITY_STORE_UNAVAILABLE"), "unavailable", "Identity store is unavailable", {
         retryAfterSeconds: 1,
       }),
     );
-    const thrown = await attempt.run().catch((error: unknown) => error);
+    const thrown = await handler.run().catch((error: unknown) => error);
     expect(domainErrorOf(thrown)?.code).toBe("IDENTITY_STORE_UNAVAILABLE");
-    expect(attempt.written, "a sign-out that did not happen must not clear the browser").toEqual([]);
+    expect(handler.written, "a sign-out that did not happen must not clear the browser").toEqual([]);
   });
 
   it("CLEARS the browser anyway when there was simply nothing left to end", async () => {
@@ -305,10 +305,10 @@ describe("WIN-267 W3 — a sign-out that could not end the session says so", () 
     // cleared. Every `unauthenticated` refusal — no token, no such session,
     // already ended — reaches here.
     for (const code of ["UNAUTHENTICATED", "SESSION_REVOKED"] as const) {
-      const attempt = signOutAgainst(domainError(published(code), "unauthenticated", "refused"));
-      await attempt.run();
-      expect(attempt.written, code).toHaveLength(1);
-      expect(String(attempt.written[0]), code).toContain("Max-Age=0");
+      const handler = signOutAgainst(domainError(published(code), "unauthenticated", "refused"));
+      await handler.run();
+      expect(handler.written, code).toHaveLength(1);
+      expect(String(handler.written[0]), code).toContain("Max-Age=0");
     }
   });
 });

--- a/apps/core-api/src/transports/rest/identity-rest.test.ts
+++ b/apps/core-api/src/transports/rest/identity-rest.test.ts
@@ -253,6 +253,12 @@ describe("WIN-267 R1 — the finding: no V1 REST route can spend an authenticati
     // the left side is read off a REAL service object, so this fails the day the
     // contract gains or loses a method — which is the day somebody must revisit
     // the finding below rather than inherit it.
+    //
+    // IT WENT RED EXACTLY ONCE, AS DESIGNED. WIN-267 W3 published
+    // `revokeOperatorSession`, this assertion failed, and the finding below was
+    // revisited: the new method performs no rate-limited action either — a
+    // sign-out spends no authentication budget — so the finding stands and the
+    // name was added.
     expect(methods).toEqual([
       "authenticateBearer",
       "authenticateOperator",
@@ -261,6 +267,7 @@ describe("WIN-267 R1 — the finding: no V1 REST route can spend an authenticati
       "describeSessionCookie",
       "issueSessionCookie",
       "listEndUsers",
+      "revokeOperatorSession",
       "rotateSessionCookie",
       "verifySessionCookie",
     ]);

--- a/docs/audits/M0.9-rest-census-independent.json
+++ b/docs/audits/M0.9-rest-census-independent.json
@@ -70,7 +70,7 @@
       "observedRoutes": 3,
       "declaredAllRoutes": 0,
       "observedAllRoutes": 0,
-      "observedNamedAllRoutes": 0,
+      "observedNonWildcardAllRoutes": 0,
       "terminalCatchAll": false,
       "emptyBasePath": true,
       "why": "process-edge liveness/readiness probes (ADR M0.4 §2 keeps them off the versioned surface); no tenant, no scope, no use case."
@@ -82,7 +82,7 @@
       "observedRoutes": 0,
       "declaredAllRoutes": 1,
       "observedAllRoutes": 1,
-      "observedNamedAllRoutes": 0,
+      "observedNonWildcardAllRoutes": 0,
       "terminalCatchAll": true,
       "emptyBasePath": true,
       "why": "the terminal 404: the LAST-registered handler, answering every unmatched path in the process with the M0.4 §2 envelope. No tenant, no scope, no use case, and no operation a client can call — a refusal, not surface."

--- a/docs/audits/M0.9-rest-census-independent.json
+++ b/docs/audits/M0.9-rest-census-independent.json
@@ -20,7 +20,8 @@
     "operator": "manifestOperator >= independentOperatorFloor per controller (wrapper/inherited operator enforcement legitimately lifts the manifest above the direct-call floor).",
     "omission": "a production controller found by glob but absent from the manifest FAILS --check.",
     "scanRoots": "every manifest route-implementation source falls under a DECLARED scan root, and each root's globbed decorators (expanded by mount multiplier) equal the manifest operations attributed to it. A surface built in a directory this census does not scan fails as UNDECLARED SCAN ROOT.",
-    "processEdge": "the named process-edge exclusions are measured, not assumed: the excluded file must exist, keep an EMPTY @Controller() argument list, and carry exactly the declared number of probes."
+    "processEdge": "the named process-edge exclusions are measured, not assumed: the excluded file must exist, keep an EMPTY @Controller() argument list, carry exactly the declared number of probes, and carry exactly the declared number of @All decorators — each a bare wildcard where the exclusion is the terminal catch-all.",
+    "unscannedControllers": "the exclusion list is joined to the tree in BOTH directions. Every *.controller.ts inside a scanned application's src/ must be under a declared scan root or named in PROCESS_EDGE_EXCLUSIONS; anything else fails as UNSCANNED ROUTE-BEARING CONTROLLER. Without this half a controller can be accounted for by nothing at all, which is what apps/core-api/src/http/not-found.controller.ts was until WIN-267 W3."
   },
   "totals": {
     "controllers": 32,
@@ -56,14 +57,35 @@
       }
     ]
   },
+  "applicationRoots": [
+    "apps/agent/src",
+    "apps/core-api/src"
+  ],
+  "unscannedControllers": [],
   "processEdgeExclusions": [
     {
       "file": "apps/core-api/src/http/health.controller.ts",
       "controller": "HealthController",
       "declaredRoutes": 3,
       "observedRoutes": 3,
+      "declaredAllRoutes": 0,
+      "observedAllRoutes": 0,
+      "observedNamedAllRoutes": 0,
+      "terminalCatchAll": false,
       "emptyBasePath": true,
       "why": "process-edge liveness/readiness probes (ADR M0.4 §2 keeps them off the versioned surface); no tenant, no scope, no use case."
+    },
+    {
+      "file": "apps/core-api/src/http/not-found.controller.ts",
+      "controller": "NotFoundController",
+      "declaredRoutes": 0,
+      "observedRoutes": 0,
+      "declaredAllRoutes": 1,
+      "observedAllRoutes": 1,
+      "observedNamedAllRoutes": 0,
+      "terminalCatchAll": true,
+      "emptyBasePath": true,
+      "why": "the terminal 404: the LAST-registered handler, answering every unmatched path in the process with the M0.4 §2 envelope. No tenant, no scope, no use case, and no operation a client can call — a refusal, not surface."
     }
   ],
   "table": [

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "fcb2b4ddc188b5d0f23615ed96be7234ec1ab44a0b4d71ad7dfaecc108d3de9d",
+  "evidenceSha256": "290ce4047dd432d014942b950cb178b0aa0f57703611dcd865ea72e33765e2b6",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "b17515f84b30b0f8ae07d05e762fcd53c64ec6933350f846b084faa4465773b7",
+    "aggregateSha256": "8bb3fddd64d385d477a1de772d53bcfeaf0b9b0371ad0fe02ed049a8a7758bd0",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -2495,7 +2495,7 @@
       },
       {
         "path": "apps/core-api/src/composition/identity-rest.integration.test.ts",
-        "sha256": "f8a68375c23691d18453f1a8a04146d80eab87a4fa697b1c24edc647f3bb695c"
+        "sha256": "a3aa7cccb37bfc521f6e03195c0a71148bc81ae6265c2977d19b52115e4925e9"
       },
       {
         "path": "apps/core-api/src/composition/installation.test.ts",
@@ -2695,7 +2695,7 @@
       },
       {
         "path": "apps/core-api/src/transports/bff/session.controller.ts",
-        "sha256": "6d27f53bbee2fafe9c8b741e519c96ed7052e63fcd06362498b215aa6f017d7b"
+        "sha256": "1c08ef04379a398edb0735df4af770abf1356d1379869c8b585774a864a34ff5"
       },
       {
         "path": "apps/core-api/src/transports/channels-ingress/index.ts",
@@ -2739,7 +2739,7 @@
       },
       {
         "path": "apps/core-api/src/transports/rest/identity-rest.test.ts",
-        "sha256": "9252d06f0d0637aebcbe50b9a40a9ba48e7273504bc0321d0a14067b407066af"
+        "sha256": "9e107953e0c252f4e0845f55ceac8d14f583480d8bf22b79cdddd5336484103a"
       },
       {
         "path": "apps/core-api/src/transports/rest/identity-session.controller.ts",
@@ -4207,7 +4207,7 @@
       },
       {
         "path": "docs/audits/M0.9-rest-census-independent.json",
-        "sha256": "8e3897c8532d3c06adffd3bb557bbf8afc4e41ecbb71ecb7016f49a31ae07b0f"
+        "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b"
       },
       {
         "path": "docs/audits/M0.9-webapp-bff-matrix.json",
@@ -15135,11 +15135,11 @@
       },
       {
         "path": "packages/contexts/identity-access/application/authenticate-operator.test.ts",
-        "sha256": "adde957585ca010facc08295575d62e5545ee2817d98de9e2e19d575b6cf0450"
+        "sha256": "dd5e2320a9170839dccc9ea0b1dbe3731a7615660761f1ea1ad8361d5f42f737"
       },
       {
         "path": "packages/contexts/identity-access/application/authenticate-operator.ts",
-        "sha256": "1592f1779c6d015975a1917077c30e7b19d4269a1d487343a203004398457be5"
+        "sha256": "71c54aa9d68880bc7c38d249b8a39b4c5a0224aa617350e90c17c7de24e41f3f"
       },
       {
         "path": "packages/contexts/identity-access/application/consume-rate-limit.test.ts",
@@ -15179,11 +15179,11 @@
       },
       {
         "path": "packages/contexts/identity-access/application/identity-access-service.test.ts",
-        "sha256": "8908d0e3d40fc9f104397fd95ce80f4e12c19dd6bb534bf72f1ba4e34c3fd146"
+        "sha256": "a85bab8516a7aa93b996c718685afae275522d817d8241823d72a1a4886d26bb"
       },
       {
         "path": "packages/contexts/identity-access/application/identity-access-service.ts",
-        "sha256": "4d42909a44c856fa2ba0c0df35494902198387739c921e134531be25fae716f2"
+        "sha256": "e932f158f007a0aff502e4cb6a2bac67bb60c012c43ede2943a91ffa0989e0e8"
       },
       {
         "path": "packages/contexts/identity-access/application/impersonation.test.ts",
@@ -15271,7 +15271,7 @@
       },
       {
         "path": "packages/contexts/identity-access/contracts/index.ts",
-        "sha256": "edc24eb6cd4d13fff9ce479c3cec4b8f4d4994f45d3bae9d29565912581c18b5"
+        "sha256": "98e69e3b5e8d3cde165abb5ba1b7f9bab4a308b26164c200d152bfcd10ab101c"
       },
       {
         "path": "packages/contexts/identity-access/domain/access-key.test.ts",
@@ -15363,7 +15363,7 @@
       },
       {
         "path": "packages/contexts/identity-access/domain/session.ts",
-        "sha256": "f9e29227f2c32710eb56ea90ff772561988bbf98ab35ec95cafe77d57e15412c"
+        "sha256": "7839d573994a20ef49e8499c509ebb7eba374f353e8e8e83d20e88b5c4a0c828"
       },
       {
         "path": "packages/contexts/identity-access/domain/testing.ts",
@@ -19971,11 +19971,11 @@
       },
       {
         "path": "scripts/arch/test-case-census.mjs",
-        "sha256": "46069742ba6a7a7149ef72c63051a63f973a1323397ebd276665b9c638b13d1e"
+        "sha256": "9503d49517b27ae85612bb9186b8466e095f1b5b259b78a6e4bc20e114e81c2c"
       },
       {
         "path": "scripts/arch/test-case-census.test.mjs",
-        "sha256": "d2a5fee22d616518a8aa68e8c933ac2635cbd6e2077219db29d818f61130656e"
+        "sha256": "ff36da00f6c011f52dc934e7c525d566f479f74fcd42f15d4f7a48920ee6c2df"
       },
       {
         "path": "scripts/arch/transaction-outcome.mjs",
@@ -20203,11 +20203,11 @@
       },
       {
         "path": "scripts/rest-census-independent.mjs",
-        "sha256": "690bda8825001b723b91c7d532ef6bb0c4daf75c820654b71581422e39813e29"
+        "sha256": "c667148e50cd42139d74a6413d91723309c440d7cda7b6a04b15e4137259efe5"
       },
       {
         "path": "scripts/rest-census-independent.test.mjs",
-        "sha256": "b2e76f4a6367553aa0fd6e633f178dfa6848a2bb18c59c7786063c267f4b2fb3"
+        "sha256": "3b986105c8f7110a219a7daddacdf6322d6adbcf2dc2a0cbd3ffd8a540998815"
       },
       {
         "path": "scripts/root-entry-manifest.mjs",
@@ -23867,7 +23867,7 @@
             {
               "from": "scripts/rest-census-independent.test.mjs",
               "kind": "reference",
-              "line": 109
+              "line": 112
             },
             {
               "from": "scripts/route-capability-parity.test.mjs",
@@ -25305,7 +25305,7 @@
           "apps/agent"
         ]
       },
-      "evidenceSha256": "db74d95f6972cee07465dcd54237811fa6a23caef0302ad5e1fdac1f349c57f5",
+      "evidenceSha256": "eddac2ffe85dda31f69ef823dc2d2f80b41685cc3c69fbe62e25c9dcbcd8a02a",
       "manifestSha256": "fb2672b4f608ba550dae81193ca9fbf7f9347a1402bd16841914dd9373e8e4af",
       "name": "platos-agent",
       "ociImageClosure": {
@@ -26194,7 +26194,7 @@
             {
               "from": "scripts/rest-census-independent.test.mjs",
               "kind": "reference",
-              "line": 110
+              "line": 113
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -26481,7 +26481,7 @@
           "apps/core-api"
         ]
       },
-      "evidenceSha256": "fc5fa8e7ccd07560584197857ab65776e35b8a49c5417f5d6b6c58983f6fd595",
+      "evidenceSha256": "7bdeeb46c8a9d34060a40ed0d771ab10a71e1498f95e2f5fe015acee511ee032",
       "manifestSha256": "8f069781279f60d7e3e5f0fdb9c952dff23d79800a8494c9a97e43672c007e26",
       "name": "@platos/core-api",
       "ociImageClosure": {
@@ -29846,7 +29846,7 @@
             {
               "from": "docs/audits/M0.9-rest-census-independent.json",
               "kind": "workspace-owned-file",
-              "line": 180
+              "line": 202
             },
             {
               "from": "docs/audits/M0.9-webapp-bff-matrix.json",
@@ -35220,7 +35220,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "cc44f4153d5e73c27b88bdfe0ce7c8fd527395e2a4dddb3c5792d8f3170fac40",
+      "evidenceSha256": "fb039ff130998ace7f4ac2406153024fb44fb75335c59033635d8ed5c01678ef",
       "manifestSha256": "5a1b05b0f1876135c37f848f7cbe73191e71b9c34ebb6980d97602ecc345a79f",
       "name": "docs",
       "ociImageClosure": {
@@ -41505,7 +41505,7 @@
             {
               "from": "apps/core-api/src/composition/identity-rest.integration.test.ts",
               "kind": "reference",
-              "line": 173
+              "line": 176
             },
             {
               "from": "apps/core-api/src/composition/operator-authentication.integration.test.ts",
@@ -42632,7 +42632,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "7582bc32b9f454b92a43b4fa5283a064003195ed1a8755b5c5bf84b0a81b6ba7",
+      "evidenceSha256": "c16e033ab3b1b00bef2c994f8134756520b34f592839b7049dc979b3319464a9",
       "manifestSha256": "22bd55003e357c1af7df013be8c2b416898d3b19fd4b38c763ffd701fb7e9de1",
       "name": "@platos/tenancy-database",
       "ociImageClosure": {
@@ -47087,7 +47087,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1812
+              "line": 1832
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -47251,7 +47251,7 @@
           "packages/adapters/keyring-envelope"
         ]
       },
-      "evidenceSha256": "cb088ba8f18c8730eb2ada449e0e717d11e1567136ef093be79055315b839e68",
+      "evidenceSha256": "520d6ec2cebce768309967a9448ef7c210b873d8e8cc83ff23af6298438990c6",
       "manifestSha256": "ae371bc6b627e6693e9a7b45f6a789d1df3f4489f8b93db1ed61c9c2fefdd854",
       "name": "@platos/adapter-keyring-envelope",
       "ociImageClosure": {
@@ -47654,7 +47654,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1254
+              "line": 1272
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -47843,7 +47843,7 @@
           "packages/adapters/model-router-providers"
         ]
       },
-      "evidenceSha256": "d891af706a4a908e44a41c0a3d1ca4327ff426f796d6276476264ffe748fde3b",
+      "evidenceSha256": "2ecd1b7f90ba22a6823181a8dc9bb2f39f46de11be666800ddd7452f441dd5be",
       "manifestSha256": "eaa4ecedce49dc05224e2c4b7982274d371f8fb27a60a9783fa643a8f6defcbd",
       "name": "@platos/adapter-model-router-providers",
       "ociImageClosure": {
@@ -48161,7 +48161,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1873
+              "line": 1893
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -48265,7 +48265,7 @@
           "packages/adapters/node-crypto-digest"
         ]
       },
-      "evidenceSha256": "96b4a4821e183e251eac31ccddb55a525184fb579559ab93c6bee49badf0b730",
+      "evidenceSha256": "f7c78d84178c985be939f1f0a0104987da0bc6d9394f972c98e4a29e441747a9",
       "manifestSha256": "229fe0120b22a0df9fb190c46ea80e762a3efc68e6e509531147796557ea58ce",
       "name": "@platos/adapter-node-crypto-digest",
       "ociImageClosure": {
@@ -49770,7 +49770,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1754
+              "line": 1774
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -49919,7 +49919,7 @@
           "packages/adapters/outbox"
         ]
       },
-      "evidenceSha256": "fb2f04e55bb213c5e7dc8404a203c515407870e524c1fef7306a4c572f1d7873",
+      "evidenceSha256": "cbf0b305a8814271478e1fe6f3a93e23f013803afe3c41cd84884817b5cc6c31",
       "manifestSha256": "83a45d455aac9f0e888c1045ad4b91d9111960486ba77a4a087018299d5941b2",
       "name": "@platos/adapter-outbox",
       "ociImageClosure": {
@@ -50283,7 +50283,7 @@
             {
               "from": "apps/core-api/src/composition/identity-rest.integration.test.ts",
               "kind": "reference",
-              "line": 276
+              "line": 284
             },
             {
               "from": "apps/core-api/src/composition/operator-authentication.integration.test.ts",
@@ -51058,7 +51058,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1351
+              "line": 1371
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -51947,7 +51947,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "8c3feb7da61ade813e524d750048c6c58f8672a9292f6d1840c21c0a883119d6",
+      "evidenceSha256": "efe26c1830ab9a6668108dc6ee8d4736ff6d7487ae77b91901d89f6ef3652cb1",
       "manifestSha256": "c3c49b3941820594e187dcbb86c78001443c58add67ce25009e535c3f1374927",
       "name": "@platos/adapter-postgres-tenancy",
       "ociImageClosure": {
@@ -54625,7 +54625,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1132
+              "line": 1150
             },
             {
               "from": "scripts/license-distribution.test.mjs",
@@ -54965,7 +54965,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "eb1002d665b66915a7d70d9a520f21907b1607a77b0022f39c3c80d10f7d6021",
+      "evidenceSha256": "56d446b5b4f950fa7c85dc98ff3e53a6705544590cb24aa35f388b27aa307d38",
       "manifestSha256": "e43db9efa534960ba5ade2f86cf89a88453e7575222d56297d6b6ccfe816a8f3",
       "name": "@platos/context-agents",
       "ociImageClosure": {
@@ -55614,7 +55614,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1196
+              "line": 1214
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -55862,7 +55862,7 @@
           "packages/contexts/channels"
         ]
       },
-      "evidenceSha256": "b57e4443a542a557484097215246d0b1086e61173bd62d1deff6c05ea68ba586",
+      "evidenceSha256": "78f06507e42a5cd738df174f13ff7aa717a2dc694ba6fa21a9da72ff1f6c8b62",
       "manifestSha256": "83395ffe4b76070f9efb7bd1bb4b49d7228aea090069f569a5eec747aa98ab74",
       "name": "@platos/context-channels",
       "ociImageClosure": {
@@ -56559,7 +56559,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1330
+              "line": 1350
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -56880,7 +56880,7 @@
           "packages/contexts/conversations"
         ]
       },
-      "evidenceSha256": "7f2763d54265bc76157ee09f839d53579e1ec9fb314b720ac52dc3d75efcf958",
+      "evidenceSha256": "eed2d48f3eba180b3e020233449dea8b6bc7b4ec2b1689980c517500bc009e02",
       "manifestSha256": "218c32b5c5b423bdf39bf215d6365c07bbd746fca291a1b0609da87e2cebd4d8",
       "name": "@platos/context-conversations",
       "ociImageClosure": {
@@ -57651,7 +57651,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1019
+              "line": 1037
             }
           ],
           "reversePaths": [
@@ -57973,7 +57973,7 @@
           "packages/contexts/cost-monitoring"
         ]
       },
-      "evidenceSha256": "e35ba95ca170c851f02667905e5cd05447036cbfd244762b770aefd9e21613d7",
+      "evidenceSha256": "dc564113f42f1a0b283a38048a6be8528a4943451ead704c72e5e006e3d0f6c5",
       "manifestSha256": "2e327d74bea9a17116d859d643836bc142e0977bd86d3a96567638fb75c7b3bb",
       "name": "@platos/context-cost-monitoring",
       "ociImageClosure": {
@@ -60925,7 +60925,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1227
+              "line": 1245
             }
           ],
           "reversePaths": [
@@ -61246,7 +61246,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "81acd55af6140f730de51ca5e78cd65b09f23cf53151608b93ec801cd4ea9c50",
+      "evidenceSha256": "2014a007b2c717a5971c86a66d5c3fe03d15f08495b235fec1e2490f6562ce92",
       "manifestSha256": "2e4c46079d53cec680be1e27cbc15aed896688935706c604462aef1db775b330",
       "name": "@platos/context-governance",
       "ociImageClosure": {
@@ -62254,7 +62254,7 @@
             {
               "file": "apps/core-api/src/transports/bff/session.controller.ts",
               "from": "apps/core-api",
-              "line": 44,
+              "line": 45,
               "specifier": "@platos/context-identity-access"
             },
             {
@@ -62990,7 +62990,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 676
+              "line": 680
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -63961,7 +63961,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "a3db2778a328ba67ecf7d8f759d8d19e373683865b2db95e46e6fbf4f5d0700d",
+      "evidenceSha256": "587293df458c7c81b62f6b16305f9c8fdfc2e9cb4dc1a0bdd515947f89d640c3",
       "manifestSha256": "df554d7bb17a6aab26b8ff63eb9c6033d16e186a234ad9d69c52d1eca7edf146",
       "name": "@platos/context-identity-access",
       "ociImageClosure": {
@@ -65864,7 +65864,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 989
+              "line": 1007
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -66219,7 +66219,7 @@
           "packages/contexts/memory"
         ]
       },
-      "evidenceSha256": "9306beb0112e91f77f052be3aebc733d0efb232ade0f50a17a5ebe5d2232684a",
+      "evidenceSha256": "49ae9f209c4e4a4c5b174dfa01ee1145bc7ee38d40dc43b30ada58907dff8f57",
       "manifestSha256": "d596af2fb68e3e6c3622cf1cfb1683e20f46b5fac434d3f8cd6bf37df74d5b28",
       "name": "@platos/context-memory",
       "ociImageClosure": {
@@ -66799,7 +66799,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1090
+              "line": 1108
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -67042,7 +67042,7 @@
           "packages/contexts/observability"
         ]
       },
-      "evidenceSha256": "b2616844c986ccfcafb45ff970f4822a5e4f666a905ce4ee5ea5c0343b4cded8",
+      "evidenceSha256": "c7796f714ac977cc7487d3f6fe41839db03ed6f54b069131f3e84bf7612939a1",
       "manifestSha256": "09d858b658a326451d6bdd026af44df9ba5d1b195ce0c71deffc0cb972afc6d7",
       "name": "@platos/context-observability",
       "ociImageClosure": {
@@ -67646,7 +67646,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1057
+              "line": 1075
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -67872,7 +67872,7 @@
           "packages/contexts/privacy"
         ]
       },
-      "evidenceSha256": "c9abe7d6af343bf9f65adbc84f6055e9f0fec39e868d7f51d12542f47cc4af5e",
+      "evidenceSha256": "33134b424d9cc08942ed4d625c3151c19c125954fcbe64b1bd46555614b9a38d",
       "manifestSha256": "8d9032044280327b5d3d795c13039f78e41ca275c9d6bce9f093b794a97473f1",
       "name": "@platos/context-privacy",
       "ociImageClosure": {
@@ -69244,7 +69244,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 777
+              "line": 782
             },
             {
               "from": "scripts/v1-ledger.test.mjs",
@@ -69869,7 +69869,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "712dfb49586f405da1535cacf256d898acadaffc0ec0493345c284c573e3be7b",
+      "evidenceSha256": "335aef72b4ac66b94af027d03b1df1f3165434c73a42a2f600fd7c15120c4e2f",
       "manifestSha256": "7462dcd3934c960646a6d3528915863411b9e195545de995cb54d10e6c43da83",
       "name": "@platos/context-providers",
       "ociImageClosure": {
@@ -72669,7 +72669,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 826
+              "line": 838
             }
           ],
           "reversePaths": [
@@ -72983,7 +72983,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "ae5c0afeaf39e92849cfec3fe091481896dcacbb36f8d9c1f1bae51ee237ae04",
+      "evidenceSha256": "391b450a5b418b13a005e9805f8fc49c339d708f7329796df69819312f57a852",
       "manifestSha256": "f1e56a67ae6b3d846f0887d8a17048ad19d4e0356bf7f38d1056b58507a2e7e2",
       "name": "@platos/context-skills",
       "ociImageClosure": {
@@ -74943,7 +74943,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 715
+              "line": 720
             },
             {
               "from": "scripts/arch/transaction-outcome.test.mjs",
@@ -75813,7 +75813,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "073c3b88d46debb75e575d8a7cabfde248592d71b1aca53022a6a883f1cd1401",
+      "evidenceSha256": "139e71ad84d45ee20b280462443d0b898407f0e2ab290cd4166626f446b820e0",
       "manifestSha256": "552444b4f4df12b062f2eb788b926946ca8310d37b21721f111e9995e78b2a94",
       "name": "@platos/context-tenancy",
       "ociImageClosure": {
@@ -76630,7 +76630,7 @@
             {
               "from": "scripts/arch/test-case-census.test.mjs",
               "kind": "reference",
-              "line": 1161
+              "line": 1179
             },
             {
               "from": "scripts/arch/v1-project-graph.test.mjs",
@@ -76954,7 +76954,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "173e831161757b8acd4aeca9432d00973e0f3f16ac021695123b933fb0602e83",
+      "evidenceSha256": "6dab3a1f6e404068d6904c32eca1dc25b5917f33d6139a293eb4a787dabfbb00",
       "manifestSha256": "87996481926b67e29a649aad1f8de452892ea7a0c07fa8f694e70a63420d490b",
       "name": "@platos/context-tools",
       "ociImageClosure": {
@@ -79808,7 +79808,7 @@
             {
               "file": "apps/core-api/src/transports/bff/session.controller.ts",
               "from": "apps/core-api",
-              "line": 43,
+              "line": 44,
               "specifier": "@platos/kernel"
             },
             {
@@ -81482,7 +81482,7 @@
             {
               "file": "packages/contexts/identity-access/application/authenticate-operator.ts",
               "from": "packages/contexts/identity-access",
-              "line": 29,
+              "line": 31,
               "specifier": "@platos/kernel"
             },
             {
@@ -81512,7 +81512,7 @@
             {
               "file": "packages/contexts/identity-access/application/identity-access-service.ts",
               "from": "packages/contexts/identity-access",
-              "line": 61,
+              "line": 64,
               "specifier": "@platos/kernel"
             },
             {
@@ -89820,7 +89820,7 @@
           "packages/kernel"
         ]
       },
-      "evidenceSha256": "045d0954c736379cc0ef9d010c77251b98e1686efb20d39682188f7c67175077",
+      "evidenceSha256": "16ff02a8f622430724a53ce99f42a1e4eb6085f43f7d23ad21173b68f185ff06",
       "manifestSha256": "4f315c3595455a1866bf39b540a93c4e447888035d3c5a445fc0bbf836219212",
       "name": "@platos/kernel",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "654a2b9a31e4a7c26a8f20de8bac91cc9bdc29249d2eaaaf9e5ea04a6ab20e1c",
+  "evidenceSha256": "4148eaf3c6e6e7db265867eb094344b0056f83b76af6262fc874480eb7d3ef9a",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "fa8541390491bd0d12059e433e2a2392b8cf269d28378c1fcd920bd44f204c8e",
+    "aggregateSha256": "0ef0cf385bf17296e691e1d71958945ea18143431e12f5f5c2d55472b7941254",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -4207,7 +4207,7 @@
       },
       {
         "path": "docs/audits/M0.9-rest-census-independent.json",
-        "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b"
+        "sha256": "0e4a7489121d19452407b774b9937b44bb2f77f0e6e2089dc7388f99e7b912b0"
       },
       {
         "path": "docs/audits/M0.9-webapp-bff-matrix.json",
@@ -20207,7 +20207,7 @@
       },
       {
         "path": "scripts/rest-census-independent.mjs",
-        "sha256": "c667148e50cd42139d74a6413d91723309c440d7cda7b6a04b15e4137259efe5"
+        "sha256": "364d8bbd01f6fae0dabb4b08d7216d2b61cfb5934aca36c9668e62292e35ba47"
       },
       {
         "path": "scripts/rest-census-independent.test.mjs",

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "290ce4047dd432d014942b950cb178b0aa0f57703611dcd865ea72e33765e2b6",
+  "evidenceSha256": "63af33bd51c295c3688fcf07b27c0f39c12ecc3c95a3b84e07a9ddc236092a01",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "8bb3fddd64d385d477a1de772d53bcfeaf0b9b0371ad0fe02ed049a8a7758bd0",
+    "aggregateSha256": "8b7ac504d3fcc736613b7e1d89d33f3d3e667291c91dab25d3ce902d707168a2",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -2739,7 +2739,7 @@
       },
       {
         "path": "apps/core-api/src/transports/rest/identity-rest.test.ts",
-        "sha256": "9e107953e0c252f4e0845f55ceac8d14f583480d8bf22b79cdddd5336484103a"
+        "sha256": "01ae7fd5ca08986e37bda8eaced3e9fddf3d1865a38c70d0be498e8683051c9a"
       },
       {
         "path": "apps/core-api/src/transports/rest/identity-session.controller.ts",
@@ -6299,7 +6299,7 @@
       },
       {
         "path": "docs/v1-ledger-rules.json",
-        "sha256": "6778fffc32c013ccc7b7ef224b2fcf9c11b7d3ffe2d62cc7344fe3e8923704d8"
+        "sha256": "d44655774607b5119ba3078e45d61ecced6c1fac9d2758ce69232df73deeb771"
       },
       {
         "path": "docs/v3-openapi.yaml",
@@ -20182,6 +20182,10 @@
         "sha256": "d69daa782f4d42ee5a3968fc229a767d16ce88606af5a03888f5ddb84712fd4b"
       },
       {
+        "path": "scripts/mutations-win267-w3.json",
+        "sha256": "1e2861996059218682dd16a1e281b7d7f80ade264d6e4e71c915520d24090b51"
+      },
+      {
         "path": "scripts/operator-operations.mjs",
         "sha256": "6fe420bc65cd8a5b123481e02767a00ce50b29b5a02b54e85819b9beb638adfa"
       },
@@ -20259,7 +20263,7 @@
       },
       {
         "path": "scripts/v1-ledger.test.mjs",
-        "sha256": "637ba8f7636d1ac9881e200eab832b6efe214bfc9b53fd44cedcb7df40dd33a6"
+        "sha256": "4019b0cccb52634a5f42fb679f2e56caba5c872372be01a5ba915226f5fb9b0b"
       },
       {
         "path": "scripts/vendored-build-audit.mjs",
@@ -38475,7 +38479,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1906
+              "line": 1924
             }
           ],
           "reversePaths": [
@@ -38500,7 +38504,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "a08bd9cdfdd91cd5a5e0feeeadbc1c4d56f618ea6d3c64e37c1ff0ea95c64443",
+      "evidenceSha256": "2e11e828ddcfa5558cea89bd18af6971504191ee93b7fe8833a33c8ad8cc3eec",
       "manifestSha256": "273951969710da5e07cfbb09885f792bbc938df2dfe3aed8d8e480438e113753",
       "name": "@platos/otlp-importer",
       "ociImageClosure": {
@@ -39641,7 +39645,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1905
+              "line": 1923
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -39866,7 +39870,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "9b24129d2752a33022918a9fc76a56129ebdb633b84c72c93e4ad04704929113",
+      "evidenceSha256": "cf4a1f682997b5e1e364ebe32d709149adb13030a0b7b6bac38658cc7a25cbaa",
       "manifestSha256": "5e3c30277d328e92c5781a7be8a60a9de1f5ab81898649bcd150b0ce5f3b48ab",
       "name": "@internal/run-engine",
       "ociImageClosure": {
@@ -62780,7 +62784,7 @@
             {
               "from": "apps/core-api/src/transports/rest/identity-rest.test.ts",
               "kind": "reference",
-              "line": 23
+              "line": 22
             },
             {
               "from": "packages/adapters/postgres-tenancy/fixtures/identity-access-rows.sql",
@@ -63961,7 +63965,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "587293df458c7c81b62f6b16305f9c8fdfc2e9cb4dc1a0bdd515947f89d640c3",
+      "evidenceSha256": "5f79e44ccf2546e6ed859ed6d5301e058a4a93a912b04ac35190ecc3d24c43a2",
       "manifestSha256": "df554d7bb17a6aab26b8ff63eb9c6033d16e186a234ad9d69c52d1eca7edf146",
       "name": "@platos/context-identity-access",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "63af33bd51c295c3688fcf07b27c0f39c12ecc3c95a3b84e07a9ddc236092a01",
+  "evidenceSha256": "654a2b9a31e4a7c26a8f20de8bac91cc9bdc29249d2eaaaf9e5ea04a6ab20e1c",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "8b7ac504d3fcc736613b7e1d89d33f3d3e667291c91dab25d3ce902d707168a2",
+    "aggregateSha256": "fa8541390491bd0d12059e433e2a2392b8cf269d28378c1fcd920bd44f204c8e",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -2695,7 +2695,7 @@
       },
       {
         "path": "apps/core-api/src/transports/bff/session.controller.ts",
-        "sha256": "1c08ef04379a398edb0735df4af770abf1356d1379869c8b585774a864a34ff5"
+        "sha256": "425c20c3122871f310c0dc4da7906fb1ef67fbb0cb549631204901cb1853e705"
       },
       {
         "path": "apps/core-api/src/transports/channels-ingress/index.ts",

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `63af33bd51c295c3688fcf07b27c0f39c12ecc3c95a3b84e07a9ddc236092a01`
+Evidence SHA-256: `654a2b9a31e4a7c26a8f20de8bac91cc9bdc29249d2eaaaf9e5ea04a6ab20e1c`
 
 ## Baseline
 

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `290ce4047dd432d014942b950cb178b0aa0f57703611dcd865ea72e33765e2b6`
+Evidence SHA-256: `63af33bd51c295c3688fcf07b27c0f39c12ecc3c95a3b84e07a9ddc236092a01`
 
 ## Baseline
 
@@ -51,9 +51,9 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
-| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `a08bd9cdfdd91cd5…` |
+| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `2e11e828ddcfa555…` |
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f0e0a0052870d59…` |
-| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `9b24129d2752a330…` |
+| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `cf4a1f682997b5e1…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
 | `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `c16e033ab3b1b00b…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
@@ -83,7 +83,7 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `d0d37c0d0c21591f…` |
 | `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `d9a119925699db70…` |
 | `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `2014a007b2c717a5…` |
-| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `587293df458c7c81…` |
+| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `5f79e44ccf2546e6…` |
 | `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `2aecfd1348b634b8…` |
 | `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `49ae9f209c4e4a4c…` |
 | `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `c7796f714ac977cc…` |

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `654a2b9a31e4a7c26a8f20de8bac91cc9bdc29249d2eaaaf9e5ea04a6ab20e1c`
+Evidence SHA-256: `4148eaf3c6e6e7db265867eb094344b0056f83b76af6262fc874480eb7d3ef9a`
 
 ## Baseline
 

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `fcb2b4ddc188b5d0f23615ed96be7234ec1ab44a0b4d71ad7dfaecc108d3de9d`
+Evidence SHA-256: `290ce4047dd432d014942b950cb178b0aa0f57703611dcd865ea72e33765e2b6`
 
 ## Baseline
 
@@ -39,11 +39,11 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 
 | Workspace | Package | OCI | App/deployable | Union | OCI+dev | Candidate status | Public boundary | Owner decision | Evidence hash |
 | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
-| `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `db74d95f6972cee0…` |
-| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `fc5fa8e7ccd07560…` |
+| `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `eddac2ffe85dda31…` |
+| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `7bdeeb46c8a9d340…` |
 | `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `5ae247020a53c416…` |
 | `apps/webapp` | `webapp` | yes | yes | yes | yes | retain-oci-image | no | no | `6d0671f708e83e8a…` |
-| `docs` | `docs` | no | no | no | no | owner-review-repository-referenced | no | yes | `cc44f4153d5e73c2…` |
+| `docs` | `docs` | no | no | no | no | owner-review-repository-referenced | no | yes | `fb039ff130998ace…` |
 | `internal-packages/cache` | `@internal/cache` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9f2db1155272a42…` |
 | `internal-packages/compute` | `@internal/compute` | no | no | no | no | owner-review-repository-referenced | no | yes | `744fd4bd20e8d379…` |
 | `internal-packages/cost-rates` | `@internal/cost-rates` | no | no | no | no | owner-review-repository-referenced | no | yes | `6164efe052d457dc…` |
@@ -55,7 +55,7 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f0e0a0052870d59…` |
 | `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `9b24129d2752a330…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
-| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `7582bc32b9f454b9…` |
+| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `c16e033ab3b1b00b…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
 | `internal-packages/testcontainers` | `@internal/testcontainers` | no | no | no | yes | owner-review-repository-referenced | no | yes | `bb476fbe57da5a07…` |
 | `internal-packages/tracing` | `@internal/tracing` | no | no | no | no | owner-review-repository-referenced | no | yes | `e03f6256d2d15deb…` |
@@ -64,37 +64,37 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/adapters/channel-slack` | `@platos/adapter-channel-slack` | no | yes | yes | no | retain-application-deployable | no | no | `29b17950af01fa36…` |
 | `packages/adapters/clickhouse-observability` | `@platos/adapter-clickhouse-observability` | no | yes | yes | no | retain-application-deployable | no | no | `90b03e040b6b4b30…` |
 | `packages/adapters/durable-runtime` | `@platos/adapter-durable-runtime` | no | yes | yes | no | retain-application-deployable | no | no | `923006eb949fcddc…` |
-| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `cb088ba8f18c8730…` |
-| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `d891af706a4a908e…` |
-| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `96b4a4821e183e25…` |
+| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `520d6ec2cebce768…` |
+| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `2ecd1b7f90ba22a6…` |
+| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `f7c78d84178c985b…` |
 | `packages/adapters/notifier-email` | `@platos/adapter-notifier-email` | no | yes | yes | no | retain-application-deployable | no | no | `214dcdfb7915d520…` |
 | `packages/adapters/notifier-webhook` | `@platos/adapter-notifier-webhook` | no | yes | yes | no | retain-application-deployable | no | no | `fde9eb07ee1d6e4c…` |
 | `packages/adapters/objectstore-minio` | `@platos/adapter-objectstore-minio` | no | yes | yes | no | retain-application-deployable | no | no | `fb582cbf0e1ab339…` |
-| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `fb2f04e55bb213c5…` |
-| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `8c3feb7da61ade81…` |
+| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `cbf0b305a8814271…` |
+| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `efe26c1830ab9a66…` |
 | `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `807d6e16ae7d31dd…` |
 | `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `8540f3d248bfdc9a…` |
 | `packages/adapters/redis-streams` | `@platos/adapter-redis-streams` | no | yes | yes | no | retain-application-deployable | no | no | `26a3c07d7a0ee3e3…` |
 | `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `bae70b172a574302…` |
-| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `eb1002d665b66915…` |
-| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `b57e4443a542a557…` |
-| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `7f2763d54265bc76…` |
-| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `e35ba95ca170c851…` |
+| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `56d446b5b4f950fa…` |
+| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `78f06507e42a5cd7…` |
+| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `eed2d48f3eba180b…` |
+| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `dc564113f42f1a0b…` |
 | `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `d0d37c0d0c21591f…` |
 | `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `d9a119925699db70…` |
-| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `81acd55af6140f73…` |
-| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `a3db2778a328ba67…` |
+| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `2014a007b2c717a5…` |
+| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `587293df458c7c81…` |
 | `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `2aecfd1348b634b8…` |
-| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `9306beb0112e91f7…` |
-| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `b2616844c986ccfc…` |
-| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `c9abe7d6af343bf9…` |
-| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `712dfb49586f405d…` |
+| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `49ae9f209c4e4a4c…` |
+| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `c7796f714ac977cc…` |
+| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `33134b424d9cc089…` |
+| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `335aef72b4ac66b9…` |
 | `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `04564a8bc6fe6435…` |
-| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `ae5c0afeaf39e928…` |
-| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `073c3b88d46debb7…` |
-| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `173e831161757b8a…` |
+| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `391b450a5b418b13…` |
+| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `139e71ad84d45ee2…` |
+| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `6dab3a1f6e404068…` |
 | `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `d1ae004000a14ce5…` |
-| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `045d0954c736379c…` |
+| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `16ff02a8f6224307…` |
 | `packages/platools-js` | `@platosdev/platools-sdk` | no | no | no | no | owner-review-public-boundary | yes | yes | `15e7a149a5ce15ca…` |
 | `packages/platos-client` | `@platosdev/client` | no | no | no | no | owner-review-public-boundary | yes | yes | `3c3aaec9b962238c…` |
 | `packages/platos-embed` | `@platosdev/embed` | no | no | no | no | owner-review-public-boundary | yes | yes | `26f83fd504a22a2c…` |

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "1af48ac762d1839c73668012052f75be74b86d8f318e085308b34d7dee2ccc24",
+      "sha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "afad10b887f0bc6e5ca84408064f85613018fb37b89da13ccf002bdaa20b454f",
+      "sha256": "c0977a03a515bb354e75fbfe9c1c20bc1e524f3b85e5afed7dfc59d770e2e5c3",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251",
+      "sha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "81a8213a2df100e28488a7795b01b481b4fdc0a21b711f4d984d8e2d325ea3ec",
+      "sha256": "8abf921f5ddb9282225614c6791c8e2fa59ffa1755b16846d92b80ae48a8d502",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "749a5e0aa2e0461525ef3550c425a9854b252f034d394d2834c2c7eaf7b14e4b",
+      "sha256": "f74222d43767966c78af4c9d9fcb0b8eb2f04d414bd143f066958490a80308ce",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d",
+      "sha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "c0977a03a515bb354e75fbfe9c1c20bc1e524f3b85e5afed7dfc59d770e2e5c3",
+      "sha256": "81a8213a2df100e28488a7795b01b481b4fdc0a21b711f4d984d8e2d325ea3ec",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "8d8fbf192a26f9f6d72f17b4ef373061085163e2897735439deedc97ec1b672e",
+      "sha256": "749a5e0aa2e0461525ef3550c425a9854b252f034d394d2834c2c7eaf7b14e4b",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1224,7 +1224,7 @@
       "path": "docs/audits/M0.9-rest-census-independent.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "8e3897c8532d3c06adffd3bb557bbf8afc4e41ecbb71ecb7016f49a31ae07b0f",
+      "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1224,7 +1224,7 @@
       "path": "docs/audits/M0.9-rest-census-independent.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b",
+      "sha256": "0e4a7489121d19452407b774b9937b44bb2f77f0e6e2089dc7388f99e7b912b0",
       "binds": "current-repository-truth"
     },
     {
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d",
+      "sha256": "47cfa686bff6e442ad53e30852d66b8b272e014530e301f5486787d686bedd56",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "8abf921f5ddb9282225614c6791c8e2fa59ffa1755b16846d92b80ae48a8d502",
+      "sha256": "2da4e21ea65c19b50d844aa54cb6ac20df18de5d614a768bbee2688ea706212c",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "f74222d43767966c78af4c9d9fcb0b8eb2f04d414bd143f066958490a80308ce",
+      "sha256": "3cf6e381f2ca245de32bdac79da69549d4ded91474b13eb1896812809cc3534d",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "34998dd65ce7731c17293258451b48b5725c0c10732c9df1a0943fd8112b8d62",
+      "sha256": "8d8fbf192a26f9f6d72f17b4ef373061085163e2897735439deedc97ec1b672e",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "34998dd65ce7731c17293258451b48b5725c0c10732c9df1a0943fd8112b8d62"
+      "sha256": "8d8fbf192a26f9f6d72f17b4ef373061085163e2897735439deedc97ec1b672e"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -848,7 +848,7 @@
     {
       "path": "docs/audits/M0.9-rest-census-independent.json",
       "mode": "100644",
-      "sha256": "8e3897c8532d3c06adffd3bb557bbf8afc4e41ecbb71ecb7016f49a31ae07b0f"
+      "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b"
     },
     {
       "path": "docs/audits/M0.9-webapp-bff-matrix.json",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d"
+      "sha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "c0977a03a515bb354e75fbfe9c1c20bc1e524f3b85e5afed7dfc59d770e2e5c3"
+      "sha256": "81a8213a2df100e28488a7795b01b481b4fdc0a21b711f4d984d8e2d325ea3ec"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "8d8fbf192a26f9f6d72f17b4ef373061085163e2897735439deedc97ec1b672e"
+      "sha256": "749a5e0aa2e0461525ef3550c425a9854b252f034d394d2834c2c7eaf7b14e4b"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",
@@ -3483,7 +3483,7 @@
     {
       "path": "docs/v1-ledger-rules.json",
       "mode": "100644",
-      "sha256": "6778fffc32c013ccc7b7ef224b2fcf9c11b7d3ffe2d62cc7344fe3e8923704d8"
+      "sha256": "d44655774607b5119ba3078e45d61ecced6c1fac9d2758ce69232df73deeb771"
     },
     {
       "path": "docs/v3-openapi.yaml",
@@ -3923,7 +3923,7 @@
     {
       "path": "scripts/v1-ledger.test.mjs",
       "mode": "100644",
-      "sha256": "637ba8f7636d1ac9881e200eab832b6efe214bfc9b53fd44cedcb7df40dd33a6"
+      "sha256": "4019b0cccb52634a5f42fb679f2e56caba5c872372be01a5ba915226f5fb9b0b"
     },
     {
       "path": "scripts/verify-advisory-nonvacuity.mjs",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "1af48ac762d1839c73668012052f75be74b86d8f318e085308b34d7dee2ccc24"
+      "sha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "afad10b887f0bc6e5ca84408064f85613018fb37b89da13ccf002bdaa20b454f"
+      "sha256": "c0977a03a515bb354e75fbfe9c1c20bc1e524f3b85e5afed7dfc59d770e2e5c3"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -848,7 +848,7 @@
     {
       "path": "docs/audits/M0.9-rest-census-independent.json",
       "mode": "100644",
-      "sha256": "9e39f923fb66c54a24179d38b78a4c908b5883301e34e2a622aa645486e1899b"
+      "sha256": "0e4a7489121d19452407b774b9937b44bb2f77f0e6e2089dc7388f99e7b912b0"
     },
     {
       "path": "docs/audits/M0.9-webapp-bff-matrix.json",
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d"
+      "sha256": "47cfa686bff6e442ad53e30852d66b8b272e014530e301f5486787d686bedd56"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "8abf921f5ddb9282225614c6791c8e2fa59ffa1755b16846d92b80ae48a8d502"
+      "sha256": "2da4e21ea65c19b50d844aa54cb6ac20df18de5d614a768bbee2688ea706212c"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "f74222d43767966c78af4c9d9fcb0b8eb2f04d414bd143f066958490a80308ce"
+      "sha256": "3cf6e381f2ca245de32bdac79da69549d4ded91474b13eb1896812809cc3534d"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251"
+      "sha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "81a8213a2df100e28488a7795b01b481b4fdc0a21b711f4d984d8e2d325ea3ec"
+      "sha256": "8abf921f5ddb9282225614c6791c8e2fa59ffa1755b16846d92b80ae48a8d502"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "749a5e0aa2e0461525ef3550c425a9854b252f034d394d2834c2c7eaf7b14e4b"
+      "sha256": "f74222d43767966c78af4c9d9fcb0b8eb2f04d414bd143f066958490a80308ce"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4729,8 +4729,8 @@
   "integration": {
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
-    "ledgerRulesSha256": "6778fffc32c013ccc7b7ef224b2fcf9c11b7d3ffe2d62cc7344fe3e8923704d8",
-    "reachabilitySha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d",
+    "ledgerRulesSha256": "d44655774607b5119ba3078e45d61ecced6c1fac9d2758ce69232df73deeb771",
+    "reachabilitySha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4730,7 +4730,7 @@
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
     "ledgerRulesSha256": "d44655774607b5119ba3078e45d61ecced6c1fac9d2758ce69232df73deeb771",
-    "reachabilitySha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d",
+    "reachabilitySha256": "47cfa686bff6e442ad53e30852d66b8b272e014530e301f5486787d686bedd56",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4730,7 +4730,7 @@
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
     "ledgerRulesSha256": "d44655774607b5119ba3078e45d61ecced6c1fac9d2758ce69232df73deeb771",
-    "reachabilitySha256": "af90315ee0843d9449d90b93d486a037d66f591e06c522f919019e39368c5251",
+    "reachabilitySha256": "41d1a6ed8e142e89543666f360ab3fc24ef111aedd259cdb53e9a75f7a8aff7d",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4730,7 +4730,7 @@
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
     "ledgerRulesSha256": "6778fffc32c013ccc7b7ef224b2fcf9c11b7d3ffe2d62cc7344fe3e8923704d8",
-    "reachabilitySha256": "1af48ac762d1839c73668012052f75be74b86d8f318e085308b34d7dee2ccc24",
+    "reachabilitySha256": "c010c37d9d71960f6fa4da0e409cc08cbec77f51378ce6668d932518db599e9d",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/v1-ledger-rules.json
+++ b/docs/v1-ledger-rules.json
@@ -2082,7 +2082,7 @@
     ]
   },
   "expected": {
-    "totalFiles": 5140,
+    "totalFiles": 5141,
     "areaCounts": {
       "apps-agent": 516,
       "apps-core-api": 86,
@@ -2091,7 +2091,7 @@
       "docs-content": 737,
       "internal-packages": 1174,
       "packages": 2140,
-      "root-infra": 296
+      "root-infra": 297
     },
     "kindCounts": {
       "asset": 155,
@@ -2102,12 +2102,12 @@
       "legal": 14,
       "lockfile": 3,
       "migration": 896,
-      "source": 2065,
+      "source": 2066,
       "test": 1036
     },
     "dispositionCounts": {
       "archive": 7,
-      "move-refactor": 1633,
+      "move-refactor": 1634,
       "regenerate": 39,
       "retain": 3459,
       "unresolved": 2
@@ -2247,9 +2247,9 @@
       "root-infra.test.harness": 69,
       "root-infra.test.script-suites": 32,
       "root-infra.test.workspace-reachability": 1,
-      "root-infra.tooling.scripts": 93,
+      "root-infra.tooling.scripts": 94,
       "root-infra.tooling.workspace-reachability": 1
     },
-    "classificationSha256": "6a69ecfd82ce6b4eb75e8cbba8e282809ea79c424b7faa66d16026fb62297964"
+    "classificationSha256": "a43addcdf5d6be94c885a47f90dc8a9045ffe63232cf35b92cf5943fef34b4ca"
   }
 }

--- a/packages/contexts/identity-access/application/authenticate-operator.test.ts
+++ b/packages/contexts/identity-access/application/authenticate-operator.test.ts
@@ -124,6 +124,37 @@ describe("revoking a session", () => {
     await revokeOperatorSession(ports, { presentedToken: RAW });
     const second = await revokeOperatorSession(ports, { presentedToken: RAW });
     expect(second.ok).toBe(false);
+    if (second.ok) return;
+    // THE CODE, NOT JUST THE FAILURE (WIN-267 W3). `.ok === false` was true both
+    // before and after this use case started calling `domain/session.ts::revoked`,
+    // which is why it did not notice that the already-ended branch answered
+    // `UNAUTHENTICATED` — the SAME code as a token no row matches — while the
+    // domain rule it duplicated answered `SESSION_REVOKED`.
+    expect(second.error.code).toBe("SESSION_REVOKED");
+  });
+
+  it("does not re-stamp a session it did not end", async () => {
+    // The revocation instant is evidence: an incident asks WHEN a session was
+    // ended, and a second logout that moved `revokedAt` forward would answer with
+    // the time of the retry.
+    const ports = arrange();
+    await revokeOperatorSession(ports, { presentedToken: RAW });
+    ports.clock.set(at(MINUTE_MS));
+    await revokeOperatorSession(ports, { presentedToken: RAW });
+    expect(ports.repository.state.sessions.get(sessionId())?.revokedAt).toEqual(T0);
+  });
+
+  it("keeps an unknown token and an absent token under ONE code, on purpose", async () => {
+    // The opposite decision from the case above, and it is not an inconsistency:
+    // separating these two would let a caller confirm whether a guessed token
+    // exists, which `unauthenticated`'s banner refuses. An already-ended session
+    // tells the presenter nothing they did not already know.
+    const ports = arrange();
+    const unknown = await revokeOperatorSession(ports, { presentedToken: "plt_os_nope" });
+    const absent = await revokeOperatorSession(ports, { presentedToken: null });
+    expect(unknown.ok || absent.ok).toBe(false);
+    if (unknown.ok || absent.ok) return;
+    expect([unknown.error.code, absent.error.code]).toEqual(["UNAUTHENTICATED", "UNAUTHENTICATED"]);
   });
 
   it("no longer authenticates once revoked", async () => {

--- a/packages/contexts/identity-access/application/authenticate-operator.ts
+++ b/packages/contexts/identity-access/application/authenticate-operator.ts
@@ -19,11 +19,13 @@
 import {
   evaluateOperatorSession,
   isTotpEnabled,
+  revoked,
   touched,
   unauthenticated,
   type OperatorAuthorization,
   type OperatorSessionRecord,
   type OperatorUserRecord,
+  type RevokedOperatorSession,
 } from "../domain/index.js";
 import type { PortsOf } from "./dependencies.js";
 import { err, ok, type Result } from "@platos/kernel";
@@ -85,19 +87,36 @@ async function loadParentSession(
  * Reports whether THIS call ended it, because a logout that silently succeeds on
  * an already-revoked session cannot be distinguished from one that worked, and
  * the impersonation-stop path depends on that distinction.
+ *
+ * THE ALREADY-REVOKED BRANCH IS THE DOMAIN'S, NOT THIS FUNCTION'S (WIN-267 W3).
+ * `domain/session.ts::revoked` has carried that rule since it was written, with
+ * a banner explaining why revoking is not idempotent, and it answers
+ * `SESSION_REVOKED`. This use case used to re-derive the same check inline and
+ * answer `UNAUTHENTICATED { reason: "already-revoked" }` instead — two guards
+ * deciding one thing under two codes, which is the exact defect
+ * `error-taxonomy.mjs` exists to prevent and which `impersonation.ts` never had
+ * because it called the domain helper. A caller could not tell "there is no such
+ * session" from "that session was already ended", and those are different
+ * answers to somebody chasing a stolen cookie.
+ *
+ * The three refusals are now distinct: no credential and no matching row stay
+ * `UNAUTHENTICATED` (they must — telling them apart is an enumeration oracle,
+ * and `unauthenticated`'s banner says so), while an already-ended session is
+ * `SESSION_REVOKED`, which reveals nothing a holder of that token did not
+ * already know.
  */
 export async function revokeOperatorSession(
   ports: AuthenticateOperatorPorts,
   input: AuthenticateOperatorInput,
-): Promise<Result<OperatorSessionRecord>> {
+): Promise<Result<RevokedOperatorSession>> {
   if (!input.presentedToken) return err(unauthenticated({ reason: "no-token" }));
   const now = ports.clock.now();
   const sessions = ports.repository.operatorSessions;
   const session = await sessions.findByTokenHash(ports.hasher.hash(input.presentedToken));
   if (session === null) return err(unauthenticated({ reason: "no-session" }));
-  if (session.revokedAt !== null) return err(unauthenticated({ reason: "already-revoked" }));
 
-  const ended: OperatorSessionRecord = { ...session, revokedAt: now };
-  await sessions.save(ended);
-  return ok(ended);
+  const ended = revoked(session, now);
+  if (!ended.ok) return ended;
+  await sessions.save(ended.value);
+  return ended;
 }

--- a/packages/contexts/identity-access/application/identity-access-service.test.ts
+++ b/packages/contexts/identity-access/application/identity-access-service.test.ts
@@ -127,6 +127,84 @@ describe("authenticateOperator — refusals", () => {
   });
 });
 
+describe("revokeOperatorSession — the other half of clearSessionCookie (WIN-267 W3)", () => {
+  it("ENDS the session, and the same token no longer authenticates", async () => {
+    const ports = withSession();
+    const service = createIdentityAccessService(ports);
+    // LIVE FIRST. Without this line the case below would pass against a store
+    // that never held the session at all, which is the shape a broken fixture
+    // takes and the reason "it is refused afterwards" is not by itself evidence.
+    expect((await service.authenticateOperator({ presentedToken: SESSION_TOKEN })).ok).toBe(true);
+
+    const ended = await service.revokeOperatorSession({ presentedToken: SESSION_TOKEN });
+    expect(ended.ok, JSON.stringify(ended)).toBe(true);
+    if (!ended.ok) return;
+    expect(ended.value.sessionId).toBe(sessionId());
+    expect(ended.value.revokedAt).toEqual(ports.clock.now());
+    // THE STORE, NOT THE RETURN VALUE. A façade that projected a revocation it
+    // never persisted would satisfy every assertion above.
+    expect(ports.repository.state.sessions.get(sessionId())?.revokedAt).toEqual(ports.clock.now());
+
+    expect(await operatorRefusal(ports, SESSION_TOKEN)).toBe("SESSION_REVOKED");
+  });
+
+  it("carries EXACTLY the two published keys, so a sign-out leaks no session internals", async () => {
+    const ended = await createIdentityAccessService(withSession()).revokeOperatorSession({
+      presentedToken: SESSION_TOKEN,
+    });
+    expect(ended.ok).toBe(true);
+    if (!ended.ok) return;
+    // An exact set for the reason the operator projection gives: the record
+    // underneath DOES carry `tokenHash`, `parentSessionId` and the impersonation
+    // chain, so a spread here would leak them and no type error would follow.
+    expect(Object.keys(ended.value).sort()).toEqual(["revokedAt", "sessionId"]);
+  });
+
+  it("tells an ALREADY-ENDED session apart from one that never existed", async () => {
+    // THE DEFECT THIS PINS. The use case used to answer `UNAUTHENTICATED
+    // { reason: "already-revoked" }` for the second call — the same code as a
+    // token no row matches — while `domain/session.ts::revoked`, which has held
+    // that rule the whole time, answers SESSION_REVOKED. Two guards, one
+    // decision, two codes: a caller could not tell "there is no such session"
+    // from "that session was already ended".
+    const ports = withSession();
+    const service = createIdentityAccessService(ports);
+    expect((await service.revokeOperatorSession({ presentedToken: SESSION_TOKEN })).ok).toBe(true);
+
+    const second = await service.revokeOperatorSession({ presentedToken: SESSION_TOKEN });
+    const unknown = await service.revokeOperatorSession({ presentedToken: "plt_os_no-such-token" });
+    const absent = await service.revokeOperatorSession({ presentedToken: null });
+    expect(second.ok).toBe(false);
+    expect(unknown.ok).toBe(false);
+    expect(absent.ok).toBe(false);
+    if (second.ok || unknown.ok || absent.ok) return;
+    expect(second.error.code).toBe("SESSION_REVOKED");
+    // AND THESE TWO STAY THE SAME CODE ON PURPOSE. Separating "no token" from
+    // "no such session" would confirm to an attacker whether a guessed token
+    // exists; `unauthenticated`'s own banner is explicit about it.
+    expect(unknown.error.code).toBe("UNAUTHENTICATED");
+    expect(absent.error.code).toBe("UNAUTHENTICATED");
+    expect(new Set([second.error.code, unknown.error.code]).size).toBe(2);
+  });
+
+  it("ENDS AN EXPIRED SESSION rather than refusing it, so a lapsed browser can still sign out", async () => {
+    // The extraction source's revoke is `updateMany where revokedAt IS NULL` and
+    // says nothing about expiry, so this is parity rather than a new rule — and
+    // it matters: refusing here would leave the one credential a user most wants
+    // destroyed alive until its own clock ran out.
+    const ports = withSession({ expiresAt: at(DAY_MS) });
+    ports.clock.set(at(DAY_MS + MINUTE_MS));
+    expect(await operatorRefusal(ports, SESSION_TOKEN)).toBe("SESSION_EXPIRED");
+    const ended = await createIdentityAccessService(ports).revokeOperatorSession({
+      presentedToken: SESSION_TOKEN,
+    });
+    expect(ended.ok, "an expired session is still ended on request").toBe(true);
+    // AND THE STORY CHANGES with it: the same token now reads REVOKED, not
+    // EXPIRED, which is the distinction a support engineer is looking at.
+    expect(await operatorRefusal(ports, SESSION_TOKEN)).toBe("SESSION_REVOKED");
+  });
+});
+
 describe("authenticateOperator — the projection", () => {
   it("returns the view a consumer is entitled to", async () => {
     const result = await createIdentityAccessService(withSession()).authenticateOperator({

--- a/packages/contexts/identity-access/application/identity-access-service.ts
+++ b/packages/contexts/identity-access/application/identity-access-service.ts
@@ -33,6 +33,7 @@ import {
   type BearerAuthorization,
   type EndUserWithIdentities,
   type OperatorAuthorization,
+  type RevokedOperatorSession,
   type SessionCookieDirective,
   type PermittedRateLimitDecision,
 } from "../domain/index.js";
@@ -44,6 +45,8 @@ import type {
   IdentityAccessContract,
   IssueSessionCookieRequest,
   ListEndUsersRequest,
+  RevokedOperatorSessionView,
+  RevokeOperatorSessionRequest,
   RotateSessionCookieRequest,
   SessionCookieDirectiveView,
   SessionCookieShapeView,
@@ -55,7 +58,7 @@ import type {
 } from "../contracts/index.js";
 import { authenticateBearerToken } from "./authenticate-bearer-token.js";
 import { listEndUsers, type EndUserPage } from "./list-end-users.js";
-import { authenticateOperator } from "./authenticate-operator.js";
+import { authenticateOperator, revokeOperatorSession } from "./authenticate-operator.js";
 import { consumeRateLimit } from "./consume-rate-limit.js";
 import type { IdentityAccessPorts } from "./dependencies.js";
 import { err, ok, type Result } from "@platos/kernel";
@@ -99,6 +102,20 @@ function operatorView(authorization: OperatorAuthorization): OperatorAuthorizati
         ? null
         : { targetUserId: authorization.impersonation.targetUserId },
   };
+}
+
+/**
+ * Project an ENDED session.
+ *
+ * TWO FIELDS, AND THE OTHER ELEVEN ARE DROPPED FOR THE REASON THE FILE BANNER
+ * GIVES: the record carries `tokenHash`, the parent session and the
+ * impersonation chain, and a consumer of a sign-out has no use for any of them.
+ * `revokedAt` needs no `?? null` because `RevokedOperatorSession` narrows it to
+ * a `Date` — the domain rule that produced the value has already excluded the
+ * null branch, so there is no unreachable fallback here to go untested.
+ */
+function revokedView(session: RevokedOperatorSession): RevokedOperatorSessionView {
+  return { sessionId: session.sessionId, revokedAt: session.revokedAt };
 }
 
 /**
@@ -202,6 +219,13 @@ export function createIdentityAccessService(ports: IdentityAccessPorts): Identit
         presentedToken: request.presentedToken,
       });
       return authorization.ok ? ok(operatorView(authorization.value)) : authorization;
+    },
+
+    async revokeOperatorSession(
+      request: RevokeOperatorSessionRequest,
+    ): Promise<Result<RevokedOperatorSessionView>> {
+      const ended = await revokeOperatorSession(ports, { presentedToken: request.presentedToken });
+      return ended.ok ? ok(revokedView(ended.value)) : ended;
     },
 
     async authenticateBearer(

--- a/packages/contexts/identity-access/contracts/index.ts
+++ b/packages/contexts/identity-access/contracts/index.ts
@@ -86,6 +86,35 @@ export interface AuthenticateOperatorRequest {
   readonly presentedToken: string | null;
 }
 
+/**
+ * The credential whose session is to be ENDED.
+ *
+ * A separate type from `AuthenticateOperatorRequest` even though the field is
+ * the same one, because the two carry different authority: presenting a token to
+ * be checked is a read, and presenting it to be destroyed is a write. A shared
+ * type would make widening one of them silently widen the other.
+ */
+export interface RevokeOperatorSessionRequest {
+  readonly presentedToken: string | null;
+}
+
+/**
+ * What a SUCCESSFUL revocation reports.
+ *
+ * `revokedAt` is the instant the store now holds, not the instant the caller
+ * asked — a caller that stamped its own clock into an audit line would be
+ * recording something no row says.
+ *
+ * NOTHING ELSE IS HERE. The use case returns the whole `OperatorSessionRecord`,
+ * which carries `tokenHash`, `parentSessionId` and the impersonation chain; this
+ * context's own banner calls those "internals it has no business with", and a
+ * sign-out has less business with them than anything else on this contract.
+ */
+export interface RevokedOperatorSessionView {
+  readonly sessionId: string;
+  readonly revokedAt: Date;
+}
+
 export interface AuthenticateBearerRequest {
   readonly presentedToken: string | null;
   /** Where the request is addressed. Null skips the cross-scope check. */
@@ -216,6 +245,39 @@ export interface IdentityAccessContract {
   authenticateOperator(
     request: AuthenticateOperatorRequest,
   ): Promise<Result<OperatorAuthorizationView>>;
+
+  /**
+   * END a dashboard session, server-side (WIN-267 W3).
+   *
+   * WHY THIS IS PUBLISHED AND MINTING IS NOT. The banner above says no other
+   * context may ISSUE a credential, and that is unchanged: this method creates
+   * nothing and can only ever be aimed at a credential the caller is already
+   * holding. A caller with no token cannot end anybody's session, and a caller
+   * with a token can already do everything that session can do — so publishing
+   * the destruction of it hands out no authority the presenter did not have.
+   *
+   * IT IS THE OTHER HALF OF `clearSessionCookie`, AND UNTIL NOW ONLY ONE HALF
+   * EXISTED. `DELETE /api/v1/bff/session` could clear the browser and nothing
+   * more, because `revokeOperatorSession` lived in `application/` behind no
+   * contract method and a V1 transport may only reach a contract method. A user
+   * who signed out was told the session had ended while it stayed valid, on the
+   * server, for the rest of its lifetime — which is precisely the window a
+   * stolen cookie is stolen for. The two are separate methods rather than one
+   * because they fail independently: the row is ended even if the header never
+   * reaches the browser, and that is the order a sign-out must happen in.
+   *
+   * THE REFUSALS ARE THREE AND THEY ARE DISTINCT. `UNAUTHENTICATED` for an
+   * absent token and for one no row matches — deliberately the same code, since
+   * separating them would confirm whether a token exists — and `SESSION_REVOKED`
+   * for a session that was already ended, which tells the caller only what
+   * holding that token already told them. `SESSION_EXPIRED` is NOT among them: a
+   * session past its window is still ended on request, exactly as the extraction
+   * source's conditional update does, so a lapsed browser can still be signed
+   * out for good.
+   */
+  revokeOperatorSession(
+    request: RevokeOperatorSessionRequest,
+  ): Promise<Result<RevokedOperatorSessionView>>;
 
   /**
    * Verify a scoped bearer credential and, when a scope is supplied, deny it

--- a/packages/contexts/identity-access/domain/session.ts
+++ b/packages/contexts/identity-access/domain/session.ts
@@ -196,10 +196,21 @@ export function touched(session: OperatorSessionRecord, now: Date): OperatorSess
  * successful one, and the same distinction is what makes concurrent
  * impersonation-stop safe.
  */
-export function revoked(session: OperatorSessionRecord, now: Date): Result<OperatorSessionRecord> {
+export function revoked(session: OperatorSessionRecord, now: Date): Result<RevokedOperatorSession> {
   if (session.revokedAt !== null) return err(sessionRevoked());
   return ok({ ...session, revokedAt: now });
 }
+
+/**
+ * A session this rule has just ENDED, with `revokedAt` narrowed to a `Date`.
+ *
+ * `OperatorSessionRecord.revokedAt` is nullable because most sessions are live,
+ * and a caller projecting the outcome of a revocation would otherwise have to
+ * write `?? somethingElse` for a branch `revoked` above has already made
+ * unreachable. A fallback on an impossible branch is untested code in an
+ * authentication path, and the type removes the need for one.
+ */
+export type RevokedOperatorSession = OperatorSessionRecord & { readonly revokedAt: Date };
 
 export function verifiedSecondFactor(
   session: OperatorSessionRecord,

--- a/scripts/arch/test-case-census.mjs
+++ b/scripts/arch/test-case-census.mjs
@@ -2616,7 +2616,16 @@ export const EXPECTED = Object.freeze({
   // constructors themselves move the EXISTING uniqueness case's list rather than
   // adding one, which is not a new case.
   "packages/contexts/governance": { files: 31, cases: 610 },
-  "packages/contexts/identity-access": { files: 23, cases: 318 },
+  // WIN-267 W3: 318 -> 324 cases, files unmoved — the sign-out that had no
+  // server side. FOUR in `application/identity-access-service.test.ts` for the
+  // newly published `revokeOperatorSession` (it ends the row and the token stops
+  // authenticating; the view carries exactly two keys; an already-ended session
+  // is told apart from one that never existed; an EXPIRED session is still ended
+  // rather than refused) and TWO in `application/authenticate-operator.test.ts`
+  // (a second revoke does not re-stamp `revokedAt`; an unknown token and an
+  // absent one stay under ONE code on purpose). No new file: both suites
+  // existed, which is why `files` does not move.
+  "packages/contexts/identity-access": { files: 23, cases: 324 },
   "packages/contexts/jobs": { files: 16, cases: 386 },
   "packages/contexts/memory": { files: 28, cases: 605 },
   "packages/contexts/observability": { files: 15, cases: 288 },
@@ -3463,8 +3472,23 @@ export const EXPECTED = Object.freeze({
  * `node scripts/arch/test-case-census.mjs` rather than trusted from this sum.
  * Two sibling branches move these pins in the same window, so the integrator
  * SUMS the deltas rather than taking any one branch's total.
+ *
+ * WIN-267 W3 DELTA, the server-side sign-out. ONE row moves and NO file does:
+ *
+ *   packages/contexts/identity-access 23 -> 23 files, 318 -> 324 cases
+ *
+ * All six run anywhere — they are in-memory port doubles, and the case that
+ * needs a real PostgreSQL (the replayed cookie, read back with `psql` inside the
+ * container) lives in `apps/core-api`, which is OUTSIDE `PACKAGE_ROOTS` and
+ * therefore moves nothing here. That asymmetry is worth stating plainly: this
+ * census does not see the evidence the tranche turns on.
+ *
+ * 8124 + 6 = 8130 over 549 files, READ BACK from
+ * `node scripts/arch/test-case-census.mjs` rather than trusted from this sum.
+ * Two sibling branches move this pin in the same window, so the integrator SUMS
+ * the deltas rather than taking any one branch's total.
  */
-export const EXPECTED_RUNTIME_TOTAL = 8124;
+export const EXPECTED_RUNTIME_TOTAL = 8130;
 
 /** Every case-declaring package directory, in byte order. */
 export function listPackages(root = repositoryRoot) {

--- a/scripts/arch/test-case-census.test.mjs
+++ b/scripts/arch/test-case-census.test.mjs
@@ -673,7 +673,12 @@ test("the split the 2026-09-02 verification reproduced is pinned per package", (
   assert.equal(EXPECTED["packages/kernel"].cases, 129);
   assert.equal(EXPECTED["packages/kernel"].cases, 44 + 16 + 29 + 40);
   assert.equal(EXPECTED["packages/kernel"].files, 6, "3 value-object suites, the WIN-259 redactor suite, and the two WIN-260 behaviour suites");
-  assert.equal(EXPECTED["packages/contexts/identity-access"].cases, 318, "231 at 3ed8f3ce, +25 contract suite, +28 end-user read, +34 session cookie");
+  // WIN-267 W3 appends `+6`: the published `revokeOperatorSession` and the two
+  // refusal-code cases underneath it. The terms are kept rather than the total
+  // adjusted, so a tranche that removed the session-cookie suite while this
+  // landed could not reach the same number.
+  assert.equal(EXPECTED["packages/contexts/identity-access"].cases, 324, "231 at 3ed8f3ce, +25 contract suite, +28 end-user read, +34 session cookie, +6 server-side sign-out");
+  assert.equal(EXPECTED["packages/contexts/identity-access"].cases, 231 + 25 + 28 + 34 + 6);
   // WIN-259 (M2.4) 162 -> 209. `secrets` was one of the five asserted UNMOVED
   // above and it moves now, so the reasons are stated rather than the number
   // adjusted. THREE suites, in three terms so one shrinking while another grows
@@ -808,7 +813,14 @@ test("the providers context is pinned at what vitest prints", () => {
   // row. Two terms because two rows move — which is the property this file
   // exists for, since a sum stated twelve ways cannot be edited in one place
   // and a term dropped from one of them shows up here rather than in the pin.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  //
+  // WIN-267 W3 appends `+ 6` to the same twelve. ONE term because ONE row moves:
+  // `packages/contexts/identity-access` 318 -> 324, four cases for the newly
+  // published `revokeOperatorSession` and two for the revoke use case's refusal
+  // codes. No file arrives, so the `totalFiles` sum below is untouched, and that
+  // asymmetry is the check working: a suite added to an EXISTING file moves cases
+  // and not files, and a term appended to both sums would have been wrong.
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the skills adoption is pinned, and moved nothing else", () => {
@@ -847,7 +859,13 @@ test("the skills adoption is pinned, and moved nothing else", () => {
     // four are still untouched by it.
     // M2 INTEGRATION: 44 + 16 + 69 = 129.
     "packages/kernel": 129,
-    "packages/contexts/identity-access": 318,
+    // WIN-267 W3 318 -> 324. `identity-access` STOPS being untouched by the
+    // skills adoption's re-derivation here, for the reason `providers` and
+    // `secrets` below stopped: the row is kept in this map rather than dropped
+    // from it, so the sum still spans every package it always spanned and a
+    // suite deleted from `identity-access` while W3 landed cannot hide inside a
+    // narrower span.
+    "packages/contexts/identity-access": 324,
     // WIN-259 (M2.4) 162 -> 215. `secrets` STOPS being untouched here too:
     // `sweep-root-key-reencryption.test.ts` adds sixteen cases for rotation as
     // a job, and the legacy-envelope migration adds thirty-seven more across its
@@ -988,7 +1006,7 @@ test("the memory context is pinned at what vitest prints", () => {
   // alone; here the identity only closes with every adoption's term present.
   assert.equal(EXPECTED["packages/contexts/memory"].files, 28);
   assert.equal(EXPECTED["packages/contexts/memory"].cases, 605);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the cost-monitoring context is pinned at what vitest prints", () => {
@@ -1018,7 +1036,7 @@ test("the cost-monitoring context is pinned at what vitest prints", () => {
   // with every adoption's term present.
   assert.equal(EXPECTED["packages/contexts/cost-monitoring"].files, 21);
   assert.equal(EXPECTED["packages/contexts/cost-monitoring"].cases, 352);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the privacy context is pinned at what vitest prints", () => {
@@ -1056,7 +1074,7 @@ test("the privacy context is pinned at what vitest prints", () => {
   // observability's 288 and agents' 515 included.
   assert.equal(EXPECTED["packages/contexts/privacy"].cases, 240 + 12 + 2);
   assert.equal(EXPECTED["packages/contexts/privacy"].files, 15, "the file count did NOT move; the case count did");
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the observability context is pinned at what vitest prints", () => {
@@ -1089,7 +1107,7 @@ test("the observability context is pinned at what vitest prints", () => {
   // agents' 515 included.
   assert.equal(EXPECTED["packages/contexts/observability"].files, 15);
   assert.equal(EXPECTED["packages/contexts/observability"].cases, 281 + 6 + 1);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the agents context is pinned at what vitest prints", () => {
@@ -1132,7 +1150,7 @@ test("the agents context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/agents"].files, 25);
   assert.equal(EXPECTED["packages/contexts/agents"].cases, 515);
   assert.equal(EXPECTED["packages/contexts/agents"].cases, 513 + 4 - 3 - 1 + 2);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the tools context is pinned at what vitest prints", () => {
@@ -1161,7 +1179,7 @@ test("the tools context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/tools"].files, 19);
   assert.equal(EXPECTED["packages/contexts/tools"].cases, 362);
   assert.equal(EXPECTED["packages/contexts/tools"].cases, 325 + 29 + 6 + 2);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the channels context is pinned at what vitest prints", () => {
@@ -1196,7 +1214,7 @@ test("the channels context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/channels"].files, 15);
   assert.equal(EXPECTED["packages/contexts/channels"].cases, 269);
   assert.equal(EXPECTED["packages/contexts/channels"].cases, 263 + 4 + 1 + 1);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the governance context is pinned at what vitest prints", () => {
@@ -1227,7 +1245,7 @@ test("the governance context is pinned at what vitest prints", () => {
   assert.equal(EXPECTED["packages/contexts/governance"].files, 31);
   assert.equal(EXPECTED["packages/contexts/governance"].cases, 610);
   assert.equal(EXPECTED["packages/contexts/governance"].cases, 586 + 1 + 22 + 1);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
   assert.equal(
     EXPECTED_RUNTIME_TOTAL,
     Object.values(EXPECTED).reduce((total, row) => total + row.cases, 0)
@@ -1253,7 +1271,7 @@ test("the model-router adapter is pinned at what vitest prints", () => {
   // caught it at 5525 against an actual 5875.
   assert.equal(EXPECTED["packages/adapters/model-router-providers"].files, 15);
   assert.equal(EXPECTED["packages/adapters/model-router-providers"].cases, 198);
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 717 + 375 + 149 + 306 + 378 + 605 + 352 + 254 + 288 + 515 + 362 + 269 + 609 + 198 + 25 + 29 + 59 + 34 + 1 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the WIN-257 identity-access contract suite is pinned at what vitest prints", () => {
@@ -1261,7 +1279,9 @@ test("the WIN-257 identity-access contract suite is pinned at what vitest prints
   // 256 cases on v1; on this tree the same package is at 23 and 318, because the
   // later tranches land in it too. The +87 is what conserves.
   assert.equal(EXPECTED["packages/contexts/identity-access"].files, 23);
-  assert.equal(EXPECTED["packages/contexts/identity-access"].cases, 318);
+  // WIN-267 W3 318 -> 324, and the FILE count deliberately does not move: both
+  // suites the six cases land in already existed.
+  assert.equal(EXPECTED["packages/contexts/identity-access"].cases, 324);
   assert.ok(
     listTestFiles(undefined, "packages/contexts/identity-access").includes(
       "packages/contexts/identity-access/application/identity-access-service.test.ts",
@@ -1343,7 +1363,7 @@ test("the conversations context is pinned at what vitest prints", () => {
   // above do NOT move for any of them: all four implement ports that already
   // existed and all four had their port entry point widened in place, which is
   // what this census distinguishes from an addition.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 5525 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 5525 + 350 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
 });
 
 test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
@@ -1719,7 +1739,7 @@ test("the postgres-tenancy adapter is pinned at what vitest prints", () => {
   // `24 + 17 + 3 + 4` is four cases added to `agents-rows.test.ts`, a file this
   // row already counted, which is why that dimension's file tail gains 3 while
   // its case tail gains 48.
-  assert.equal(EXPECTED_RUNTIME_TOTAL, 5875 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1);
+  assert.equal(EXPECTED_RUNTIME_TOTAL, 5875 + 56 + 67 + 43 + 41 + 33 + 59 + 60 + 61 + 4 + 72 + 66 + 83 + 77 + 97 + 62 + 89 + 76 + 97 + 100 + 52 + 56 + 48 + 83 + 36 + 6 + 16 + 13 + 11 + 1 + 53 + 1 + 3 + 1 + 71 + 12 + 8 + 53 + 5 + 8 + 5 + 9 + 40 + 25 + 69 + 8 + 22 + 27 + 30 + 136 + 26 + 19 + 13 + 28 + 11 + 1 + 6);
   assert.equal(
     EXPECTED_RUNTIME_TOTAL,
     Object.values(EXPECTED).reduce((total, row) => total + row.cases, 0)

--- a/scripts/mutations-win267-w3.json
+++ b/scripts/mutations-win267-w3.json
@@ -1,0 +1,365 @@
+{
+  "$schema-note": "Hand-maintained. Data, not code: nothing under scripts/ or src/ imports this file.",
+  "issue": "WIN-267",
+  "tranche": "W3 — server-side sign-out, and the unscanned terminal route",
+  "branch": "tejas/win-267-w3-signout",
+  "base": "63388a9f (tejas/win-267-rest, the head of PR #159)",
+  "purpose": [
+    "W3 closes two defects the previous tranche NAMED rather than fixed, and the",
+    "two are the same shape one layer apart: something that was true was not",
+    "checkable, so nothing went red while it stopped being true.",
+    "",
+    "THE SIGN-OUT. `DELETE /api/v1/bff/session` cleared the browser cookie and",
+    "stopped, because `revokeOperatorSession` lived in `application/` behind no",
+    "contract method and a V1 transport may only reach a contract method. The",
+    "cookie is a COPY of the credential, so the route deleted the copy in the one",
+    "browser that asked and left every other copy valid for the rest of the",
+    "session's lifetime. M14 is that exact handler restored, and it is the",
+    "mutation this ledger exists for: it changes no status code, no envelope and",
+    "no header — only whether the replayed cookie still works.",
+    "",
+    "THE TERMINAL 404. `apps/core-api/src/http/not-found.controller.ts` was a",
+    "route-bearing controller under no scan root and named in no exclusion. Every",
+    "census case passed with it invisible, because the exclusion list was checked",
+    "in ONE direction only: each named file must exist and keep its shape, and",
+    "nothing enumerated the complement. M01 and M05 are the other direction.",
+    "",
+    "M03 IS THE ONE WORTH READING TWICE. Business surface would not arrive here",
+    "as a sixth method decorator — it would arrive as `@All(\"organizations\")`,",
+    "which leaves the method-decorator count at zero, keeps the empty base path,",
+    "satisfies every tripwire the sibling `HealthController` exclusion carries,",
+    "and serves every HTTP method of a real resource from a file no enumerator",
+    "can see."
+  ],
+  "procedure": [
+    "Every mutation is applied to ONE file and run INDIVIDUALLY. The laptop runs",
+    "the thirteen that need no container; Docker is quit there by standing",
+    "instruction, so the four that need PostgreSQL and Redis run on the Mac mini",
+    "over ssh, in a FRESH worktree, against pgvector/pgvector:pg16 and",
+    "redis:7-alpine through @testcontainers/*.",
+    "",
+    "A PACKAGE-SOURCE MUTATION MUST REBUILD, AND M15 PROVED IT THE HARD WAY.",
+    "`apps/core-api` resolves `@platos/context-identity-access` through that",
+    "package's `dist/`, so mutating `domain/session.ts` and running the container",
+    "suite without `pnpm build:v1` runs the UNMUTATED code and reports a false",
+    "survivor. M15 was recorded as SURVIVED on its first run for exactly that",
+    "reason, re-run with the rebuild, and killed. The first result is kept in this",
+    "note rather than deleted, because the trap is the finding.",
+    "",
+    "MUTATIONS RUN AGAINST COMMITTED WORK, and that is also learned rather than",
+    "assumed: the driver restores with `git checkout -- .`, so an UNCOMMITTED test",
+    "file is destroyed by the first restore and every later mutation is measured",
+    "against a suite that no longer contains the case meant to kill it. M11 and",
+    "M12 were recorded as survivors on their first run for that reason and were",
+    "re-run after committing."
+  ],
+  "commands": {
+    "census": "node scripts/rest-census-independent.mjs --check",
+    "identity-access": "pnpm --filter @platos/context-identity-access exec vitest run",
+    "identity-rest": "pnpm --filter @platos/core-api exec vitest run src/transports/rest/identity-rest.test.ts",
+    "build": "pnpm build:v1",
+    "integration": "pnpm test:core-api:integration"
+  },
+  "baseline": {
+    "census": "OK — 32 controllers, 289 unique + 19 dual-mount = 308 manifest ops, scan roots agent=300 + core-api-transports=8",
+    "identity-access": "324 cases across 23 files, green",
+    "identity-rest": "20 cases, green",
+    "build": "tsc -b tsconfig.json, clean",
+    "integration": "48 cases across 3 files, green (identity-rest 26, operator-authentication 6, idempotency 16) — 44 at the base, +4 from this tranche"
+  },
+  "mutations": [
+    {
+      "name": "M01 the terminal 404's exclusion entry is deleted",
+      "guards": "PROCESS_EDGE_EXCLUSIONS — the entry naming not-found.controller.ts",
+      "why": "This IS the tree as it stood at the base. The file was accounted for by nothing, and no gate said so. Without the completeness sweep this mutation is invisible: removing an exclusion entry for a file no root scans simply makes the file unmentioned again.",
+      "file": "scripts/rest-census-independent.mjs",
+      "from": "PROCESS_EDGE_EXCLUSIONS contains the NotFoundController entry",
+      "to": "the entry is removed",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "UNSCANNED ROUTE-BEARING CONTROLLER: apps/core-api/src/http/not-found.controller.ts lives inside a scanned application but under no declared scan root and named in no process-edge exclusion"
+      ]
+    },
+    {
+      "name": "M02 a business @Get lands in the terminal handler",
+      "guards": "the exclusion's declared route count (0 method decorators)",
+      "why": "Business surface parked in the process edge, which is what the sibling HealthController tripwire was written for.",
+      "file": "apps/core-api/src/http/not-found.controller.ts",
+      "from": "@All(\"{*path}\") only",
+      "to": "@Get(\"organizations\") added beside it",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "PROCESS-EDGE EXCLUSION DRIFT: now carries 1 route decorator(s); the exclusion is written for exactly 0 process probes"
+      ]
+    },
+    {
+      "name": "M03 the terminal @All takes a NAMED path",
+      "guards": "the exclusion's terminalCatchAll requirement",
+      "why": "THE MUTATION THE ROUTE-DECORATOR COUNT CANNOT SEE. `routes` counts only @Get/@Post/@Put/@Patch/@Delete, so this leaves it at zero, keeps the empty base path, and would have passed a tripwire copied from HealthController — while serving every HTTP method of a real resource from a file no enumerator scans.",
+      "file": "apps/core-api/src/http/not-found.controller.ts",
+      "from": "@All(\"{*path}\")",
+      "to": "@All(\"organizations\")",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "PROCESS-EDGE EXCLUSION DRIFT: declares 1 @All decorator(s) whose path is not a bare wildcard"
+      ]
+    },
+    {
+      "name": "M04 a SECOND @All in the terminal handler",
+      "guards": "the exclusion's declared allRoutes count",
+      "why": "Two catch-alls are two handlers, and the second is unreachable — or, if registered first, shadows the one the module deliberately puts last. A wildcard-only check would accept both.",
+      "file": "apps/core-api/src/http/not-found.controller.ts",
+      "from": "one @All(\"{*path}\")",
+      "to": "@All(\"/{*any}\") added beside it — also a bare wildcard, so only the COUNT can see it",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "PROCESS-EDGE EXCLUSION DRIFT: now carries 2 @All decorator(s); the exclusion is written for exactly 1"
+      ]
+    },
+    {
+      "name": "M05 a NEW controller lands in apps/core-api/src/http",
+      "guards": "unscannedControllerReport — the completeness sweep",
+      "why": "The general case of the defect rather than the one file that had it. A controller in a scanned application, under no root and in no exclusion, is ungoverned, and this is the case that will catch the next one.",
+      "file": "apps/core-api/src/http/probe.controller.ts",
+      "from": "(absent)",
+      "to": "@Controller({ path: \"probe\" }) with one @Get",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "UNSCANNED ROUTE-BEARING CONTROLLER: apps/core-api/src/http/probe.controller.ts"
+      ]
+    },
+    {
+      "name": "M06 the excluded file is deleted",
+      "guards": "the exclusion's presence check",
+      "why": "An exclusion naming a file that is gone excludes nothing, and would sit in the list for ever claiming to.",
+      "file": "apps/core-api/src/http/not-found.controller.ts",
+      "from": "present",
+      "to": "deleted",
+      "command": "census",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "PROCESS-EDGE EXCLUSION DRIFT: is named as an excluded process-edge controller but is not on disk"
+      ]
+    },
+    {
+      "name": "M07 the revocation never reaches the store",
+      "guards": "revokeOperatorSession — the sessions.save",
+      "why": "The return value is unchanged and correct, and every caller that reads only the Result is satisfied. Only the store knows.",
+      "file": "packages/contexts/identity-access/application/authenticate-operator.ts",
+      "from": "await sessions.save(ended.value); return ended;",
+      "to": "return ended;",
+      "command": "identity-access",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× revoking a session > ends it and reports that this call was the one that did",
+        "× revoking a session > no longer authenticates once revoked",
+        "× revokeOperatorSession (W3) > ENDS the session, and the same token no longer authenticates"
+      ]
+    },
+    {
+      "name": "M08 the already-revoked branch answers UNAUTHENTICATED again",
+      "guards": "the distinct refusal codes",
+      "why": "THE DEFECT AS IT ACTUALLY STOOD, restored. The use case re-derived a rule `domain/session.ts::revoked` already owned and answered the same code as a token no row matches, so 'there is no such session' and 'that session was already ended' were indistinguishable. Every pre-W3 case stayed green because they asserted `.ok === false`.",
+      "file": "packages/contexts/identity-access/application/authenticate-operator.ts",
+      "from": "const ended = revoked(session, now);",
+      "to": "if (session.revokedAt !== null) return err(unauthenticated({ reason: \"already-revoked\" })); ...",
+      "command": "identity-access",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× revoking a session > refuses the second revoke, so a double logout is distinguishable",
+        "× revokeOperatorSession (W3) > tells an ALREADY-ENDED session apart from one that never existed"
+      ]
+    },
+    {
+      "name": "M09 the revoked view spreads the whole session record",
+      "guards": "revokedView — the projection",
+      "why": "A sign-out that hands back `tokenHash`, `parentSessionId` and the impersonation chain. No type error follows, because the extra keys are structural.",
+      "file": "packages/contexts/identity-access/application/identity-access-service.ts",
+      "from": "return { sessionId: session.sessionId, revokedAt: session.revokedAt };",
+      "to": "return { ...session, sessionId: session.sessionId, revokedAt: session.revokedAt };",
+      "command": "identity-access",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× revokeOperatorSession (W3) > carries EXACTLY the two published keys, so a sign-out leaks no session internals"
+      ]
+    },
+    {
+      "name": "M10 revoking becomes idempotent",
+      "guards": "domain/session.ts::revoked",
+      "why": "A second sign-out re-stamps `revokedAt`, so the answer to 'when was this session ended?' becomes the time of the retry. The rule's own banner says revoking is not idempotent; this is that sentence deleted.",
+      "file": "packages/contexts/identity-access/domain/session.ts",
+      "from": "if (session.revokedAt !== null) return err(sessionRevoked());",
+      "to": "(removed)",
+      "command": "identity-access",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× session mutation is explicit > reports who won: revoking twice refuses the second caller",
+        "× revoking a session > does not re-stamp a session it did not end",
+        "× revokeOperatorSession (W3) > tells an ALREADY-ENDED session apart from one that never existed"
+      ]
+    },
+    {
+      "name": "M11 the sign-out raises on EVERY refusal",
+      "guards": "the handler's category branch",
+      "why": "The property the route was designed around goes away: a browser holding a dead credential is answered 401 and can no longer get rid of it without opening developer tools.",
+      "file": "apps/core-api/src/transports/bff/session.controller.ts",
+      "from": "if (!ended.ok && ended.error.category !== \"unauthenticated\") raise(ended.error);",
+      "to": "if (!ended.ok) raise(ended.error);",
+      "command": "identity-rest",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× W3 — a sign-out that could not end the session says so > CLEARS the browser anyway when there was simply nothing left to end"
+      ]
+    },
+    {
+      "name": "M12 the sign-out swallows EVERY refusal",
+      "guards": "the handler's category branch, the other way",
+      "why": "The lie this tranche exists to remove, in its subtler form: the store is unreachable, nothing is ended, and the caller is told 204. Nothing on the wire distinguishes it from a sign-out that worked.",
+      "file": "apps/core-api/src/transports/bff/session.controller.ts",
+      "from": "if (!ended.ok && ended.error.category !== \"unauthenticated\") raise(ended.error);",
+      "to": "(removed)",
+      "command": "identity-rest",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× W3 — a sign-out that could not end the session says so > RAISES when the store could not be reached, and writes no cookie"
+      ]
+    },
+    {
+      "name": "M13 revokeOperatorSession is unpublished again",
+      "guards": "IdentityAccessContract",
+      "why": "The base state. A V1 transport may reach a contract method and nothing else, so unpublishing the method is what made the server-side sign-out impossible in the first place.",
+      "file": "packages/contexts/identity-access/contracts/index.ts",
+      "from": "revokeOperatorSession(request): Promise<Result<RevokedOperatorSessionView>>;",
+      "to": "(removed)",
+      "command": "build",
+      "exit": 2,
+      "outcome": "killed",
+      "kills": [
+        "identity-access-service.ts(224,11): error TS2353: Object literal may only specify known properties, and 'revokeOperatorSession' does not exist in type 'IdentityAccessContract'"
+      ]
+    }
+  ],
+  "container_mutations": [
+    {
+      "name": "M14 the sign-out reverts to clearing the cookie only",
+      "guards": "the handler's call to revokeOperatorSession",
+      "why": "THE PRE-W3 HANDLER, RESTORED VERBATIM. It is the mutation this whole tranche is measured by, and it changes nothing an ordinary assertion looks at: the status is still 204, the Set-Cookie is still Max-Age=0, the envelope is unchanged. Only the REPLAY of the same cookie can see it, and only against a real database.",
+      "file": "apps/core-api/src/transports/bff/session.controller.ts",
+      "from": "const ended = await identityAccess.revokeOperatorSession({ ... }); if (!ended.ok && ...) raise(...);",
+      "to": "(removed — clearSessionCookie only)",
+      "command": "integration",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× W3 — a sign-out ends the session on the SERVER > REFUSES THE REPLAYED COOKIE, and the row says SESSION_REVOKED rather than expiry"
+      ]
+    },
+    {
+      "name": "M15 revoking becomes idempotent, seen in the DATABASE",
+      "guards": "domain/session.ts::revoked, observed through psql",
+      "why": "M10 one layer out. The in-memory suite proves the rule; this proves the rule REACHES PostgreSQL, by reading `revokedAt` back with a psql process inside the container after a second sign-out.",
+      "file": "packages/contexts/identity-access/domain/session.ts",
+      "from": "if (session.revokedAt !== null) return err(sessionRevoked());",
+      "to": "(removed)",
+      "command": "integration (after pnpm build:v1 — see `procedure`)",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× W3 — a sign-out ends the session on the SERVER > signs out again without re-stamping the revocation"
+      ],
+      "false-survivor-recorded": "The first run of M15 reported SURVIVED because the mutation was applied to package SOURCE and the container suite resolves that context through its dist/. Re-run with pnpm build:v1 and killed. Kept here because the trap is the finding."
+    },
+    {
+      "name": "M16 the sign-out raises on EVERY refusal, over HTTP",
+      "guards": "the handler's category branch, at the socket",
+      "why": "M11 as a browser sees it: 401 instead of 204 for a dead cookie, and the three indistinguishable answers become distinguishable — the route turns into an oracle for whether a token is real.",
+      "file": "apps/core-api/src/transports/bff/session.controller.ts",
+      "from": "if (!ended.ok && ended.error.category !== \"unauthenticated\") raise(ended.error);",
+      "to": "if (!ended.ok) raise(ended.error);",
+      "command": "integration",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× R1 — the BFF sets bytes and nothing else > clears the cookie for anybody, authenticated or not",
+        "× W3 > signs out again without re-stamping the revocation",
+        "× W3 > answers an ALREADY-ENDED token, an unknown token and no token IDENTICALLY"
+      ]
+    },
+    {
+      "name": "M17 the sign-out AUTHENTICATES first",
+      "guards": "the route's deliberate refusal to authenticate",
+      "why": "The most plausible wrong fix, and the one a reviewer would ask for: 'surely you should check who is signing out'. It strands every browser holding an expired, revoked or unknown cookie — the browsers that most need it cleared — and it makes the route report whether a token is real.",
+      "file": "apps/core-api/src/transports/bff/session.controller.ts",
+      "from": "(no authentication)",
+      "to": "await authenticateOperator(this.application.app, request); before the revocation",
+      "command": "integration",
+      "exit": 1,
+      "outcome": "killed",
+      "kills": [
+        "× R1 — the BFF sets bytes and nothing else > clears the cookie for anybody, authenticated or not",
+        "× W3 > signs out again without re-stamping the revocation",
+        "× W3 > answers an ALREADY-ENDED token, an unknown token and no token IDENTICALLY"
+      ]
+    }
+  ],
+  "survivors": [],
+  "declared": [
+    "THE SIGN-OUT DOES NOT ROTATE OR CASCADE, and that is a scope statement rather",
+    "than an omission. Ending an IMPERSONATION session does not end its parent, and",
+    "ending a parent does not walk its children — `evaluateOperatorSession` already",
+    "refuses an impersonation whose parent chain is broken, with SESSION_REVOKED, so",
+    "the cascade is a READ-side rule that this write does not need to duplicate.",
+    "Nothing here changes that behaviour and no case in this tranche asserts it.",
+    "",
+    "THE STORE-OUTAGE BRANCH IS PROVEN AT THE CONTROLLER, NOT OVER HTTP. Making",
+    "PostgreSQL unreachable mid-suite would destroy the fixture every other case in",
+    "the file depends on, so `identity-rest.test.ts` drives the handler directly",
+    "against a real IdentityAccessContract with one method replaced. M12 kills it.",
+    "That is weaker than a socket-level proof and is recorded as such.",
+    "",
+    "THE TERMINAL 404 IS EXCLUDED RATHER THAN SCANNED, and the alternative was",
+    "considered. Scanning it would demand a manifest row, a capability and a",
+    "route-parity entry for 'no route matched' — an operation no client can call.",
+    "The exclusion is only honest because it is falsifiable in both directions, and",
+    "M01 through M06 are that falsifiability."
+  ],
+  "runs": {
+    "laptop": {
+      "where": "the laptop, no container runtime (Docker is quit by standing instruction)",
+      "mutations": 13,
+      "killed": 13,
+      "survived": 0,
+      "note": "M11 and M12 were recorded as survivors on their FIRST run and were re-run after committing — the driver restores with `git checkout -- .`, which had destroyed the uncommitted cases meant to kill them."
+    },
+    "mini": {
+      "where": "Mac mini over ssh, FRESH worktree /tmp/pl-w3-mut at a715a715, pgvector/pgvector:pg16 + redis:7-alpine through @testcontainers/*",
+      "mutations": 4,
+      "killed": 4,
+      "survived": 0,
+      "baseline": "pnpm test:core-api:integration — 48 cases across 3 files, all green",
+      "note": "M15 was a FALSE SURVIVOR on its first run: a package-source mutation without `pnpm build:v1` runs the unmutated dist. Re-run with the rebuild and killed."
+    },
+    "total": {
+      "mutations": 17,
+      "killed": 17,
+      "survivors_measured": 0
+    }
+  }
+}

--- a/scripts/rest-census-independent.mjs
+++ b/scripts/rest-census-independent.mjs
@@ -72,14 +72,56 @@ const SRC = join(ROOT, SCAN_ROOTS[0].dir);
 // carry exactly the three probes named here. A fourth route, or a base path,
 // means business surface has been parked in the process edge, and this census
 // says so by name instead of shrugging.
+//
+// AND A SECOND ONE, WHICH WAS INVISIBLE UNTIL WIN-267 W3 (below).
 export const PROCESS_EDGE_EXCLUSIONS = Object.freeze([
   Object.freeze({
     file: "apps/core-api/src/http/health.controller.ts",
     controller: "HealthController",
     routes: 3,
+    allRoutes: 0,
+    terminalCatchAll: false,
     emptyBasePath: true,
     why:
       "process-edge liveness/readiness probes (ADR M0.4 §2 keeps them off the versioned surface); no tenant, no scope, no use case.",
+  }),
+  // WIN-267 W3 — THE TERMINAL 404, WHICH NEITHER SCAN ROOT REACHED AND NO
+  // EXCLUSION NAMED.
+  //
+  // `apps/core-api/src/http/not-found.controller.ts` is a route-bearing
+  // controller. It sits in `apps/core-api/src/http`, and the declared roots are
+  // `apps/agent/src` and `apps/core-api/src/transports` — so it fell between
+  // them. Its sibling in the same directory had a measured tripwire; the handler
+  // that answers EVERY unmatched path in the process had nothing, which is the
+  // wrong way round: it is the one route whose reach is unbounded.
+  //
+  // IT IS EXCLUDED RATHER THAN SCANNED, for the same reason `HealthController`
+  // is and for one more. It takes no tenant, resolves no scope and calls no use
+  // case; it is `VERSION_NEUTRAL` on purpose, because under `defaultVersion` the
+  // terminal handler would have moved to `/api/v1/{*path}` and `/does-not-exist`
+  // would have got Express's HTML page instead of an M0.4 §2 envelope. And it is
+  // not an OPERATION: scanning it would demand a manifest row, a capability and a
+  // parity entry for "no route matched", which is a refusal, not a thing a client
+  // can call.
+  //
+  // WHAT THE TRIPWIRE HAS TO CATCH IS THEREFORE DIFFERENT FROM ITS SIBLING'S.
+  // `routes: 0` alone would not: this controller carries no
+  // `@Get/@Post/@Put/@Patch/@Delete` today, and the way business surface would
+  // arrive here is not a sixth method decorator but a NAMED path on the `@All` it
+  // already has — `@All("organizations")` reads almost identically and would
+  // serve every method of a real resource from a file nothing enumerates. So the
+  // exclusion pins BOTH: zero method decorators, and exactly one `@All` whose
+  // path is a bare wildcard. A named `@All`, a second `@All`, or any method
+  // decorator fails `--check` by name.
+  Object.freeze({
+    file: "apps/core-api/src/http/not-found.controller.ts",
+    controller: "NotFoundController",
+    routes: 0,
+    allRoutes: 1,
+    terminalCatchAll: true,
+    emptyBasePath: true,
+    why:
+      "the terminal 404: the LAST-registered handler, answering every unmatched path in the process with the M0.4 §2 envelope. No tenant, no scope, no use case, and no operation a client can call — a refusal, not surface.",
   }),
 ]);
 
@@ -145,12 +187,32 @@ export function parseController(src) {
   // Line-anchored HTTP method decorators. This matches the manifest's per-route
   // counting and ignores decorator names appearing inside comments or strings.
   const routes = (src.match(/^\s*@(Get|Post|Put|Patch|Delete)\s*\(/gm) || []).length;
+  // `@All` IS COUNTED SEPARATELY, AND ONLY WIN-267 W3 NEEDED IT TO BE. It is not
+  // folded into `routes` above because that count is joined to the MANIFEST's
+  // per-route operations, and no manifest row exists for a catch-all; adding it
+  // there would have made every scan-root identity fail rather than making the
+  // terminal handler visible. It is measured here so the process-edge tripwire
+  // can pin the SHAPE of the catch-all — see PROCESS_EDGE_EXCLUSIONS.
+  //
+  // The path is captured so a NAMED `@All` can be told from a wildcard one. A
+  // wildcard is `@All("*")` or `@All("{*name}")`, with or without a leading slash
+  // — Express 4 spelt it the first way and Express 5 / path-to-regexp 8 spell it
+  // the second, and both are read so a framework bump does not silently turn this
+  // tripwire into a rubber stamp. `@All()` with NO argument is NOT a wildcard: it
+  // binds the controller's base path exactly, which on an empty base path is `/`
+  // — one specific route, not every unmatched one.
+  const allPaths = [...src.matchAll(/^\s*@All\s*\(\s*(?:["'`]([^"'`]*)["'`])?\s*\)/gm)].map(
+    (match) => match[1] ?? "",
+  );
+  const allRoutes = allPaths.length;
+  const nonWildcardAllRoutes = allPaths.filter((path) => !/^\/?(?:\*|\{\*[A-Za-z0-9_]+\})$/u.test(path))
+    .length;
   // Operator LOWER BOUND: direct requireOperator(...) invocations. Controllers
   // that guard many handlers through one shared wrapper (e.g. getOperatorScope)
   // legitimately show a lower floor than the manifest's semantic count — that is
   // an inequality the reconciliation permits, never an equality it forces.
   const requireOperator = (src.match(/requireOperator\s*\(/g) || []).length;
-  return { className, basePaths, emptyBasePath, routes, requireOperator };
+  return { className, basePaths, emptyBasePath, routes, allRoutes, nonWildcardAllRoutes, requireOperator };
 }
 
 /** Every declared scan root, measured: presence, controllers, decorators. */
@@ -173,6 +235,59 @@ export function scanRootReport(root = ROOT) {
       parsed,
     };
   });
+}
+
+/**
+ * The application `src` directory a declared scan root sits inside.
+ *
+ * DERIVED, NEVER DECLARED. A second hand-maintained list of directories would be
+ * a second thing to forget, and forgetting is the whole defect this function
+ * exists to close. `apps/agent/src` is its own application root;
+ * `apps/core-api/src/transports` belongs to `apps/core-api/src`.
+ */
+export function applicationRootOf(dir) {
+  const parts = dir.split("/");
+  const index = parts.indexOf("src");
+  return index < 0 ? dir : parts.slice(0, index + 1).join("/");
+}
+
+/**
+ * EVERY route-bearing controller in every scanned application, and whether
+ * anything accounts for it (WIN-267 W3).
+ *
+ * THIS IS THE JOIN THE CENSUS WAS MISSING, and `not-found.controller.ts` is the
+ * proof it was missing. Until now the exclusion list was checked ONE WAY: each
+ * named file must exist and keep its shape. Nothing checked the other direction
+ * — that every controller file in a scanned application is either under a
+ * declared root or named in the list — so a controller could sit in
+ * `apps/core-api/src/http` and be accounted for by NOTHING, which is exactly what
+ * the terminal 404 did for two tranches. An exclusion list that only validates
+ * its own entries is a list that can never notice an omission, which is lesson 1
+ * in this repository's own words: an assertion comparing two things you control
+ * cannot fail.
+ *
+ * It sweeps the APPLICATION root rather than the scan root, so the complement is
+ * a real set of files on disk rather than a restatement of the roots.
+ */
+export function unscannedControllerReport(
+  root = ROOT,
+  roots = SCAN_ROOTS,
+  exclusions = PROCESS_EDGE_EXCLUSIONS,
+) {
+  const applicationRoots = [...new Set(roots.map((declared) => applicationRootOf(declared.dir)))].sort();
+  const excused = new Set(exclusions.map((declared) => declared.file));
+  const unscanned = [];
+  for (const application of applicationRoots) {
+    for (const file of walkControllers(join(root, application))) {
+      const path = relative(root, file).split("\\").join("/");
+      const scanned = roots.some(
+        (declared) => path === declared.dir || path.startsWith(`${declared.dir}/`),
+      );
+      if (scanned || excused.has(path)) continue;
+      unscanned.push(path);
+    }
+  }
+  return { applicationRoots, unscanned: unscanned.sort() };
 }
 
 /** The process-edge exclusions, measured against the tree they claim to describe. */
@@ -234,6 +349,7 @@ export function reconcileScanRoots(
   edge = processEdgeReport(),
   man = manifestCensus(),
   indep = independentCensus(roots),
+  sweep = unscannedControllerReport(),
 ) {
   const failures = [];
 
@@ -296,6 +412,15 @@ export function reconcileScanRoots(
     };
   });
 
+  // THE COMPLEMENT. Anything route-bearing inside a scanned application that no
+  // root reaches and no exclusion names is ungoverned by NAME, which is a stronger
+  // statement than "the roots reconcile" — the roots reconciled perfectly while
+  // the terminal 404 sat outside all of them.
+  for (const path of sweep.unscanned)
+    failures.push(
+      `UNSCANNED ROUTE-BEARING CONTROLLER: ${path} lives inside a scanned application (${sweep.applicationRoots.join(", ")}) but under no declared scan root (${roots.map((r) => r.dir).join(", ")}) and named in no process-edge exclusion. Move it under a root, or name it in PROCESS_EDGE_EXCLUSIONS with a tripwire.`,
+    );
+
   for (const declared of edge) {
     if (!declared.present) {
       failures.push(
@@ -316,9 +441,24 @@ export function reconcileScanRoots(
       failures.push(
         `PROCESS-EDGE EXCLUSION DRIFT: ${declared.file} no longer declares an EMPTY @Controller() argument list, so it is no longer pinned off the versioned surface; it must be scanned as a transport instead of excluded.`,
       );
+    // THE CATCH-ALL SHAPE (WIN-267 W3). `routes` above counts only
+    // `@Get/@Post/@Put/@Patch/@Delete`, so a file whose whole surface is `@All`
+    // passes it at zero no matter what path the `@All` names. Both halves are
+    // pinned here: how many `@All` decorators the file may carry, and — for the
+    // terminal handler — that each one is a bare wildcard. `@All("organizations")`
+    // is business surface answering every HTTP method from a file nothing
+    // enumerates, and it is the mutation this pair exists to kill.
+    if (o.allRoutes !== declared.allRoutes)
+      failures.push(
+        `PROCESS-EDGE EXCLUSION DRIFT: ${declared.file} now carries ${o.allRoutes} @All decorator(s); the exclusion is written for exactly ${declared.allRoutes}.`,
+      );
+    if (declared.terminalCatchAll && o.nonWildcardAllRoutes > 0)
+      failures.push(
+        `PROCESS-EDGE EXCLUSION DRIFT: ${declared.file} declares ${o.nonWildcardAllRoutes} @All decorator(s) whose path is not a bare wildcard. It is excluded as the terminal catch-all — the handler that answers every unmatched path — and any other path makes it a business route answering every HTTP method from a file no enumerator can see.`,
+      );
   }
 
-  return { ok: failures.length === 0, failures, table };
+  return { ok: failures.length === 0, failures, table, unscanned: sweep };
 }
 
 /**
@@ -423,14 +563,22 @@ function build() {
       scanRoots:
         "every manifest route-implementation source falls under a DECLARED scan root, and each root's globbed decorators (expanded by mount multiplier) equal the manifest operations attributed to it. A surface built in a directory this census does not scan fails as UNDECLARED SCAN ROOT.",
       processEdge:
-        "the named process-edge exclusions are measured, not assumed: the excluded file must exist, keep an EMPTY @Controller() argument list, and carry exactly the declared number of probes.",
+        "the named process-edge exclusions are measured, not assumed: the excluded file must exist, keep an EMPTY @Controller() argument list, carry exactly the declared number of probes, and carry exactly the declared number of @All decorators — each a bare wildcard where the exclusion is the terminal catch-all.",
+      unscannedControllers:
+        "the exclusion list is joined to the tree in BOTH directions. Every *.controller.ts inside a scanned application's src/ must be under a declared scan root or named in PROCESS_EDGE_EXCLUSIONS; anything else fails as UNSCANNED ROUTE-BEARING CONTROLLER. Without this half a controller can be accounted for by nothing at all, which is what apps/core-api/src/http/not-found.controller.ts was until WIN-267 W3.",
     },
     totals: { ...r.totals, scanRoots: s.table },
+    applicationRoots: s.unscanned.applicationRoots,
+    unscannedControllers: s.unscanned.unscanned,
     processEdgeExclusions: edge.map((e) => ({
       file: e.file,
       controller: e.controller,
       declaredRoutes: e.routes,
       observedRoutes: e.observed?.routes ?? null,
+      declaredAllRoutes: e.allRoutes,
+      observedAllRoutes: e.observed?.allRoutes ?? null,
+      observedNamedAllRoutes: e.observed?.nonWildcardAllRoutes ?? null,
+      terminalCatchAll: e.terminalCatchAll,
       emptyBasePath: e.observed?.emptyBasePath ?? null,
       why: e.why,
     })),

--- a/scripts/rest-census-independent.mjs
+++ b/scripts/rest-census-independent.mjs
@@ -577,7 +577,7 @@ function build() {
       observedRoutes: e.observed?.routes ?? null,
       declaredAllRoutes: e.allRoutes,
       observedAllRoutes: e.observed?.allRoutes ?? null,
-      observedNamedAllRoutes: e.observed?.nonWildcardAllRoutes ?? null,
+      observedNonWildcardAllRoutes: e.observed?.nonWildcardAllRoutes ?? null,
       terminalCatchAll: e.terminalCatchAll,
       emptyBasePath: e.observed?.emptyBasePath ?? null,
       why: e.why,

--- a/scripts/rest-census-independent.test.mjs
+++ b/scripts/rest-census-independent.test.mjs
@@ -8,7 +8,9 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   KNOWN_MULTI_MOUNT,
+  PROCESS_EDGE_EXCLUSIONS,
   SCAN_ROOTS,
+  applicationRootOf,
   independentCensus,
   manifestCensus,
   parseController,
@@ -16,6 +18,7 @@ import {
   reconcile,
   reconcileScanRoots,
   scanRootReport,
+  unscannedControllerReport,
 } from "./rest-census-independent.mjs";
 
 const manOf = (controllers) => {
@@ -267,4 +270,157 @@ test("BASELINE: the process-edge exclusion still describes the file it excludes"
   assert.equal(edge.observed.className, "HealthController");
   assert.equal(edge.observed.routes, 3, "livez, healthz, readyz — and nothing else");
   assert.equal(edge.observed.emptyBasePath, true);
+});
+
+// ── WIN-267 W3: THE TERMINAL 404, AND THE HALF OF THE JOIN THAT WAS MISSING ──
+//
+// `apps/core-api/src/http/not-found.controller.ts` is a route-bearing controller
+// that neither declared scan root reached and no exclusion named. Every case
+// above passed with it invisible, which is the point: the exclusion list was
+// checked in ONE direction — each named file must exist and keep its shape — and
+// nothing checked the other, so a controller accounted for by nothing at all was
+// indistinguishable from a tree with no such controller in it.
+//
+// `unscannedControllerReport` is that other direction, and the cases below feed
+// it a SYNTHETIC tree rather than mutating the real one, so they measure the
+// rule instead of the current file list.
+
+const sweepStub = (over = {}) => ({ applicationRoots: ["apps/core-api/src"], unscanned: [], ...over });
+
+test("applicationRootOf derives the application from the scan root, and does not need a second list", () => {
+  assert.equal(applicationRootOf("apps/agent/src"), "apps/agent/src");
+  assert.equal(applicationRootOf("apps/core-api/src/transports"), "apps/core-api/src");
+  assert.equal(applicationRootOf("apps/core-api/src/transports/rest"), "apps/core-api/src");
+  // A root with no `src` segment is its own application root rather than being
+  // silently widened to the repository.
+  assert.equal(applicationRootOf("apps/agent"), "apps/agent");
+});
+
+test("MUTATION: a controller under no scan root and in no exclusion fails as UNSCANNED", () => {
+  const r = reconcileScanRoots(
+    [rootStub()],
+    edgeOk,
+    manStub({}, {}),
+    {},
+    sweepStub({ unscanned: ["apps/core-api/src/http/not-found.controller.ts"] }),
+  );
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.failures.some((f) => f.startsWith("UNSCANNED ROUTE-BEARING CONTROLLER")),
+    r.failures.join("\n"),
+  );
+  // BY NAME. A count would tell a reader that something is ungoverned without
+  // telling them which file to look at, and the file is the whole finding.
+  assert.ok(r.failures.some((f) => f.includes("not-found.controller.ts")), r.failures.join("\n"));
+});
+
+test("the sweep is what makes the exclusion list falsifiable: drop the entry and the file reappears", () => {
+  // THE PRE-W3 STATE, RECONSTRUCTED. With `not-found.controller.ts` removed from
+  // the exclusion list — which is precisely the tree as it stood — the sweep over
+  // the REAL directories reports it. That is the assertion that could not have
+  // been written before, because nothing enumerated the complement.
+  const without = PROCESS_EDGE_EXCLUSIONS.filter(
+    (e) => e.file !== "apps/core-api/src/http/not-found.controller.ts",
+  );
+  const before = unscannedControllerReport(undefined, SCAN_ROOTS, without);
+  assert.deepEqual(before.unscanned, ["apps/core-api/src/http/not-found.controller.ts"]);
+  // And with the entry restored, the live tree has nothing ungoverned at all.
+  const after = unscannedControllerReport();
+  assert.deepEqual(after.unscanned, [], `ungoverned controllers: ${after.unscanned.join(", ")}`);
+  assert.deepEqual(after.applicationRoots, ["apps/agent/src", "apps/core-api/src"]);
+});
+
+test("parseController tells a WILDCARD @All from a named one, which routes counts as neither", () => {
+  // `routes` counts only @Get/@Post/@Put/@Patch/@Delete, so a file whose entire
+  // surface is @All reads zero there no matter what path it names. That is why
+  // the catch-all is measured separately rather than folded in.
+  const terminal = parseController(`export class NotFoundController {\n  @All("{*path}")\n  x(){}\n}`);
+  assert.equal(terminal.routes, 0);
+  assert.equal(terminal.allRoutes, 1);
+  assert.equal(terminal.nonWildcardAllRoutes, 0);
+  // Express 4's spelling, and a leading slash, are the same statement.
+  assert.equal(parseController(`@All("*")\nexport class C {}`).nonWildcardAllRoutes, 0);
+  assert.equal(parseController(`  @All("/{*rest}")\nexport class C {}`).nonWildcardAllRoutes, 0);
+  // A NAMED path is business surface answering every HTTP method.
+  const named = parseController(`export class NotFoundController {\n  @All("organizations")\n  x(){}\n}`);
+  assert.equal(named.routes, 0, "a named @All still adds nothing to the method-decorator count");
+  assert.equal(named.nonWildcardAllRoutes, 1);
+  // And a bare @All() binds the base path exactly — one route, not every one.
+  assert.equal(parseController(`  @All()\nexport class C {}`).nonWildcardAllRoutes, 1);
+});
+
+test("MUTATION: the terminal handler's @All taking a NAMED path fails, though routes stays 0", () => {
+  const edge = [
+    {
+      file: "x/not-found.controller.ts",
+      controller: "NotFoundController",
+      routes: 0,
+      allRoutes: 1,
+      terminalCatchAll: true,
+      emptyBasePath: true,
+      why: "test",
+      present: true,
+      observed: {
+        className: "NotFoundController",
+        routes: 0,
+        allRoutes: 1,
+        nonWildcardAllRoutes: 1,
+        emptyBasePath: true,
+        basePaths: 1,
+        requireOperator: 0,
+      },
+    },
+  ];
+  const r = reconcileScanRoots([rootStub()], edge, manStub({}, {}), {}, sweepStub());
+  assert.equal(r.ok, false);
+  assert.ok(
+    r.failures.some((f) => f.includes("not a bare wildcard")),
+    r.failures.join("\n"),
+  );
+});
+
+test("MUTATION: a SECOND @All in the terminal handler fails as exclusion drift", () => {
+  const edge = [
+    {
+      file: "x/not-found.controller.ts",
+      controller: "NotFoundController",
+      routes: 0,
+      allRoutes: 1,
+      terminalCatchAll: true,
+      emptyBasePath: true,
+      why: "test",
+      present: true,
+      observed: {
+        className: "NotFoundController",
+        routes: 0,
+        allRoutes: 2,
+        nonWildcardAllRoutes: 0,
+        emptyBasePath: true,
+        basePaths: 1,
+        requireOperator: 0,
+      },
+    },
+  ];
+  const r = reconcileScanRoots([rootStub()], edge, manStub({}, {}), {}, sweepStub());
+  assert.equal(r.ok, false);
+  assert.ok(r.failures.some((f) => f.includes("@All decorator(s); the exclusion")), r.failures.join("\n"));
+});
+
+test("BASELINE: the terminal 404 is excluded, measured, and the ONLY @All in the surface", () => {
+  const declared = PROCESS_EDGE_EXCLUSIONS.find(
+    (e) => e.file === "apps/core-api/src/http/not-found.controller.ts",
+  );
+  assert.ok(declared, "the terminal 404 must be named in the exclusion list");
+  const observed = processEdgeReport().find((e) => e.file === declared.file);
+  assert.equal(observed.present, true);
+  assert.equal(observed.observed.className, "NotFoundController");
+  assert.equal(observed.observed.routes, 0, "no method decorator: it is a refusal, not a resource");
+  assert.equal(observed.observed.allRoutes, 1);
+  assert.equal(observed.observed.nonWildcardAllRoutes, 0);
+  assert.equal(observed.observed.emptyBasePath, true, "VERSION_NEUTRAL, so /does-not-exist reaches it");
+  // AND NO SCANNED CONTROLLER CARRIES ONE. A catch-all inside a scan root would
+  // shadow real routes registered after it, and this is where that would show up.
+  const roots = scanRootReport();
+  const withAll = roots.flatMap((root) => root.parsed.filter((c) => c.allRoutes > 0));
+  assert.deepEqual(withAll.map((c) => c.file), []);
 });

--- a/scripts/v1-ledger.test.mjs
+++ b/scripts/v1-ledger.test.mjs
@@ -1650,7 +1650,15 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // inside `apps-core-api`, and every gate, generator and artifact it touches
     // outside the deployable is an EDIT or a REGENERATION of a file that already
     // existed. 59 + 1 = 60.
-    "root-infra": 60,
+    // WIN-267 W3 60 -> 61: `scripts/mutations-win267-w3.json`, the EIGHTH guard
+    // ledger to land beside its siblings, on the same
+    // `root-infra.tooling.scripts` rule (93 -> 94). It is the WHOLE of this
+    // branch's file delta. W3 adds no source file and no suite: its six
+    // identity-access cases go into two suites that already existed, its four
+    // integration cases and its two controller-branch cases go into two files
+    // that already existed, and the census, the ledger pins and the four derived
+    // artifacts are all EDITS or REGENERATIONS of tracked files. 60 + 1 = 61.
+    "root-infra": 61,
   };
   // M2 INTEGRATION: 1495 + 42 + 27 + 15 = 1579, and 3469 + 1579 = 5048, which
   // is what the ledger fingerprint carried before M4.
@@ -1721,7 +1729,14 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
   // independently-merged keys. R1 moved `apps-core-api` and `root-infra`; R303
   // moved `packages`; no key took a contribution from both, which is why the
   // auto-merge of that object is safe and is checked here rather than assumed.
-  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1671);
+  //
+  // WIN-267 W3 1671 -> 1672. ONE file, `root-infra` only, itemised on that area's
+  // delta above, so the two halves of this case are the same arithmetic:
+  // 2 + 0 + 75 + 4 + 10 + 1503 + 17 + 61 = 1672. Two sibling branches move this
+  // pin in the same window and neither of their deltas is here, so the integrator
+  // SUMS rather than taking any one branch's total — the exact mistake the A1+A2
+  // paragraph above records.
+  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1672);
   assert.deepEqual(
     Object.fromEntries(
       Object.entries(summary.areaCounts).map(([area, count]) => [area, count - rulesDocument.baseline.areaCounts[area]])
@@ -1873,7 +1888,10 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // and the assertion above are two different arithmetics over the same tree
     // and a merge that had side-picked either branch's total would be red here
     // even if the other assertion had been patched to match.
-    rulesDocument.baseline.totalFiles + 1671
+    //
+    // WIN-267 W3 1671 -> 1672, the TWELFTH hand move: one mutation manifest in
+    // `root-infra`, and it is the only file this branch adds anywhere.
+    rulesDocument.baseline.totalFiles + 1672
   );
 });
 


### PR DESCRIPTION
Two defects the previous tranche NAMED rather than fixed. Both were true and both are closed.

## 1. There was no server-side sign-out

`revokeOperatorSession` lived in `application/` behind no contract method, and a V1 transport may only reach a contract method — so `DELETE /api/v1/bff/session` cleared the browser cookie and stopped. The cookie is a COPY of the credential: deleting the copy in the one browser that asked left every other copy valid for the rest of the session's lifetime.

- **Published** `revokeOperatorSession` on `IdentityAccessContract`, with `RevokedOperatorSessionView` carrying exactly `sessionId` and `revokedAt`.
- **Served** it from the handler, **before** the header is written, so a store that cannot be reached refuses the sign-out instead of answering 204 over a live session.
- Every `unauthenticated` refusal still clears the browser and answers 204 — a dead cookie is the one that most needs clearing, and the route must not become an oracle for whether a token is real. The branch is on the kernel CATEGORY, not on codes copied into the transport.

**Proven against a real database.** `identity-rest.integration.test.ts` exchanges a token for a cookie, confirms it authenticates, signs out, **reads the row back with a `psql` process inside the container** (it still EXISTS and now carries a revocation instant — ended, not evicted), then **replays the exact same cookie** and gets `SESSION_REVOKED` at 401 — paired in the same case against an expired session's `SESSION_EXPIRED`, so the two operator stories are separated.

**A finding found on the way.** `domain/session.ts::revoked` has carried the already-revoked rule since it was written and answers `SESSION_REVOKED`; `application/authenticate-operator.ts` re-derived the same check inline and answered `UNAUTHENTICATED` — the same code as a token no row matches. Two guards, one decision, two codes; `impersonation.ts` never had the bug because it called the domain helper. The use case now calls it. "No token" and "no such session" stay under one code on purpose — separating them is an enumeration oracle.

## 2. The terminal 404 was scanned by nothing

`apps/core-api/src/http/not-found.controller.ts` is route-bearing, sits under no declared scan root, and was named in no exclusion. The exclusion list was checked in ONE direction only — each named file must exist and keep its shape — so a controller accounted for by nothing at all was indistinguishable from a tree with no such controller.

- `unscannedControllerReport` is the other direction: every `*.controller.ts` inside a scanned application's `src/` must be under a declared scan root or named in `PROCESS_EDGE_EXCLUSIONS`. The application roots are DERIVED from the scan roots, so there is no second list to forget.
- The terminal 404 is **excluded rather than scanned** — it takes no tenant, resolves no scope, calls no use case, and is a refusal rather than an operation a client can call.
- Its tripwire is **not** its sibling's. `routes: 0` alone would not catch anything: business surface would arrive as `@All("organizations")`, which leaves the method-decorator count at zero and keeps the empty base path. The exclusion pins zero method decorators AND exactly one `@All` whose path is a bare wildcard.

## Evidence

**17 mutations, 17 killed, 0 survivors** (`scripts/mutations-win267-w3.json`). Two are recorded with their first, WRONG result kept, because each is a trap:
- M11/M12 were false survivors because the driver restores with `git checkout -- .` and the killing cases were still uncommitted.
- M15 was a false survivor because `apps/core-api` resolves the context through its `dist/`: a package-source mutation without `pnpm build:v1` runs the unmutated code.

**Mini sweep at `84c07f6b`, fresh worktree, real PostgreSQL 16 + Redis:** 28 gates PASS, `build:v1` PASS, `test:v1-packages` PASS, `test:core-api:integration` 48/48 (44 at base, +4), core-api unit 407, identity-access unit 324. Tree clean.

## Canaries

- v1-ledger `totalFiles` 5140 → **5141**; `root-infra` 296 → 297; every other area unchanged. `expectedDeltas` root-infra 60 → **61**, total delta 1671 → **1672**, and `2 + 0 + 75 + 4 + 10 + 1503 + 17 + 61 = 1672` re-derives it. `3469 + 1672 = 5141`. Disposition `move-refactor` 1633 → 1634 and kind `source` 2065 → 2066 carry the same one file; both sums still equal 5141.
- test-case-census 8124 → **8130** cases (+6, all `packages/contexts/identity-access` 318 → 324), **549 files unchanged** — both suites already existed. `+ 6` appended to all twelve restated sums.
- rest-census route counts do NOT move: 32 controllers, 289 + 19 = 308 ops, agent 300 + core-api-transports 8. What moves is `processEdgeExclusions` 1 → 2 entries plus `applicationRoots` and `unscannedControllers` (`[]`).
- gen-v1-skeleton unchanged: 106 + 14 = 120 generated files, 35 projects, 122 project edges, 28 adopted, 96 placeholders released.

The ONE file this branch adds anywhere is `scripts/mutations-win267-w3.json`.

## Boundaries

No merge, no tag, no deploy. Nothing touched in M3.1 (AgentController) or M4.2 (MCP). `route-capability-parity --completion` is still RED at exactly 125 blockers — the base's known red, unmoved by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzDWyb7YEERRegYTvNwzRp