### PR TITLE
WIN-268 P2: take the MCP authorization surfaces off the ORM, and refuse the forged tenant triple

### DIFF
--- a/.dependency-cruiser.js
+++ b/.dependency-cruiser.js
@@ -322,6 +322,17 @@ module.exports = {
       }
     },
     {
+      "name": "mcp-platform-service-no-prisma",
+      "comment": "a converted apps/agent/src/mcp-platform service must reach data through its store seam, never through the ORM or the DI provider that carries the client.",
+      "severity": "error",
+      "from": {
+        "path": "^(apps/agent/src/mcp-platform/permission-gateway\\.service\\.ts|apps/agent/src/mcp-platform/mcp-tool-acl\\.service\\.ts|apps/agent/src/mcp-platform/identity-resolver\\.service\\.ts)$"
+      },
+      "to": {
+        "path": "^((node_modules/(@prisma/|prisma(?:/|$)|@platos/tenancy-database(?:/|$))|internal-packages/tenancy-database(?:/|$))|apps/agent/src/shared/database\\.provider)"
+      }
+    },
+    {
       "name": "unknown-context-directory",
       "comment": "packages/contexts/<name>/ must be one of the 17 contexts named in ADR M0.3 §4; an adapter belongs under packages/adapters/.",
       "severity": "error",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,33 @@ jobs:
         # analyzer finds fewer call sites than the pin expects.
         run: pnpm --filter platos-agent exec vitest run src/clean-prisma-delegates.test.ts
 
+      - name: WIN-268 P2 MCP platform ORM ownership census
+        # The SPLIT, not the total. `clean-prisma-delegates.test.ts` above pins
+        # how many ORM call sites the whole app holds; this pins WHICH CONTEXT
+        # OWNS the rows `apps/agent/src/mcp-platform/**` still reaches, and
+        # ratchets it per file so a tranche cannot trade one file's statements
+        # for another's and report progress.
+        #
+        # Its own step, and AFTER the tenancy-database build, for both reasons
+        # the step above gives: a red log should name the gate that failed, and
+        # this census walks the same type-checker program, so an unbuilt client
+        # makes it under-count rather than fail.
+        run: pnpm --filter platos-agent exec vitest run src/mcp-platform/orm-ownership-census.test.ts
+
+      - name: WIN-268 P2 MCP authorization refusals against real PostgreSQL
+        # The forged-triple proof. Two tenants, and a scope whose environment is
+        # tenant A's while its organization id is tenant B's — the shape
+        # `apps/agent/src/auth/scope.guard.ts` admits, because it assembles the
+        # triple from three unrelated request headers and joins them only when an
+        # agent id is also present.
+        #
+        # A COHERENT two-tenant case passes with or without the ancestry check
+        # this tranche added, which is why the suite carries the forged one and
+        # why it runs here rather than being left to a reviewer to run by hand.
+        # It starts its own PostgreSQL testcontainer and FAILS when Docker is
+        # absent rather than skipping.
+        run: pnpm --filter platos-agent exec vitest run src/mcp-platform/mcp-scope.integration.test.ts
+
       - name: WIN-290 ClickHouse lifecycle, redaction, and DLQ suite
         run: pnpm test:win-290
 

--- a/apps/agent/src/clean-prisma-delegates.test.ts
+++ b/apps/agent/src/clean-prisma-delegates.test.ts
@@ -1,324 +1,35 @@
 import { createHash } from "node:crypto";
-import { readdirSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
-import { Prisma, PrismaClient } from "@platos/tenancy-database";
 import ts from "typescript";
 import { afterAll, describe, expect, it } from "vitest";
 
-const sourceRoot = __dirname;
-const generatedClient = new PrismaClient();
+import {
+  analyzeAgentSource,
+  createAnalyzer,
+  disconnectGeneratedClient,
+  generatedDelegates,
+  generatedOperationsByDelegate,
+} from "./prisma-delegate-census";
 
-function productionTypeScriptFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) return productionTypeScriptFiles(path);
-    if (!entry.isFile() || !entry.name.endsWith(".ts")) return [];
-    if (/\.(?:test|spec)\.ts$/.test(entry.name) || entry.name.endsWith(".d.ts")) return [];
-    return [path];
-  });
-}
-
-function lowerFirst(value: string): string {
-  return `${value[0]?.toLowerCase() ?? ""}${value.slice(1)}`;
-}
-
-const generatedDelegates = new Set(
-  Prisma.dmmf.datamodel.models.map((model) => lowerFirst(model.name)),
-);
-const generatedOperationsByDelegate = new Map<string, Set<string>>(
-  [...generatedDelegates].map((delegate) => {
-    const value = (generatedClient as unknown as Record<string, Record<string, unknown>>)[delegate];
-    return [
-      delegate,
-      new Set(Object.keys(value).filter((key) => typeof value[key] === "function" && !key.startsWith("$"))),
-    ];
-  }),
-);
-const generatedOperations = new Set(
-  [...generatedOperationsByDelegate.values()].flatMap((operations) => [...operations]),
-);
-
-type DelegateCall = {
-  delegate: string;
-  operation: string;
-  file: string;
-  line: number;
-};
-
-type Analysis = {
-  calls: DelegateCall[];
-  unresolvedDynamicAccesses: string[];
-};
-
-function staticMemberName(expression: ts.Expression): string | null {
-  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
-  if (ts.isElementAccessExpression(expression)) {
-    const argument = expression.argumentExpression;
-    return argument && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))
-      ? argument.text
-      : null;
-  }
-  return null;
-}
-
-function memberBase(expression: ts.Expression): ts.Expression | null {
-  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
-    return expression.expression;
-  }
-  return null;
-}
-
-function symbolAt(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | undefined {
-  return checker.getSymbolAtLocation(node) ?? undefined;
-}
-
-function declarationsFor(checker: ts.TypeChecker, identifier: ts.Identifier): readonly ts.Declaration[] {
-  return symbolAt(checker, identifier)?.declarations ?? [];
-}
-
-function hasInjectedPrismaToken(parameter: ts.ParameterDeclaration): boolean {
-  const decorators = ts.canHaveDecorators(parameter) ? ts.getDecorators(parameter) : undefined;
-  return decorators?.some((decorator) => decorator.getText().includes("Inject(PRISMA_TOKEN)")) ?? false;
-}
-
-function createAnalyzer(program: ts.Program, files: readonly ts.SourceFile[]) {
-  const checker = program.getTypeChecker();
-  const clientSymbols = new Set<ts.Symbol>();
-
-  const markTypedClient = (node: ts.Node, name: ts.Node) => {
-    const rendered = checker.typeToString(checker.getTypeAtLocation(node));
-    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) {
-      const symbol = symbolAt(checker, name);
-      if (symbol) clientSymbols.add(symbol);
-    }
-  };
-
-  for (const file of files) {
-    const visit = (node: ts.Node): void => {
-      if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
-        markTypedClient(node, node.name);
-        if (hasInjectedPrismaToken(node)) {
-          const symbol = symbolAt(checker, node.name);
-          if (symbol) clientSymbols.add(symbol);
-        }
-      } else if (
-        (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node))
-        && ts.isIdentifier(node.name)
-      ) {
-        markTypedClient(node, node.name);
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(file);
-  }
-
-  const isClientExpression = (expression: ts.Expression, seen = new Set<ts.Symbol>()): boolean => {
-    const rendered = checker.typeToString(checker.getTypeAtLocation(expression));
-    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) return true;
-
-    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
-      return isClientExpression(expression.expression, seen);
-    }
-    if (ts.isIdentifier(expression)) {
-      const symbol = symbolAt(checker, expression);
-      if (!symbol || seen.has(symbol)) return false;
-      if (clientSymbols.has(symbol)) return true;
-      seen.add(symbol);
-      return (symbol.declarations ?? []).some((declaration) => {
-        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-          return isClientExpression(declaration.initializer, seen);
-        }
-        if (ts.isParameter(declaration) && hasInjectedPrismaToken(declaration)) return true;
-        return false;
-      });
-    }
-    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
-      const nameNode = ts.isPropertyAccessExpression(expression)
-        ? expression.name
-        : expression.argumentExpression;
-      const symbol = nameNode ? symbolAt(checker, nameNode) : undefined;
-      if (symbol && clientSymbols.has(symbol)) return true;
-    }
-    return false;
-  };
-
-  // Resolve constructor assignments (`this.prisma = prisma`) and transaction
-  // callback parameters. Repeat because either side may itself be an alias.
-  for (let pass = 0; pass < 3; pass++) {
-    for (const file of files) {
-      const visit = (node: ts.Node): void => {
-        if (
-          ts.isBinaryExpression(node)
-          && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
-          && isClientExpression(node.right)
-        ) {
-          const target = ts.isPropertyAccessExpression(node.left)
-            ? node.left.name
-            : ts.isIdentifier(node.left)
-              ? node.left
-              : null;
-          const symbol = target ? symbolAt(checker, target) : undefined;
-          if (symbol) clientSymbols.add(symbol);
-        }
-        if (ts.isCallExpression(node) && staticMemberName(node.expression) === "$transaction") {
-          const base = memberBase(node.expression);
-          const callback = node.arguments[0];
-          if (
-            base
-            && isClientExpression(base)
-            && callback
-            && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
-          ) {
-            const parameter = callback.parameters[0];
-            if (parameter && ts.isIdentifier(parameter.name)) {
-              const symbol = symbolAt(checker, parameter.name);
-              if (symbol) clientSymbols.add(symbol);
-            }
-          }
-        }
-        ts.forEachChild(node, visit);
-      };
-      visit(file);
-    }
-  }
-
-  const delegateFromType = (expression: ts.Expression): string | null => {
-    const expressionType = checker.getTypeAtLocation(expression);
-    const types = expressionType.isUnion() ? expressionType.types : [expressionType];
-    for (const type of types) {
-      const name = (type.aliasSymbol ?? type.getSymbol())?.getName() ?? "";
-      const match = /^\$?(.+)Delegate$/.exec(name);
-      if (match?.[1]) return lowerFirst(match[1]);
-    }
-    return null;
-  };
-
-  const delegateFor = (expression: ts.Expression, seen = new Set<ts.Symbol>()): string | null => {
-    const typed = delegateFromType(expression);
-    if (typed) return typed;
-    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
-      return delegateFor(expression.expression, seen);
-    }
-    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
-      const base = memberBase(expression);
-      const name = staticMemberName(expression);
-      if (base && isClientExpression(base)) return name ?? "<dynamic>";
-    }
-    if (ts.isIdentifier(expression)) {
-      const symbol = symbolAt(checker, expression);
-      if (!symbol || seen.has(symbol)) return null;
-      seen.add(symbol);
-      for (const declaration of symbol.declarations ?? []) {
-        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-          const delegated = delegateFor(declaration.initializer, seen);
-          if (delegated) return delegated;
-        }
-        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
-          const variable = declaration.parent.parent;
-          if (ts.isVariableDeclaration(variable) && variable.initializer && isClientExpression(variable.initializer)) {
-            return declaration.propertyName && ts.isIdentifier(declaration.propertyName)
-              ? declaration.propertyName.text
-              : ts.isIdentifier(declaration.name)
-                ? declaration.name.text
-                : null;
-          }
-        }
-      }
-    }
-    return null;
-  };
-
-  const callable = (
-    expression: ts.Expression,
-    seen = new Set<ts.Symbol>(),
-  ): { delegate: string; operation: string } | null => {
-    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
-      const operation = staticMemberName(expression);
-      const base = memberBase(expression);
-      if (operation && generatedOperations.has(operation) && base) {
-        const delegate = delegateFor(base);
-        return delegate ? { delegate, operation } : null;
-      }
-      return null;
-    }
-    if (ts.isIdentifier(expression)) {
-      const symbol = symbolAt(checker, expression);
-      if (!symbol || seen.has(symbol)) return null;
-      seen.add(symbol);
-      for (const declaration of declarationsFor(checker, expression)) {
-        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
-          const resolved = callable(declaration.initializer, seen);
-          if (resolved) return resolved;
-        }
-        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
-          const operation = declaration.propertyName && ts.isIdentifier(declaration.propertyName)
-            ? declaration.propertyName.text
-            : ts.isIdentifier(declaration.name)
-              ? declaration.name.text
-              : null;
-          const variable = declaration.parent.parent;
-          if (
-            operation
-            && generatedOperations.has(operation)
-            && ts.isVariableDeclaration(variable)
-            && variable.initializer
-          ) {
-            const delegate = delegateFor(variable.initializer);
-            if (delegate) return { delegate, operation };
-          }
-        }
-      }
-    }
-    return null;
-  };
-
-  return (): Analysis => {
-    const calls: DelegateCall[] = [];
-    const unresolvedDynamicAccesses: string[] = [];
-    for (const file of files) {
-      const visit = (node: ts.Node): void => {
-        if (ts.isCallExpression(node)) {
-          const resolvedCall = callable(node.expression);
-          if (resolvedCall) {
-            const position = file.getLineAndCharacterOfPosition(node.getStart(file));
-            const location = `${relative(sourceRoot, file.fileName)}:${position.line + 1}`;
-            if (resolvedCall.delegate === "<dynamic>") {
-              unresolvedDynamicAccesses.push(location);
-            } else {
-              calls.push({
-                ...resolvedCall,
-                file: relative(sourceRoot, file.fileName),
-                line: position.line + 1,
-              });
-            }
-          }
-        }
-        ts.forEachChild(node, visit);
-      };
-      visit(file);
-    }
-    return { calls, unresolvedDynamicAccesses };
-  };
-}
-
-function productionProgram(files: string[]): ts.Program {
-  const configPath = ts.findConfigFile(resolve(sourceRoot, ".."), ts.sys.fileExists, "tsconfig.json");
-  if (!configPath) throw new Error("apps/agent tsconfig.json not found");
-  const config = ts.readConfigFile(configPath, ts.sys.readFile);
-  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, resolve(configPath, ".."));
-  return ts.createProgram({ rootNames: files, options: parsed.options });
-}
+// WIN-268 P2. THE ANALYZER MOVED; NOTHING IT MEASURES DID.
+//
+// The three hundred lines of type-checker walk that used to sit here are now
+// `prisma-delegate-census.ts`, because a SECOND gate needs the same walk with
+// its per-call-site results kept rather than reduced to three numbers — see
+// that module's header, and `mcp-platform/orm-ownership-census.test.ts`, which
+// splits the same calls by the context that owns the row.
+//
+// THE PINS BELOW ARE UNMOVED, and that is the whole evidence for the move being
+// a refactor: 815 / 329 / 0c4fd159... were measured by the analyzer in its old
+// home and are re-measured by the analyzer in its new one. A move that changed
+// what is walked would have moved them.
 
 afterAll(async () => {
-  await generatedClient.$disconnect();
+  await disconnectGeneratedClient();
 });
 
 describe("clean tenancy Prisma boundary", () => {
   it("uses the type checker to inventory every production delegate operation", () => {
-    const paths = productionTypeScriptFiles(sourceRoot);
-    const program = productionProgram(paths);
-    const files = paths.map((path) => program.getSourceFile(path)).filter((file): file is ts.SourceFile => !!file);
-    const analysis = createAnalyzer(program, files)();
+    const { analysis, fileCount } = analyzeAgentSource();
     const violations = analysis.calls.filter(({ delegate, operation }) =>
       !generatedDelegates.has(delegate)
       || !generatedOperationsByDelegate.get(delegate)?.has(operation),
@@ -328,7 +39,7 @@ describe("clean tenancy Prisma boundary", () => {
     )].sort();
     const inventoryDigest = createHash("sha256").update(inventory.join("\n")).digest("hex");
 
-    expect(files.length).toBeGreaterThan(100);
+    expect(fileCount).toBeGreaterThan(100);
     expect(analysis.unresolvedDynamicAccesses).toEqual([]);
     expect(violations).toEqual([]);
     // Independently pin both call-site count and unique operation inventory so

--- a/apps/agent/src/clean-prisma-delegates.test.ts
+++ b/apps/agent/src/clean-prisma-delegates.test.ts
@@ -88,7 +88,39 @@ describe("clean tenancy Prisma boundary", () => {
     // 0b36ea83f83a49ed4795881e9c9ccc00a6214c5e30ef654091d36dc13c2cc5a4 — which
     // is what establishes that 815 is real growth rather than a measurement
     // artifact of a different build state.
-    expect(analysis.calls.length).toBe(815);
+    // WIN-268 P2, 2026-09-09. RE-PINNED 815 -> 813, and the two are ACCOUNTED
+    // FOR rather than absorbed.
+    //
+    // THE ARITHMETIC. Base `3b3f1ebb` measured with THIS analyzer: 815 app-wide,
+    // of which `mcp-platform/**` held 125 —
+    // `permission-gateway.service.ts` 8, `mcp-tool-acl.service.ts` 11,
+    // `identity-resolver.service.ts` 5. Those three now hold ZERO and their
+    // statements live in three store seams: `mcp-policy.store.ts` 7,
+    // `entity-tool-policy.store.ts` 10, `mcp-identity.store.ts` 5.
+    // 8 + 11 + 5 = 24 OUT; 7 + 10 + 5 = 22 IN; net -2, so 815 - 2 = 813 and
+    // the directory's own 125 - 2 = 123.
+    //
+    // THE TWO THAT VANISHED ARE DUPLICATE STATEMENTS THE EXTRACTION MERGED, not
+    // deleted behaviour. `organizationMcpPolicy.findMany` was written TWICE in
+    // the gateway (once for tier 2, once for the operator listing) and is now
+    // one method both call; `entityToolPolicy.upsert` was written THREE times in
+    // the ACL (`upsert`, `bulk`, `autoInsert`) and is now two, with `autoInsert`
+    // delegating. Both merged rows are `tools`-owned, which is why the ownership
+    // split in `mcp-platform/orm-ownership-census.test.ts` moves `tools`
+    // 35 -> 33 and leaves the other nine owners untouched — a cross-check that a
+    // net-2 arrived at any other way would fail.
+    //
+    // NOT A LAUNDERED REDUCTION. This is the first time this pin has moved DOWN.
+    // `orm-ownership-census.test.ts` reads this digit back out of this file, so
+    // the two gates cannot be re-pinned independently, and its per-file ratchet
+    // pins where each of the 123 remaining sites lives.
+    //
+    // BUILD STATE UNCHANGED from the note above: measured on the mini under
+    // `pnpm install --frozen-lockfile --ignore-scripts`, then `pnpm --filter
+    // @platos/tenancy-database build && pnpm --filter @internal/workload-identity
+    // build`, which is the state ci.yml's agent job reaches before its Vitest
+    // steps. Re-measured on base `3b3f1ebb` in the SAME state: 815.
+    expect(analysis.calls.length).toBe(813);
     expect(inventory).toHaveLength(329);
     expect(inventoryDigest).toBe(
       "0c4fd159179dbf051d093ac039b87771c53d407adbf06e7aa79df0a3cc6f85ac",

--- a/apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts
+++ b/apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts
@@ -15,6 +15,7 @@ import { McpBearerTokenService } from "../mcp-platform/mcp-bearer-token.service"
 import { McpEntityController } from "../mcp-platform/mcp-entity.controller";
 import { McpPlatformController } from "../mcp-platform/mcp-platform.controller";
 import { McpToolAclService } from "../mcp-platform/mcp-tool-acl.service";
+import { EntityToolPolicyStore } from "../mcp-platform/entity-tool-policy.store";
 import { PlatosMCPTokenService } from "../mcp-platform/token.service";
 import { ConversationService } from "../memory/conversation.service";
 
@@ -1058,7 +1059,10 @@ describeWithPostgres("WIN-234 non-browser completion evidence", () => {
     });
 
     it("converges concurrent ACL writes to one canonical policy and recovers by replay", async () => {
-      const acl = new McpToolAclService(prisma);
+      // WIN-268 P2 — the service takes its ORM seam, not the client. The store
+      // is the same object the Nest module provides, so this suite still
+      // exercises the real statements against real PostgreSQL.
+      const acl = new McpToolAclService(new EntityToolPolicyStore(prisma));
       const value = controller<McpEntityController>(McpEntityController.prototype, {
         prisma,
         toolAclService: acl,

--- a/apps/agent/src/mcp-platform/entity-tool-policy.store.ts
+++ b/apps/agent/src/mcp-platform/entity-tool-policy.store.ts
@@ -1,0 +1,354 @@
+// The ORM seam behind the entity tool ACL — the inbound MCP surface's
+// default-deny exposure decision.
+//
+// WIN-268 P2. `mcp-tool-acl.service.ts` held ten `entityToolPolicy` /
+// `environmentEntityTool` / `entityMcpConfig` calls AND the projection, the
+// label codec and the caller filter that run on them. The codec and the filter
+// are pure; the ten calls are not. This module takes the ten.
+//
+// ---------------------------------------------------------------------------
+// EVERY ROW HERE BELONGS TO `tools`, AND SO DOES EVERY USE CASE
+//
+// ADR M0.3 §1 row 7 gives `EntityToolPolicy`, `EnvironmentEntityTool`,
+// `EntityMcpConfig` and `Tool` to the `tools` context, and
+// `packages/contexts/tools/application/entity-tool-policy.ts` already
+// implements this file's whole job:
+//
+//   `listEntityToolPolicies` completes the listing with the synthetic denials
+//   `domain/entity-policy.ts` mints — the same "a mapping without a policy gets
+//   a synthetic deny row" the extraction source spells inline;
+//   `setEntityToolPolicy` performs the partial-patch label merge, including the
+//   reason the two halves of the `String[]` must be patched independently;
+//   `resyncAllowlist` recomputes `EntityMcpConfig.toolAllowlist` after every
+//   mutation and PROPAGATES its failure rather than swallowing it;
+//   `listCallableForMcpCaller` is the four-gate read the caller filter belongs
+//   to, with the caller DERIVED from a verified principal rather than asserted.
+//
+// So the use cases are not missing — this is the fourth time this programme has
+// checked a "missing" thing and found it present. What is missing is a way to
+// CALL them from here: see `mcp-policy.store.ts`'s header for the three
+// independent measurements (no context/adapter/kernel import in `apps/agent`;
+// rule (j) plus `composition-root.mjs` narrowing adapter imports to one file in
+// `apps/core-api`; `tools` uncomposed for want of `ToolDispatch`, which is
+// WIN-269's scope).
+//
+// ---------------------------------------------------------------------------
+// WHAT CHANGED BEHIND THE SEAM
+//
+// THE SCOPED READS AND WRITES NOW REFUSE A FORGED SCOPE. The extraction source
+// keyed every statement on `{ entityId, environmentId }` and never asked whether
+// the environment it was handed belongs to the project and organization the
+// caller claimed. `mcp-scope.ts` records why that triple cannot be trusted, and
+// the destination adapter — `postgres-tenancy/src/tools-scope.ts` — already puts
+// exactly this join on the front of every scoped method of the port that owns
+// these rows.
+//
+// `getExposedToolNames` IS THE ONE METHOD THAT STAYS UNSCOPED, and that is
+// deliberate rather than an oversight. It feeds `syncAllowlist`, which writes
+// `EntityMcpConfig.toolAllowlist` — and `EntityMcpConfig` is keyed by ENTITY
+// ALONE (`findUnique({ where: { entityId } })`), not by (environment, entity),
+// while `EntityToolPolicy` is keyed by `@@unique([environmentId, entityId,
+// toolId])`. Narrowing the read to one environment would write a per-entity
+// cache from one environment's policies and silently drop the others'. The cache
+// is a denormalisation that no authorization path reads —
+// `mcp-entity.controller.ts` says in as many words that
+// "EntityMcpConfig.toolAllowlist is only a compatibility/dashboard" field, and
+// the destination use case's own header says the authority is the policy rows,
+// always — so the mismatch is recorded here rather than "fixed" into a
+// regression.
+
+import { Inject, Injectable } from "@nestjs/common";
+import { PolicyEffect } from "@platos/tenancy-database";
+
+import { type ControlDatabaseClient, PRISMA_TOKEN } from "../shared/database.provider";
+import { resolveClaimedScope, scopeAllowed, type ClaimedScope, type Scoped } from "./mcp-scope";
+
+/** One `EnvironmentEntityTool` row, as the listing needs it. */
+export interface ExposureRow {
+  readonly id: string;
+  readonly toolId: string;
+  readonly toolName: string;
+}
+
+/** One `EntityToolPolicy` row, with the ORM enum already off it. */
+export interface EntityToolPolicyRow {
+  readonly id: string;
+  readonly environmentId: string;
+  readonly entityId: string;
+  readonly toolId: string;
+  readonly toolName: string;
+  readonly effect: "ALLOW" | "DENY";
+  readonly minIdentityMode: string;
+  readonly scopeLabels: string[];
+  readonly addedAt: Date;
+  readonly lastReviewedAt: Date | null;
+}
+
+export interface ExposurePage {
+  readonly exposures: readonly ExposureRow[];
+  readonly policies: readonly EntityToolPolicyRow[];
+  readonly total: number;
+}
+
+export interface PolicyPatch {
+  readonly effect?: "ALLOW" | "DENY";
+  readonly minIdentityMode?: string;
+  readonly scopeLabels?: string[];
+}
+
+export interface EntityToolPolicyReader {
+  pageExposures(
+    scope: ClaimedScope,
+    entityId: string,
+    options: { exposed?: boolean; search?: string; limit: number; offset: number },
+  ): Promise<Scoped<ExposurePage>>;
+  /**
+   * The inbound dispatch authority. NO scope check, and the name says why.
+   *
+   * The environment id here is read off the `McpBearerToken` or anonymous
+   * session row that authenticated the request — a fact the credential carries,
+   * not a triple a caller claimed — so there is no organization or project to
+   * check it against and nothing would be gained by inventing one. The scoped
+   * methods above are the operator paths, where the triple IS a claim.
+   */
+  listAllowedPoliciesForVerifiedEnvironment(
+    verifiedEnvironmentId: string,
+    entityId: string,
+    toolName?: string,
+  ): Promise<readonly EntityToolPolicyRow[]>;
+  /** Unscoped BY DESIGN — see the header note on the allowlist cache's key. */
+  exposedToolNamesForEntity(entityId: string): Promise<readonly string[]>;
+  readScopeLabels(scope: ClaimedScope, entityId: string, toolId: string): Promise<Scoped<string[] | null>>;
+  savePolicy(
+    scope: ClaimedScope,
+    entityId: string,
+    toolId: string,
+    addedBy: string,
+    create: Required<PolicyPatch>,
+    update: PolicyPatch,
+  ): Promise<Scoped<EntityToolPolicyRow>>;
+  toolIdsForMappings(scope: ClaimedScope, entityId: string, mappingIds: string[]): Promise<Scoped<string[]>>;
+  savePolicies(
+    scope: ClaimedScope,
+    entityId: string,
+    toolIds: string[],
+    create: Required<PolicyPatch> & { addedBy: string },
+    update: PolicyPatch,
+  ): Promise<Scoped<number>>;
+  syncAllowlist(entityId: string, names: readonly string[]): Promise<void>;
+}
+
+@Injectable()
+export class EntityToolPolicyStore implements EntityToolPolicyReader {
+  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
+
+  async pageExposures(
+    scope: ClaimedScope,
+    entityId: string,
+    options: { exposed?: boolean; search?: string; limit: number; offset: number },
+  ): Promise<Scoped<ExposurePage>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const environmentId = scope.environmentId;
+    const policyScope = { environmentId, entityId, effect: PolicyEffect.ALLOW };
+    const toolWhere = {
+      ...(options.search
+        ? { name: { contains: options.search, mode: "insensitive" as const } }
+        : {}),
+      ...(options.exposed === true
+        ? { entityPolicies: { some: policyScope } }
+        : options.exposed === false
+          ? { entityPolicies: { none: policyScope } }
+          : {}),
+    };
+    const where = {
+      entityId,
+      environmentId,
+      enabled: true,
+      ...(Object.keys(toolWhere).length > 0 ? { tool: toolWhere } : {}),
+    };
+    const { exposures, policies, total } = await this.prisma.$transaction(async (tx) => {
+      const [count, page] = await Promise.all([
+        tx.environmentEntityTool.count({ where }),
+        tx.environmentEntityTool.findMany({
+          where,
+          select: { id: true, toolId: true, tool: { select: { name: true } } },
+          orderBy: [{ tool: { name: "asc" } }, { id: "asc" }],
+          skip: options.offset,
+          take: options.limit,
+        }),
+      ]);
+      const pagePolicies = page.length === 0
+        ? []
+        : await tx.entityToolPolicy.findMany({
+            where: {
+              environmentId,
+              entityId,
+              toolId: { in: page.map((mapping) => mapping.toolId) },
+            },
+            include: { tool: { select: { name: true } } },
+          });
+      return { exposures: page, policies: pagePolicies, total: count };
+    });
+    return scopeAllowed({
+      exposures: exposures.map((row) => ({ id: row.id, toolId: row.toolId, toolName: row.tool.name })),
+      policies: policies.map(toPolicyRow),
+      total,
+    });
+  }
+
+  async listAllowedPoliciesForVerifiedEnvironment(
+    verifiedEnvironmentId: string,
+    entityId: string,
+    toolName?: string,
+  ): Promise<readonly EntityToolPolicyRow[]> {
+    const rows = await this.prisma.entityToolPolicy.findMany({
+      where: {
+        entityId,
+        environmentId: verifiedEnvironmentId,
+        effect: PolicyEffect.ALLOW,
+        ...(toolName ? { tool: { name: toolName } } : {}),
+      },
+      include: { tool: { select: { name: true } } },
+    });
+    return rows.map(toPolicyRow);
+  }
+
+  async exposedToolNamesForEntity(entityId: string): Promise<readonly string[]> {
+    const rows = await this.prisma.entityToolPolicy.findMany({
+      where: { entityId, effect: PolicyEffect.ALLOW },
+      select: { tool: { select: { name: true } } },
+    });
+    return Array.from(new Set(rows.map((row) => row.tool.name)));
+  }
+
+  async readScopeLabels(
+    scope: ClaimedScope,
+    entityId: string,
+    toolId: string,
+  ): Promise<Scoped<string[] | null>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const existing = await this.prisma.entityToolPolicy.findUnique({
+      where: {
+        environmentId_entityId_toolId: { environmentId: scope.environmentId, entityId, toolId },
+      },
+      select: { scopeLabels: true },
+    });
+    return scopeAllowed(existing?.scopeLabels ?? null);
+  }
+
+  async savePolicy(
+    scope: ClaimedScope,
+    entityId: string,
+    toolId: string,
+    addedBy: string,
+    create: Required<PolicyPatch>,
+    update: PolicyPatch,
+  ): Promise<Scoped<EntityToolPolicyRow>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const row = await this.prisma.entityToolPolicy.upsert({
+      where: {
+        environmentId_entityId_toolId: { environmentId: scope.environmentId, entityId, toolId },
+      },
+      create: {
+        environmentId: scope.environmentId,
+        entityId,
+        toolId,
+        effect: create.effect as PolicyEffect,
+        minIdentityMode: create.minIdentityMode,
+        scopeLabels: create.scopeLabels,
+        addedBy,
+      },
+      update: {
+        ...(update.effect !== undefined && { effect: update.effect as PolicyEffect }),
+        ...(update.minIdentityMode !== undefined && { minIdentityMode: update.minIdentityMode }),
+        ...(update.scopeLabels !== undefined && { scopeLabels: update.scopeLabels }),
+      },
+      include: { tool: { select: { name: true } } },
+    });
+    return scopeAllowed(toPolicyRow(row));
+  }
+
+  async toolIdsForMappings(
+    scope: ClaimedScope,
+    entityId: string,
+    mappingIds: string[],
+  ): Promise<Scoped<string[]>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const mappings = await this.prisma.environmentEntityTool.findMany({
+      where: { id: { in: mappingIds }, entityId, environmentId: scope.environmentId },
+      select: { toolId: true },
+    });
+    return scopeAllowed(Array.from(new Set(mappings.map((mapping) => mapping.toolId))));
+  }
+
+  async savePolicies(
+    scope: ClaimedScope,
+    entityId: string,
+    toolIds: string[],
+    create: Required<PolicyPatch> & { addedBy: string },
+    update: PolicyPatch,
+  ): Promise<Scoped<number>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    await this.prisma.$transaction(
+      toolIds.map((toolId) =>
+        this.prisma.entityToolPolicy.upsert({
+          where: {
+            environmentId_entityId_toolId: { environmentId: scope.environmentId, entityId, toolId },
+          },
+          create: {
+            environmentId: scope.environmentId,
+            entityId,
+            toolId,
+            effect: create.effect as PolicyEffect,
+            minIdentityMode: create.minIdentityMode,
+            scopeLabels: create.scopeLabels,
+            addedBy: create.addedBy,
+          },
+          update: {
+            ...(update.effect !== undefined && { effect: update.effect as PolicyEffect }),
+            ...(update.minIdentityMode !== undefined && { minIdentityMode: update.minIdentityMode }),
+          },
+        }),
+      ),
+    );
+    return scopeAllowed(toolIds.length);
+  }
+
+  async syncAllowlist(entityId: string, names: readonly string[]): Promise<void> {
+    await this.prisma.entityMcpConfig.updateMany({
+      where: { entityId },
+      data: { toolAllowlist: [...names] },
+    });
+  }
+}
+
+function toPolicyRow(row: {
+  id: string;
+  environmentId: string;
+  entityId: string;
+  toolId: string;
+  effect: PolicyEffect;
+  minIdentityMode: string;
+  scopeLabels: string[];
+  addedAt: Date;
+  lastReviewedAt: Date | null;
+  tool: { name: string };
+}): EntityToolPolicyRow {
+  return {
+    id: row.id,
+    environmentId: row.environmentId,
+    entityId: row.entityId,
+    toolId: row.toolId,
+    toolName: row.tool.name,
+    effect: row.effect === PolicyEffect.ALLOW ? "ALLOW" : "DENY",
+    minIdentityMode: row.minIdentityMode,
+    scopeLabels: row.scopeLabels,
+    addedAt: row.addedAt,
+    lastReviewedAt: row.lastReviewedAt,
+  };
+}

--- a/apps/agent/src/mcp-platform/identity-resolver.service.test.ts
+++ b/apps/agent/src/mcp-platform/identity-resolver.service.test.ts
@@ -13,28 +13,32 @@ function request(
   } as unknown as Request;
 }
 
-function createPrisma() {
+// WIN-268 P2 — the double is an `McpIdentityReader`, the interface the resolver
+// actually names, not a fake `PrismaClient`. The one clause-shape assertion this
+// suite made (that the environment lookup joins through
+// `project.entities.some`) has moved to `mcp-identity.integration.test.ts`,
+// where a second tenant's environment can be shown to actually be excluded
+// rather than a `where` object shown to be spelled a certain way.
+function createStore() {
   return {
-    entityMcpConfig: { findUnique: vi.fn() },
-    mcpAnonymousSession: {
-      findFirst: vi.fn(),
-      update: vi.fn().mockResolvedValue({}),
-      create: vi.fn(),
-    },
-    environment: { findMany: vi.fn() },
-  } as any;
+    readMcpSurface: vi.fn(),
+    findActiveEnvironmentForEntity: vi.fn().mockResolvedValue(null),
+    findLiveAnonymousSession: vi.fn().mockResolvedValue(null),
+    touchAnonymousSession: vi.fn().mockResolvedValue(undefined),
+    createAnonymousSession: vi.fn(),
+  } satisfies Record<string, unknown> as any;
 }
 
 describe("McpIdentityResolverService authentication order", () => {
-  let prisma: ReturnType<typeof createPrisma>;
+  let store: ReturnType<typeof createStore>;
   let bearer: { validate: ReturnType<typeof vi.fn> };
   let service: McpIdentityResolverService;
 
   beforeEach(() => {
-    prisma = createPrisma();
+    store = createStore();
     bearer = { validate: vi.fn() };
-    service = new McpIdentityResolverService(prisma, bearer as any);
-    prisma.entityMcpConfig.findUnique.mockResolvedValue({
+    service = new McpIdentityResolverService(store, bearer as any);
+    store.readMcpSurface.mockResolvedValue({
       enabled: true,
       identityMode: "bearer+oidc+anonymous",
     });
@@ -64,7 +68,7 @@ describe("McpIdentityResolverService authentication order", () => {
         environmentId: "env_1",
       },
     });
-    expect(prisma.mcpAnonymousSession.create).not.toHaveBeenCalled();
+    expect(store.createAnonymousSession).not.toHaveBeenCalled();
   });
 
   it("uses an upstream verified OAuth identity before anonymous fallback", async () => {
@@ -79,15 +83,15 @@ describe("McpIdentityResolverService authentication order", () => {
     await expect(service.resolve(req, "entity_1")).resolves.toEqual(
       (req as any).mcpIdentity,
     );
-    expect(prisma.mcpAnonymousSession.create).not.toHaveBeenCalled();
+    expect(store.createAnonymousSession).not.toHaveBeenCalled();
   });
 
   it("creates an environment-owned anonymous session only when enabled", async () => {
-    prisma.environment.findMany.mockResolvedValue([{ id: "env_1" }]);
-    prisma.mcpAnonymousSession.create.mockImplementation(async ({ data }: any) => ({
+    store.findActiveEnvironmentForEntity.mockResolvedValue("env_1");
+    store.createAnonymousSession.mockResolvedValue({
       id: "session_1",
-      mcpUserId: data.mcpUserId,
-    }));
+      mcpUserId: "mcp:anon:generated",
+    });
 
     const result = await service.resolve(request({}, { environmentId: "env_1" }), "entity_1");
 
@@ -96,14 +100,11 @@ describe("McpIdentityResolverService authentication order", () => {
       environmentId: "env_1",
       metadata: { sessionId: "session_1", environmentId: "env_1" },
     });
-    expect(prisma.mcpAnonymousSession.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
-        entityId: "entity_1",
-        environmentId: "env_1",
-        firstSeenIp: "127.0.0.1",
-      }),
-      select: { id: true, mcpUserId: true },
-    });
+    expect(store.createAnonymousSession).toHaveBeenCalledWith(
+      "entity_1",
+      "env_1",
+      expect.objectContaining({ firstSeenIp: "127.0.0.1" }),
+    );
   });
 
   it("requires an explicit environment when anonymous scope is ambiguous", async () => {
@@ -111,12 +112,12 @@ describe("McpIdentityResolverService authentication order", () => {
       error: "environmentId is required for anonymous MCP authentication",
       status: 400,
     });
-    expect(prisma.mcpAnonymousSession.create).not.toHaveBeenCalled();
+    expect(store.createAnonymousSession).not.toHaveBeenCalled();
   });
 
   it("accepts a canonical anonymous environment selector and verifies ancestry", async () => {
-    prisma.environment.findMany.mockResolvedValue([{ id: "env_2" }]);
-    prisma.mcpAnonymousSession.create.mockResolvedValue({
+    store.findActiveEnvironmentForEntity.mockResolvedValue("env_2");
+    store.createAnonymousSession.mockResolvedValue({
       id: "session_2",
       mcpUserId: "mcp:anon:user",
     });
@@ -125,20 +126,14 @@ describe("McpIdentityResolverService authentication order", () => {
     (req as any).query = { environmentId: "env_2" };
     const result = await service.resolve(req, "entity_1");
     expect(result).toMatchObject({ environmentId: "env_2" });
-    expect(prisma.environment.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          project: { entities: { some: { id: "entity_1" } } },
-        }),
-      }),
-    );
+    // The ENTITY is carried into the lookup, which is what makes the ancestry
+    // check possible at all. That it actually excludes a foreign environment is
+    // proved against real PostgreSQL in `mcp-identity.integration.test.ts`.
+    expect(store.findActiveEnvironmentForEntity).toHaveBeenCalledWith("entity_1", "env_2");
   });
 
   it("rejects anonymous and bearer credentials when their modes are disabled", async () => {
-    prisma.entityMcpConfig.findUnique.mockResolvedValue({
-      enabled: true,
-      identityMode: "oidc",
-    });
+    store.readMcpSurface.mockResolvedValue({ enabled: true, identityMode: "oidc" });
 
     await expect(service.resolve(request(), "entity_1")).resolves.toEqual({
       error: "This entity requires authentication",

--- a/apps/agent/src/mcp-platform/identity-resolver.service.ts
+++ b/apps/agent/src/mcp-platform/identity-resolver.service.ts
@@ -1,11 +1,7 @@
 import { Injectable, Inject } from "@nestjs/common";
-import {
-  type ControlDatabaseClient,
-  PRISMA_TOKEN,
-} from "../shared/database.provider";
+import { McpIdentityStore, type McpIdentityReader } from "./mcp-identity.store";
 import { McpBearerTokenService } from "./mcp-bearer-token.service";
 import type { Request } from "express";
-import { randomUUID } from "crypto";
 
 export interface McpIdentityResult {
   mcpUserId: string;
@@ -31,7 +27,7 @@ export interface McpIdentityRejectReason {
 @Injectable()
 export class McpIdentityResolverService {
   constructor(
-    @Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient,
+    @Inject(McpIdentityStore) private readonly store: McpIdentityReader,
     private readonly bearerTokenService: McpBearerTokenService,
   ) {}
 
@@ -40,16 +36,13 @@ export class McpIdentityResolverService {
     entityPk: string,
   ): Promise<McpIdentityResult | McpIdentityRejectReason> {
     const authHeader = req.headers["authorization"] as string | undefined;
-    const entityConfig = await this.prisma.entityMcpConfig.findUnique({
-      where: { entityId: entityPk },
-      select: { identityMode: true, enabled: true },
-    });
+    const entityConfig = await this.store.readMcpSurface(entityPk);
 
     if (!entityConfig?.enabled) {
       return { error: "MCP not enabled for this entity", status: 403 };
     }
 
-    const identityMode = (entityConfig.identityMode as string) ?? "anonymous";
+    const identityMode = entityConfig.identityMode ?? "anonymous";
     const allowedModes = identityMode.split("+");
 
     // 1. Bearer PAT (plt_ent_ prefix)
@@ -118,37 +111,23 @@ export class McpIdentityResolverService {
     // Check for existing anon session cookie/header
     const existingId = req.headers["x-mcp-anon-session"] as string | undefined;
     if (existingId) {
-      const existing = await this.prisma.mcpAnonymousSession.findFirst({
-        where: {
-          mcpUserId: existingId,
-          entityId: entityPk,
-          environmentId,
-          revokedAt: null,
-        },
-        select: { id: true, mcpUserId: true },
-      });
+      const existing = await this.store.findLiveAnonymousSession(entityPk, environmentId, existingId);
       if (existing) {
-        void this.prisma.mcpAnonymousSession.update({
-          where: { id: existing.id },
-          data: { lastUsedAt: new Date() },
-        }).catch(() => undefined);
+        void this.store.touchAnonymousSession(existing.id);
         return existing;
       }
     }
 
-    // Create new anon session
-    const mcpUserId = `mcp:anon:${randomUUID().replace(/-/g, "")}`;
-    const session = await this.prisma.mcpAnonymousSession.create({
-      data: {
-        entityId: entityPk,
-        environmentId,
-        mcpUserId,
-        firstSeenIp: (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ?? (req.socket.remoteAddress ?? null),
-        userAgent: req.headers["user-agent"] ?? null,
-      },
-      select: { id: true, mcpUserId: true },
+    // Create new anon session. `identity-access` owns `McpAnonymousSession` and
+    // its contract publishes NO mint — deliberately, per its own banner — so
+    // this is a call site WIN-268 P2 stopped at rather than routed. See
+    // `mcp-identity.store.ts`.
+    return this.store.createAnonymousSession(entityPk, environmentId, {
+      firstSeenIp:
+        (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim()
+        ?? (req.socket.remoteAddress ?? null),
+      userAgent: req.headers["user-agent"] ?? null,
     });
-    return session;
   }
 
   private async resolveAnonymousEnvironment(
@@ -165,18 +144,9 @@ export class McpIdentityResolverService {
     if (!requested) {
       return { error: "environmentId is required for anonymous MCP authentication", status: 400 };
     }
-    const environments = await this.prisma.environment.findMany({
-      where: {
-        id: requested,
-        archivedAt: null,
-        project: { entities: { some: { id: entityPk } } },
-      },
-      select: { id: true },
-      orderBy: { id: "asc" },
-      take: 1,
-    });
-    return environments[0]
-      ? { environmentId: environments[0].id }
+    const environmentId = await this.store.findActiveEnvironmentForEntity(entityPk, requested);
+    return environmentId
+      ? { environmentId }
       : { error: "environmentId is not active for this entity", status: 403 };
   }
 }

--- a/apps/agent/src/mcp-platform/mcp-entity.controller.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-entity.controller.test.ts
@@ -519,9 +519,13 @@ describe("McpEntityController operator management", () => {
 
     await expect(controller.listToolAcl({ scope: operatorScope }, "acme", undefined, undefined, "2", "4"))
       .resolves.toEqual({ tools: [], total: 7, limit: 2, offset: 4 });
+    // WIN-268 P2 — the WHOLE claimed triple goes down, not the leaf alone.
+    // The environment id used to be passed on its own, which is precisely what
+    // let a forged organization id reach the policy rows unchallenged; the
+    // store now resolves the triple against the tree before reading anything.
     expect(controller.toolAclService.list).toHaveBeenCalledWith(
+      operatorScope,
       "entity_1",
-      "env_1",
       expect.objectContaining({ limit: 2, offset: 4 }),
     );
   });

--- a/apps/agent/src/mcp-platform/mcp-entity.controller.ts
+++ b/apps/agent/src/mcp-platform/mcp-entity.controller.ts
@@ -1266,7 +1266,7 @@ export class McpEntityController {
     const entity = await this.loadEntity(entityId, scope);
     if (!entity) throw new HttpException("Entity not found", HttpStatus.NOT_FOUND);
     if (entity.organizationId !== scope.organizationId) throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
-    const result = await this.toolAclService.list(entity.entityPk, scope.environmentId, {
+    const result = await this.toolAclService.list(scope, entity.entityPk, {
       exposed: exposed === "true" ? true : exposed === "false" ? false : undefined,
       search,
       limit: limit ? parseInt(limit, 10) : undefined,
@@ -1298,8 +1298,8 @@ export class McpEntityController {
     });
     if (!toolReg) throw new HttpException("Tool not found", HttpStatus.NOT_FOUND);
     const row = await this.toolAclService.upsert(
+      scope,
       entity.entityPk,
-      scope.environmentId,
       toolReg.toolId,
       toolReg.tool.name,
       scope.userId,
@@ -1319,7 +1319,7 @@ export class McpEntityController {
     const entity = await this.loadEntity(entityId, scope);
     if (!entity) throw new HttpException("Entity not found", HttpStatus.NOT_FOUND);
     if (entity.organizationId !== scope.organizationId) throw new HttpException("Forbidden", HttpStatus.FORBIDDEN);
-    const count = await this.toolAclService.bulk(entity.entityPk, scope.environmentId, body.toolIds, body.action, {
+    const count = await this.toolAclService.bulk(scope, entity.entityPk, body.toolIds, body.action, {
       minIdentityMode: body.minIdentityMode,
       addedBy: scope.userId,
     });

--- a/apps/agent/src/mcp-platform/mcp-identity.store.ts
+++ b/apps/agent/src/mcp-platform/mcp-identity.store.ts
@@ -1,0 +1,168 @@
+// The ORM seam behind the inbound MCP identity resolver.
+//
+// WIN-268 P2. `identity-resolver.service.ts` held five statements across three
+// contexts' rows and the admission decision that runs on them. This module takes
+// the five; the decision stays where it belongs.
+//
+// ---------------------------------------------------------------------------
+// THREE OWNERS, ONE FILE, AND THAT IS THE FINDING RATHER THAN A TIDY-UP
+//
+// `scripts/arch/table-ownership.mjs` gives the five statements to THREE
+// different contexts:
+//
+//   `EntityMcpConfig`      -> `tools`            (ADR M0.3 §1 row 7)
+//   `McpAnonymousSession`  -> `identity-access`  (ADR M0.3 §1 row 1)
+//   `Environment`          -> `tenancy`          (ADR M0.3 §1 row 2)
+//
+// and the three are in three different states with respect to a published use
+// case, which is worth recording precisely because "route it to the contract"
+// has three different answers here:
+//
+//   `tools` publishes `describeMcpSurface`, which is exactly the
+//   `entityMcpConfig` read below — the use case EXISTS. The context is not
+//   composed (no `ToolDispatch` adapter; WIN-269's scope).
+//
+//   `tenancy` IS composed, and this environment read is a scoped existence
+//   check of the shape its contract already answers.
+//
+//   `identity-access` IS composed and publishes NO use case for this at all,
+//   and that is deliberate on its side rather than an oversight on ours. Its
+//   contract's own banner says: "WHAT IS DELIBERATELY ABSENT: minting. No other
+//   context may issue a session, a magic link, an access key or an OAuth pair."
+//   `getOrCreateAnonSession` MINTS `McpAnonymousSession`. So this is a call site
+//   where the contract does not merely lack a method — it refuses to have one,
+//   and a tranche that added `mintAnonymousMcpSession` to
+//   `IdentityAccessContract` would be reversing a decision that context took on
+//   purpose. STOPPED HERE, reported, not worked around.
+//
+// The `apps/agent` process cannot call any of the three regardless — see
+// `mcp-policy.store.ts`'s header for the three independent measurements.
+
+import { randomUUID } from "node:crypto";
+
+import { Inject, Injectable } from "@nestjs/common";
+
+import { type ControlDatabaseClient, PRISMA_TOKEN } from "../shared/database.provider";
+
+/** The `EntityMcpConfig` fields the resolver decides on. */
+export interface McpSurfaceState {
+  readonly identityMode: string | null;
+  readonly enabled: boolean;
+}
+
+export interface AnonymousSession {
+  readonly id: string;
+  readonly mcpUserId: string;
+}
+
+export interface AnonymousSessionSeed {
+  readonly firstSeenIp: string | null;
+  readonly userAgent: string | null;
+}
+
+export interface McpIdentityReader {
+  /** `tools`' `describeMcpSurface`, in the shape this resolver needs. */
+  readMcpSurface(entityId: string): Promise<McpSurfaceState | null>;
+  /**
+   * `tenancy`: is this environment live, and does it hang off a project that
+   * owns this entity?
+   *
+   * THE ENTITY JOIN IS THE COHERENCE CHECK AND IT WAS ALREADY HERE. Unlike the
+   * operator surfaces this tranche had to harden, the extraction source already
+   * refused to accept an environment id that does not belong to the entity being
+   * addressed — `project: { entities: { some: { id: entityId } } }` — so there is
+   * no forged-scope hole to close on this path and none has been invented.
+   */
+  findActiveEnvironmentForEntity(entityId: string, environmentId: string): Promise<string | null>;
+  findLiveAnonymousSession(
+    entityId: string,
+    environmentId: string,
+    mcpUserId: string,
+  ): Promise<AnonymousSession | null>;
+  touchAnonymousSession(id: string): Promise<void>;
+  /** MINTS. `identity-access` publishes no contract method for this on purpose. */
+  createAnonymousSession(
+    entityId: string,
+    environmentId: string,
+    seed: AnonymousSessionSeed,
+  ): Promise<AnonymousSession>;
+}
+
+@Injectable()
+export class McpIdentityStore implements McpIdentityReader {
+  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
+
+  async readMcpSurface(entityId: string): Promise<McpSurfaceState | null> {
+    const config = await this.prisma.entityMcpConfig.findUnique({
+      where: { entityId },
+      select: { identityMode: true, enabled: true },
+    });
+    return config ? { identityMode: config.identityMode, enabled: config.enabled } : null;
+  }
+
+  async findActiveEnvironmentForEntity(
+    entityId: string,
+    environmentId: string,
+  ): Promise<string | null> {
+    const environments = await this.prisma.environment.findMany({
+      where: {
+        id: environmentId,
+        archivedAt: null,
+        project: { entities: { some: { id: entityId } } },
+      },
+      select: { id: true },
+      orderBy: { id: "asc" },
+      take: 1,
+    });
+    return environments[0]?.id ?? null;
+  }
+
+  async findLiveAnonymousSession(
+    entityId: string,
+    environmentId: string,
+    mcpUserId: string,
+  ): Promise<AnonymousSession | null> {
+    const existing = await this.prisma.mcpAnonymousSession.findFirst({
+      where: { mcpUserId, entityId, environmentId, revokedAt: null },
+      select: { id: true, mcpUserId: true },
+    });
+    return existing ?? null;
+  }
+
+  /**
+   * Stamp `lastUsedAt`, best effort.
+   *
+   * FIRE-AND-FORGET IS PRESERVED FROM THE EXTRACTION SOURCE, which called this
+   * with `void ... .catch(() => undefined)`. It is a liveness stamp, not an
+   * authorization fact: an anonymous session that is admitted and then fails to
+   * record that it was used is still admitted, and making the admission depend
+   * on the stamp would turn a write hiccup into an outage of the surface.
+   */
+  async touchAnonymousSession(id: string): Promise<void> {
+    try {
+      await this.prisma.mcpAnonymousSession.update({
+        where: { id },
+        data: { lastUsedAt: new Date() },
+      });
+    } catch {
+      // Deliberate: see the note above.
+    }
+  }
+
+  async createAnonymousSession(
+    entityId: string,
+    environmentId: string,
+    seed: AnonymousSessionSeed,
+  ): Promise<AnonymousSession> {
+    return this.prisma.mcpAnonymousSession.create({
+      data: {
+        entityId,
+        environmentId,
+        mcpUserId: `mcp:anon:${randomUUID().replace(/-/g, "")}`,
+        firstSeenIp: seed.firstSeenIp,
+        userAgent: seed.userAgent,
+      },
+      select: { id: true, mcpUserId: true },
+    });
+  }
+}

--- a/apps/agent/src/mcp-platform/mcp-platform.module.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform.module.ts
@@ -7,6 +7,11 @@ import { McpEntityController } from "./mcp-entity.controller";
 import { McpBearerTokenService } from "./mcp-bearer-token.service";
 import { McpIdentityResolverService } from "./identity-resolver.service";
 import { McpToolAclService } from "./mcp-tool-acl.service";
+// WIN-268 P2 — the ORM seams. Each is shaped like the `tools` / `identity-access`
+// contract call that replaces it; see each file's header for the three
+// measurements that say why that call cannot be made from this process yet.
+import { McpPolicyStore } from "./mcp-policy.store";
+import { EntityToolPolicyStore } from "./entity-tool-policy.store";
 import { AgentRuntimeModule } from "../agent-runtime/agent-runtime.module";
 import { MemoryModule } from "../memory/memory.module";
 import { EvalsModule } from "../evals/evals.module";
@@ -56,7 +61,7 @@ import { AdminModule } from "../admin/admin.module";
   // both share OAuthModule + ToolGatewayModule (ToolExecutorService +
   // ToolRouterService).
   controllers: [McpPlatformController, McpEntityController],
-  providers: [PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
+  providers: [McpPolicyStore, EntityToolPolicyStore, PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
   exports: [PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
 })
 export class McpPlatformModule {}

--- a/apps/agent/src/mcp-platform/mcp-platform.module.ts
+++ b/apps/agent/src/mcp-platform/mcp-platform.module.ts
@@ -12,6 +12,7 @@ import { McpToolAclService } from "./mcp-tool-acl.service";
 // measurements that say why that call cannot be made from this process yet.
 import { McpPolicyStore } from "./mcp-policy.store";
 import { EntityToolPolicyStore } from "./entity-tool-policy.store";
+import { McpIdentityStore } from "./mcp-identity.store";
 import { AgentRuntimeModule } from "../agent-runtime/agent-runtime.module";
 import { MemoryModule } from "../memory/memory.module";
 import { EvalsModule } from "../evals/evals.module";
@@ -61,7 +62,7 @@ import { AdminModule } from "../admin/admin.module";
   // both share OAuthModule + ToolGatewayModule (ToolExecutorService +
   // ToolRouterService).
   controllers: [McpPlatformController, McpEntityController],
-  providers: [McpPolicyStore, EntityToolPolicyStore, PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
+  providers: [McpPolicyStore, EntityToolPolicyStore, McpIdentityStore, PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
   exports: [PlatosMCPTokenService, MCPPermissionGatewayService, McpEventsService, McpBearerTokenService, McpIdentityResolverService, McpToolAclService],
 })
 export class McpPlatformModule {}

--- a/apps/agent/src/mcp-platform/mcp-policy.store.ts
+++ b/apps/agent/src/mcp-platform/mcp-policy.store.ts
@@ -1,0 +1,257 @@
+// The ORM seam behind the four-tier MCP permission gateway.
+//
+// WIN-268 P2. `permission-gateway.service.ts` held the four-tier lattice AND the
+// eight `organizationMcpPolicy`/`agentBinding` reads the lattice runs on. The
+// lattice is pure — a total order and a max over four opinions — and the reads
+// are the only thing in that file that is not. This module takes the reads.
+//
+// ---------------------------------------------------------------------------
+// IT IS SHAPED LIKE THE CONTRACT CALL THAT REPLACES IT
+//
+// `packages/contexts/tools/contracts/index.ts` publishes `resolvePermission`,
+// `listOrganizationPolicies`, `setOrganizationPolicy` and
+// `deleteOrganizationPolicy`, and `tools/application/resolve-permission.ts` is a
+// faithful re-statement of the very algebra this gateway runs: the same
+// short-circuit order, the same "no agent means no opinion, an agent with no
+// binding in this scope is a denial", the same tier reporting. The rows are
+// `tools`' too — ADR M0.3 §1 row 7 gives it `OrganizationMcpPolicy`, and
+// `ADAPTER_BINDINGS` binds `postgres-tenancy:ToolsRepository` to owner `tools`.
+//
+// SO WHY IS THIS NOT `toolsContract.resolvePermission(...)`? Three measurements,
+// each of which independently forbids it, recorded here because the next tranche
+// will want to know which one to attack:
+//
+//   1. `apps/agent` imports NO `@platos/context-*`, NO `@platos/adapter-*` and
+//      NO `@platos/kernel` — zero occurrences in the tree, and its
+//      `package.json` declares none of them. There is no seam through which a
+//      composed contract reaches this Nest container.
+//   2. It could not gain one by importing an adapter: ADR M0.3 §5.1 rule (j)
+//      `adapters-only-from-core` gives that to `apps/core-api`, and
+//      `scripts/arch/composition-root.mjs` narrows it to the single file
+//      `apps/core-api/src/composition/adapter-bindings.ts`.
+//   3. `tools` is not composed in that root either. Its factory IS importable
+//      (`toolsContract`, from the package's own `.` entry point — it is NOT on
+//      `UNIMPORTABLE_CONTEXT_FACTORIES`) and its `ToolsRepository` IS bound to
+//      `postgres-tenancy`. What is missing is `ToolDispatch`, which has no
+//      adapter directory — and tool execution and the external MCP adapters are
+//      WIN-269's scope, not this tranche's.
+//
+// This module is therefore the seam, and it is deliberately the SAME SHAPE as
+// the call that will replace it: a scope in, a discriminated union out, no
+// Prisma type crossing the boundary in either direction. The swap is a
+// constructor argument, not a rewrite.
+//
+// ---------------------------------------------------------------------------
+// WHAT CHANGED BEHIND THE SEAM, AND IT IS NOT A REFACTOR
+//
+// TIER 2 NOW REFUSES A FORGED SCOPE INSTEAD OF ANSWERING FROM THE WRONG ORG.
+// The extraction source read `where: { organizationId: scope.organizationId }`,
+// with the organization taken on trust from the `x-platos-organization-id`
+// header. See `mcp-scope.ts` for the measurement of why that triple is not
+// trustworthy and why the failure mode is silent: the wrong organization is
+// usually one with NO policy rows, `findMany` answers `[]`, and an empty list
+// reads as "this tier has no objection". A tier that can only tighten became a
+// tier that could be made to abstain.
+//
+// Every scoped method below runs `resolveClaimedScope` first, exactly as
+// `tools-scope.ts` does for the context that owns these rows, and returns a
+// REFUSAL that is distinguishable from an empty result.
+
+import { Inject, Injectable } from "@nestjs/common";
+
+import { type ControlDatabaseClient, PRISMA_TOKEN } from "../shared/database.provider";
+import {
+  resolveClaimedScope,
+  scopeAllowed,
+  type ClaimedScope,
+  type Scoped,
+} from "./mcp-scope";
+
+/** One tier-2 row, with the ORM's enum already off it. */
+export interface OrganizationPolicyRow {
+  readonly id: string;
+  readonly organizationId: string;
+  readonly pattern: string;
+  readonly effect: "ALLOW" | "DENY";
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * The tier-3 opinion source: an agent's active version, as the lattice needs it.
+ *
+ * `null` for the whole binding means "this agent is not deployed in this scope",
+ * which `domain/permission.ts` in the destination context and the extraction
+ * source both treat as a DENIAL rather than as an absence of opinion.
+ */
+export interface AgentPolicyBinding {
+  readonly defaultPolicy: string;
+  /** The highest-priority explicit effect for the named tool, if any. */
+  readonly explicitEffect: "ALLOW" | "DENY" | null;
+}
+
+/**
+ * The reads and writes the MCP permission gateway runs on.
+ *
+ * An INTERFACE and not just a class, so `permission-gateway.service.ts` names
+ * this shape rather than an implementation and a suite can drive the lattice
+ * with no database at all — which is what lets the lattice's own cases stay unit
+ * tests while the REFUSALS get proved against a real PostgreSQL.
+ */
+export interface McpPolicyReader {
+  listOrganizationPolicies(scope: ClaimedScope): Promise<Scoped<readonly OrganizationPolicyRow[]>>;
+  findAgentPolicyBinding(
+    scope: ClaimedScope,
+    agentId: string,
+    toolName: string,
+  ): Promise<Scoped<AgentPolicyBinding | null>>;
+  upsertOrganizationPolicy(
+    scope: ClaimedScope,
+    pattern: string,
+    effect: "ALLOW" | "DENY",
+  ): Promise<Scoped<OrganizationPolicyRow>>;
+  deleteOrganizationPolicy(scope: ClaimedScope, id: string): Promise<Scoped<boolean>>;
+}
+
+@Injectable()
+export class McpPolicyStore implements McpPolicyReader {
+  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
+
+  /**
+   * Tier 2, scope-checked.
+   *
+   * THE ORGANIZATION IS THE RESOLVED ONE, NOT THE CLAIMED ONE. `resolveClaimedScope`
+   * returns the organization it read THROUGH the environment's project, and that
+   * is the value the `where` clause is built from. Passing the claimed id after
+   * checking it would work today and would silently stop working the moment
+   * somebody widened the check; reading rows for a value the database resolved
+   * cannot drift from the check that resolved it.
+   */
+  async listOrganizationPolicies(
+    scope: ClaimedScope,
+  ): Promise<Scoped<readonly OrganizationPolicyRow[]>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const rows = await this.prisma.organizationMcpPolicy.findMany({
+      where: { organizationId: resolved.value.organizationId },
+      orderBy: [{ pattern: "asc" }],
+    });
+    return scopeAllowed(rows.map(toOrganizationPolicyRow));
+  }
+
+  /**
+   * Tier 3, scope-checked, with the tool's explicit effect resolved in the same
+   * statement the binding is.
+   *
+   * THE RELATION FILTERS STAY. The extraction source already re-derived the
+   * whole chain here — `environmentId`, `environment.projectId`,
+   * `environment.project.organizationId` and `agent.projectId` — and that is
+   * KEPT rather than replaced by the scope resolver above, because the two
+   * check different things: the resolver says the claimed triple is a real
+   * chain, and these say the BINDING sits on it. A scope resolver alone would
+   * admit an agent bound in a sibling project of the same organization.
+   */
+  async findAgentPolicyBinding(
+    scope: ClaimedScope,
+    agentId: string,
+    toolName: string,
+  ): Promise<Scoped<AgentPolicyBinding | null>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const binding = await this.prisma.agentBinding.findFirst({
+      where: {
+        agentId,
+        environmentId: scope.environmentId,
+        environment: {
+          projectId: resolved.value.projectId,
+          project: { organizationId: resolved.value.organizationId },
+        },
+        agent: { projectId: resolved.value.projectId },
+      },
+      select: {
+        activeAgentVersion: {
+          select: {
+            toolDefaultPolicy: true,
+            toolPolicies: {
+              where: { tool: { name: toolName } },
+              orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
+              take: 1,
+              select: { effect: true },
+            },
+          },
+        },
+      },
+    });
+    if (!binding) return scopeAllowed(null);
+    return scopeAllowed({
+      defaultPolicy: binding.activeAgentVersion.toolDefaultPolicy,
+      explicitEffect: binding.activeAgentVersion.toolPolicies[0]?.effect ?? null,
+    });
+  }
+
+  async upsertOrganizationPolicy(
+    scope: ClaimedScope,
+    pattern: string,
+    effect: "ALLOW" | "DENY",
+  ): Promise<Scoped<OrganizationPolicyRow>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const organizationId = resolved.value.organizationId;
+    // The unique key is composite, so this is find + update/create rather than
+    // `upsert`. Unchanged from the extraction source.
+    const existing = await this.prisma.organizationMcpPolicy.findFirst({
+      where: { organizationId, pattern },
+      select: { id: true },
+    });
+    if (existing) {
+      const updated = await this.prisma.organizationMcpPolicy.update({
+        where: { id: existing.id },
+        data: { effect },
+      });
+      return scopeAllowed(toOrganizationPolicyRow(updated));
+    }
+    const created = await this.prisma.organizationMcpPolicy.create({
+      data: { organizationId, pattern, effect },
+    });
+    return scopeAllowed(toOrganizationPolicyRow(created));
+  }
+
+  /**
+   * Delete one tier-2 row, scope-checked.
+   *
+   * `false` MEANS "no such row in THIS organization" and is not a refusal: a
+   * caller deleting a policy that is already gone has got what it asked for.
+   * A forged scope is the other branch, and it is a refusal — which is the
+   * distinction the extraction source could not make, because it answered
+   * `false` for both.
+   */
+  async deleteOrganizationPolicy(scope: ClaimedScope, id: string): Promise<Scoped<boolean>> {
+    const resolved = await resolveClaimedScope(this.prisma, scope);
+    if (!resolved.ok) return resolved;
+    const existing = await this.prisma.organizationMcpPolicy.findFirst({
+      where: { id, organizationId: resolved.value.organizationId },
+      select: { id: true },
+    });
+    if (!existing) return scopeAllowed(false);
+    await this.prisma.organizationMcpPolicy.delete({ where: { id } });
+    return scopeAllowed(true);
+  }
+}
+
+function toOrganizationPolicyRow(row: {
+  id: string;
+  organizationId: string;
+  pattern: string;
+  effect: "ALLOW" | "DENY";
+  createdAt: Date;
+  updatedAt: Date;
+}): OrganizationPolicyRow {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    pattern: row.pattern,
+    effect: row.effect,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}

--- a/apps/agent/src/mcp-platform/mcp-scope.integration.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-scope.integration.test.ts
@@ -1,0 +1,391 @@
+// WIN-268 P2 — the MCP authorization surfaces' refusals, against a REAL
+// PostgreSQL, with TWO TENANTS and a FORGED TRIPLE.
+//
+// ---------------------------------------------------------------------------
+// WHY A COHERENT TWO-TENANT CASE WOULD HAVE PROVED NOTHING
+//
+// Give tenant A's operator tenant A's whole triple and tenant B's operator
+// tenant B's, and every version of this code passes — including the version
+// with no ancestry check at all — because a `where` keyed on the leaf alone
+// already separates two tenants whose leaves differ. A two-tenant test is not
+// automatically a tenancy test.
+//
+// The case that separates them is the FORGED triple: an environment from tenant
+// A carried under tenant B's organization id. `apps/agent/src/auth/scope.guard.ts`
+// assembles `RequestScope` from three unrelated request headers —
+// `x-platos-organization-id`, `x-platos-project-id`, `x-platos-environment-id` —
+// and joins them only when `x-platos-agent-id` is also present. So the forged
+// triple is not hypothetical; it is what that guard admits.
+//
+// AND THE DEFECT IT EXPOSES IS AN ESCALATION, NOT A LEAK. `readOrgPolicy` used
+// to read `where: { organizationId: scope.organizationId }`. Point it at an
+// organization with NO policy rows and it answers `[]`; `[]` means "no pattern
+// matched" means "this tier has no objection". So a caller sitting under a
+// tenant that DENIES a tool could escape that denial by naming a second tenant's
+// organization id — a tier that can only tighten, made to abstain. Case 3 below
+// runs the extraction source's own statement against these rows and shows the
+// empty answer, then shows the current code refusing. That is the join to
+// something outside this file: the defect is demonstrated on real rows rather
+// than asserted in prose.
+//
+// ---------------------------------------------------------------------------
+// IT FAILS WHEN DOCKER IS ABSENT RATHER THAN SKIPPING, for the reason
+// `packages/adapters/postgres-tenancy/src/harness.ts` gives: a skipped
+// integration suite and a passing one look identical in a CI summary, and this
+// suite IS the evidence.
+
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { resolve } from "node:path";
+
+import { PostgreSqlContainer, type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
+import { PrismaClient } from "@platos/tenancy-database";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { EntityToolPolicyStore } from "./entity-tool-policy.store";
+import { McpIdentityStore } from "./mcp-identity.store";
+import { McpPolicyStore } from "./mcp-policy.store";
+import { MCPPermissionGatewayService, McpScopeRefusedError } from "./permission-gateway.service";
+import { MCP_SCOPE_FOREIGN, MCP_SCOPE_UNKNOWN, type ClaimedScope } from "./mcp-scope";
+
+// A container start plus a `migrate deploy` is minutes, not seconds, on a
+// hosted runner.
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 300_000 });
+
+const AGENT_ROOT = resolve(__dirname, "../..");
+const DATABASE_PACKAGE = resolve(AGENT_ROOT, "../../internal-packages/tenancy-database");
+const PRISMA_BINARY = resolve(AGENT_ROOT, "../../node_modules/.bin/prisma");
+
+interface Tenant {
+  readonly organizationId: string;
+  readonly projectId: string;
+  readonly environmentId: string;
+  readonly entityId: string;
+  readonly toolId: string;
+  readonly mappingId: string;
+  readonly scope: ClaimedScope;
+}
+
+let container: StartedPostgreSqlContainer;
+let prisma: PrismaClient;
+let alpha: Tenant;
+let beta: Tenant;
+
+async function seedTenant(label: string): Promise<Tenant> {
+  const organizationId = randomUUID();
+  const projectId = randomUUID();
+  const environmentId = randomUUID();
+  const entityId = randomUUID();
+  const toolId = randomUUID();
+  const mappingId = randomUUID();
+
+  await prisma.organization.create({
+    data: { id: organizationId, slug: `${label}-org`, name: `${label} org` },
+  });
+  await prisma.project.create({
+    data: { id: projectId, organizationId, slug: `${label}-proj`, name: `${label} project` },
+  });
+  await prisma.environment.create({
+    data: { id: environmentId, projectId, slug: `${label}-env`, name: `${label} environment` },
+  });
+  await prisma.entity.create({
+    data: {
+      id: entityId,
+      projectId,
+      externalId: `${label}-entity`,
+      displayName: `${label} entity`,
+      connectionStatus: "connected",
+      connectionKind: "mcp",
+    },
+  });
+  await prisma.entityMcpConfig.create({
+    data: { entityId, enabled: true, identityMode: "bearer+anonymous" },
+  });
+  await prisma.tool.create({
+    data: {
+      id: toolId,
+      name: `reports.get`,
+      description: `${label} report reader`,
+      paramSchema: {},
+      schemaHash: `hash-${label}`,
+    },
+  });
+  await prisma.environmentEntityTool.create({
+    data: { id: mappingId, environmentId, entityId, toolId, enabled: true },
+  });
+
+  return {
+    organizationId,
+    projectId,
+    environmentId,
+    entityId,
+    toolId,
+    mappingId,
+    scope: { organizationId, projectId, environmentId },
+  };
+}
+
+beforeAll(async () => {
+  container = await new PostgreSqlContainer("pgvector/pgvector:pg16").start();
+  const databaseUrl = container.getConnectionUri();
+  execFileSync(PRISMA_BINARY, ["migrate", "deploy", "--schema", resolve(DATABASE_PACKAGE, "prisma/schema.prisma")], {
+    cwd: DATABASE_PACKAGE,
+    env: { ...process.env, DATABASE_URL: databaseUrl },
+    stdio: "inherit",
+  });
+  prisma = new PrismaClient({ datasourceUrl: databaseUrl });
+  await prisma.$connect();
+  alpha = await seedTenant("alpha");
+  beta = await seedTenant("beta");
+
+  // TENANT ALPHA DENIES `reports.*`. TENANT BETA HAS NO POLICY AT ALL — which
+  // is what makes beta's organization id a useful thing for an alpha caller to
+  // forge, and is therefore the whole point of the fixture.
+  await prisma.organizationMcpPolicy.create({
+    data: { organizationId: alpha.organizationId, pattern: "reports.*", effect: "DENY" },
+  });
+}, 300_000);
+
+afterAll(async () => {
+  await prisma?.$disconnect();
+  await container?.stop();
+});
+
+/** The forged triple: alpha's environment and project, beta's organization. */
+function forged(): ClaimedScope {
+  return {
+    organizationId: beta.organizationId,
+    projectId: alpha.projectId,
+    environmentId: alpha.environmentId,
+  };
+}
+
+describe("WIN-268 P2 — the four-tier gate's refusals against real PostgreSQL", () => {
+  it("COHERENT: each tenant sees its own tier-2 answer, and this case passes either way", async () => {
+    const gateway = new MCPPermissionGatewayService(new McpPolicyStore(prisma));
+
+    await expect(
+      gateway.resolve({ scope: alpha.scope, agentId: null, userId: null, toolName: "reports.get" }),
+    ).resolves.toEqual({ state: "block", tier: 2, reason: "org-policy block" });
+
+    await expect(
+      gateway.resolve({ scope: beta.scope, agentId: null, userId: null, toolName: "reports.get" }),
+    ).resolves.toMatchObject({ state: "auto_allow" });
+
+    // Stated so the next reader does not mistake the above for the tenancy
+    // proof: a `where` keyed on `organizationId` alone already separates these
+    // two, so a build with NO ancestry check passes this case. The next one is
+    // the one that does the work.
+  });
+
+  it("FORGED: alpha's environment under beta's organization is REFUSED, not answered", async () => {
+    const store = new McpPolicyStore(prisma);
+    const gateway = new MCPPermissionGatewayService(store);
+
+    const refused = await store.listOrganizationPolicies(forged());
+    expect(refused).toEqual({ ok: false, reason: MCP_SCOPE_FOREIGN });
+
+    await expect(
+      gateway.resolve({ scope: forged(), agentId: null, userId: null, toolName: "reports.get" }),
+    ).resolves.toEqual({ state: "block", tier: 2, reason: `scope ${MCP_SCOPE_FOREIGN}` });
+  });
+
+  it("FORGED, THE DISCRIMINATOR: the pre-P2 statement ESCAPES alpha's deny on these same rows", async () => {
+    // The extraction source's own read, verbatim, run against the fixture.
+    // This is not a re-implementation for the sake of an assertion: it is the
+    // statement that shipped, and it is here so the defect is demonstrated on
+    // real rows rather than described.
+    const asShipped = await prisma.organizationMcpPolicy.findMany({
+      where: { organizationId: forged().organizationId },
+      select: { pattern: true, effect: true },
+    });
+
+    // An EMPTY RESULT. Not an error, not a refusal — nothing matched, because
+    // beta has no policies, and the caller is standing in alpha's environment.
+    expect(asShipped).toEqual([]);
+
+    // And an empty tier-2 answer is an ABSTENTION, so the tool alpha DENIES
+    // would have resolved `auto_allow`. That is the escalation.
+    const alphaDenied = await prisma.organizationMcpPolicy.findMany({
+      where: { organizationId: alpha.organizationId },
+      select: { pattern: true, effect: true },
+    });
+    expect(alphaDenied).toEqual([{ pattern: "reports.*", effect: "DENY" }]);
+
+    // The current code refuses instead. THE REFUSAL IS THE POINT: it is not
+    // that the answer is empty, it is that there is no answer.
+    const gateway = new MCPPermissionGatewayService(new McpPolicyStore(prisma));
+    const resolved = await gateway.resolve({
+      scope: forged(),
+      agentId: null,
+      userId: null,
+      toolName: "reports.get",
+    });
+    expect(resolved.state).toBe("block");
+    expect(resolved.state).not.toBe("auto_allow");
+  });
+
+  it("distinguishes a forged ancestry from an environment that does not exist", async () => {
+    const store = new McpPolicyStore(prisma);
+
+    await expect(
+      store.listOrganizationPolicies({ ...alpha.scope, environmentId: randomUUID() }),
+    ).resolves.toEqual({ ok: false, reason: MCP_SCOPE_UNKNOWN });
+
+    // A NON-UUID leaf is `unknown_environment` too, and it must not raise.
+    // The id arrives as a raw HTTP header, so `::uuid` in the resolver's join
+    // would turn `x-platos-environment-id: not-a-uuid` into a PostgreSQL 22P02
+    // and a 500 — which is a worse answer than the 403 a forged scope earned.
+    await expect(
+      store.listOrganizationPolicies({ ...alpha.scope, environmentId: "not-a-uuid" }),
+    ).resolves.toEqual({ ok: false, reason: MCP_SCOPE_UNKNOWN });
+  });
+
+  it("refuses every WRITE on a forged scope, including the delete that used to answer false", async () => {
+    const gateway = new MCPPermissionGatewayService(new McpPolicyStore(prisma));
+
+    await expect(gateway.listOrgPolicies(forged())).rejects.toThrow(McpScopeRefusedError);
+    await expect(gateway.upsertOrgPolicy(forged(), "secrets.*", "block")).rejects.toThrow(
+      McpScopeRefusedError,
+    );
+    await expect(gateway.deleteOrgPolicy(forged(), randomUUID())).rejects.toThrow(
+      McpScopeRefusedError,
+    );
+
+    // AND NOTHING WAS WRITTEN. A refusal that still left a row would be a
+    // refusal in name only, so the count is read back rather than assumed.
+    const betaPolicies = await prisma.organizationMcpPolicy.count({
+      where: { organizationId: beta.organizationId },
+    });
+    expect(betaPolicies).toBe(0);
+  });
+
+  it("the coherent write path still works, so the refusal is not a blanket outage", async () => {
+    const gateway = new MCPPermissionGatewayService(new McpPolicyStore(prisma));
+    const created = await gateway.upsertOrgPolicy(beta.scope, "secrets.*", "block");
+    expect(created.policy).toBe("block");
+
+    await expect(gateway.deleteOrgPolicy(beta.scope, created.id)).resolves.toBe(true);
+    // "no such row" is still `false`, and it is NOT the same value a forged
+    // scope produces — that is the distinction the extraction source could not
+    // make, because it answered `false` for both.
+    await expect(gateway.deleteOrgPolicy(beta.scope, randomUUID())).resolves.toBe(false);
+  });
+});
+
+describe("WIN-268 P2 — the entity tool ACL's refusals against real PostgreSQL", () => {
+  it("COHERENT: each tenant pages only its own exposures", async () => {
+    const store = new EntityToolPolicyStore(prisma);
+
+    const alphaPage = await store.pageExposures(alpha.scope, alpha.entityId, { limit: 50, offset: 0 });
+    expect(alphaPage.ok).toBe(true);
+    expect(alphaPage.ok && alphaPage.value.exposures.map((row) => row.id)).toEqual([alpha.mappingId]);
+
+    const betaPage = await store.pageExposures(beta.scope, beta.entityId, { limit: 50, offset: 0 });
+    expect(betaPage.ok && betaPage.value.exposures.map((row) => row.id)).toEqual([beta.mappingId]);
+  });
+
+  it("FORGED: the exposure page is refused, and the refusal is not an empty page", async () => {
+    const store = new EntityToolPolicyStore(prisma);
+    const page = await store.pageExposures(forged(), alpha.entityId, { limit: 50, offset: 0 });
+    expect(page).toEqual({ ok: false, reason: MCP_SCOPE_FOREIGN });
+
+    // The discriminator, again on real rows: the pre-P2 statement — keyed on
+    // `{ entityId, environmentId }` with no ancestry — answers alpha's real
+    // exposure to a caller claiming beta's organization.
+    const asShipped = await prisma.environmentEntityTool.findMany({
+      where: { entityId: alpha.entityId, environmentId: alpha.environmentId, enabled: true },
+      select: { id: true },
+    });
+    expect(asShipped).toEqual([{ id: alpha.mappingId }]);
+  });
+
+  it("FORGED: every scoped write is refused and leaves no row behind", async () => {
+    const store = new EntityToolPolicyStore(prisma);
+
+    await expect(
+      store.savePolicy(forged(), alpha.entityId, alpha.toolId, "attacker", {
+        effect: "ALLOW",
+        minIdentityMode: "bearer",
+        scopeLabels: ["mcp:tools"],
+      }, {}),
+    ).resolves.toEqual({ ok: false, reason: MCP_SCOPE_FOREIGN });
+
+    await expect(
+      store.savePolicies(forged(), alpha.entityId, [alpha.toolId], {
+        effect: "ALLOW",
+        minIdentityMode: "bearer",
+        scopeLabels: ["mcp:tools"],
+        addedBy: "attacker",
+      }, {}),
+    ).resolves.toEqual({ ok: false, reason: MCP_SCOPE_FOREIGN });
+
+    await expect(
+      store.toolIdsForMappings(forged(), alpha.entityId, [alpha.mappingId]),
+    ).resolves.toEqual({ ok: false, reason: MCP_SCOPE_FOREIGN });
+
+    expect(
+      await prisma.entityToolPolicy.count({ where: { entityId: alpha.entityId } }),
+    ).toBe(0);
+  });
+
+  it("the coherent write path still works and the exposure becomes visible", async () => {
+    const store = new EntityToolPolicyStore(prisma);
+    const saved = await store.savePolicy(beta.scope, beta.entityId, beta.toolId, "operator", {
+      effect: "ALLOW",
+      minIdentityMode: "bearer",
+      scopeLabels: ["mcp:tools"],
+    }, {});
+    expect(saved.ok).toBe(true);
+
+    const rows = await store.listAllowedPoliciesForVerifiedEnvironment(
+      beta.environmentId,
+      beta.entityId,
+      "reports.get",
+    );
+    expect(rows.map((row) => row.toolId)).toEqual([beta.toolId]);
+
+    // And the verified-environment read is still keyed on the environment the
+    // CREDENTIAL names: alpha's environment sees none of beta's policies.
+    const foreign = await store.listAllowedPoliciesForVerifiedEnvironment(
+      alpha.environmentId,
+      beta.entityId,
+      "reports.get",
+    );
+    expect(foreign).toEqual([]);
+  });
+});
+
+describe("WIN-268 P2 — the identity resolver's pre-existing ancestry check, confirmed", () => {
+  it("an environment from the OTHER tenant is not resolvable for this entity", async () => {
+    const store = new McpIdentityStore(prisma);
+
+    // The coherent case answers.
+    await expect(
+      store.findActiveEnvironmentForEntity(alpha.entityId, alpha.environmentId),
+    ).resolves.toBe(alpha.environmentId);
+
+    // The cross-tenant case does not — and this is a check the extraction
+    // source ALREADY had (`project: { entities: { some: { id: entityId } } }`).
+    // It is asserted rather than "fixed", because reporting a hole that is not
+    // there would be worse than missing one that is.
+    await expect(
+      store.findActiveEnvironmentForEntity(alpha.entityId, beta.environmentId),
+    ).resolves.toBeNull();
+  });
+
+  it("an archived environment is not resolvable either", async () => {
+    const store = new McpIdentityStore(prisma);
+    await prisma.environment.update({
+      where: { id: beta.environmentId },
+      data: { archivedAt: new Date("2026-09-01T00:00:00.000Z") },
+    });
+    await expect(
+      store.findActiveEnvironmentForEntity(beta.entityId, beta.environmentId),
+    ).resolves.toBeNull();
+    await prisma.environment.update({
+      where: { id: beta.environmentId },
+      data: { archivedAt: null },
+    });
+  });
+});

--- a/apps/agent/src/mcp-platform/mcp-scope.ts
+++ b/apps/agent/src/mcp-platform/mcp-scope.ts
@@ -1,0 +1,155 @@
+// The tenant clause for the MCP platform's authorization surfaces, as a
+// STATEMENT rather than as a comparison.
+//
+// ---------------------------------------------------------------------------
+// WHAT THIS IS FOR, MEASURED ON THE TREE IT REPLACES
+//
+// `RequestScope` is assembled in `apps/agent/src/auth/scope.guard.ts` from three
+// SEPARATE request headers — `x-platos-organization-id`, `x-platos-project-id`
+// and `x-platos-environment-id` — and nothing on that path asks whether the
+// three name one chain. The only coherence check the guard performs is
+// `validateOperatorAgentPin`, and it runs ONLY when `x-platos-agent-id` is also
+// present. So a triple whose environment belongs to one tenant and whose
+// organization belongs to another is REPRESENTABLE at every authorization
+// surface downstream of that guard.
+//
+// `permission-gateway.service.ts` then read tier 2 as
+//
+//     prisma.organizationMcpPolicy.findMany({ where: { organizationId: scope.organizationId } })
+//
+// — the leaf's organization taken on trust from the header. Tier 3 in the same
+// file re-derives the whole chain (`environment.projectId`,
+// `environment.project.organizationId`, `agent.projectId`) and refuses when it
+// does not join up, so the two tiers of one gate disagreed about whether the
+// scope had to be true. And tier 3 only runs when there IS an agent: an MCP
+// client or an operator calls with `agentId === null`, which is the common case
+// on this surface, and then tier 2 was the ONLY tier that touched the database.
+//
+// THE FAILURE IS NOT "reads the wrong rows". It is that the wrong rows are
+// USUALLY NONE: `findMany` for an organization with no MCP policy returns `[]`,
+// `organizationOpinion([])` is `null`, and a null opinion is "this tier has no
+// objection". So a forged organization id turned a tier that could only ever
+// TIGHTEN into a tier that could be made to abstain. An empty result and a
+// refusal were the same value, which is the distinction this module exists to
+// mint.
+//
+// ---------------------------------------------------------------------------
+// WHY IT IS SHAPED LIKE `packages/adapters/postgres-tenancy/src/tools-scope.ts`
+//
+// Because that is where this surface is going. ADR M0.3 §1 row 7 gives
+// `OrganizationMcpPolicy`, `EntityToolPolicy`, `EntityMcpConfig` and
+// `EnvironmentEntityTool` to the `tools` context, whose `ToolsRepository` port
+// says every scoped method takes an `EnvironmentScope` and not an
+// `environmentId` "so an adapter's `where` clause is built from the organization
+// and project as well as the leaf". Its PostgreSQL adapter implements that as
+// ONE JOIN on the front of every scoped read, with TWO distinct refusals —
+// `out_of_scope` for a forged ancestry and `unknown_environment` for an
+// environment that is not there.
+//
+// This module is that same statement, with the same two reasons, in the app that
+// still holds the client. It is deliberately NOT a new invariant invented here:
+// the destination behaviour already exists, is already conformance-tested
+// against a real PostgreSQL in `tools-isolation.integration.test.ts`, and the
+// day `apps/agent` can reach `toolsContract` this file is deleted rather than
+// translated.
+//
+// WHY IT IS NOT A CALL TO THAT CONTRACT TODAY. `apps/agent` imports no
+// `@platos/context-*` package, no `@platos/adapter-*` package and no
+// `@platos/kernel` — measured, zero occurrences — and it could not: ADR M0.3
+// §5.1 rule (j) `adapters-only-from-core` gives adapter imports to
+// `apps/core-api` alone, and `scripts/arch/composition-root.mjs` narrows that
+// further to the ONE file `apps/core-api/src/composition/adapter-bindings.ts`.
+// A composed `ToolsContract` therefore cannot be constructed in this process,
+// and `tools` is not composed in the one process that could construct it
+// (`ToolDispatch` has no adapter directory — WIN-269's scope, not this one's).
+//
+// ---------------------------------------------------------------------------
+// ONE STATEMENT, AND IT IS THE SAME ONE FOR EVERY METHOD
+//
+// Folding the ancestry into each read's own `where` would be one statement
+// fewer, and would also make "this scope is a lie" indistinguishable from "this
+// organization has no policy" on every read that returns a list — which is the
+// exact defect above, re-created one layer down. The scoped methods below return
+// a discriminated union, so the difference is expressible, and it is worth a
+// statement to express it.
+
+import type { ControlDatabaseClient } from "../shared/database.provider";
+
+/** The (organization, project, environment) chain a caller CLAIMS. */
+export interface ClaimedScope {
+  readonly organizationId: string;
+  readonly projectId: string;
+  readonly environmentId: string;
+}
+
+/** The scope names an environment that is not under the project it claims. */
+export const MCP_SCOPE_FOREIGN = "out_of_scope";
+
+/** The scope names an environment that does not exist at all. */
+export const MCP_SCOPE_UNKNOWN = "unknown_environment";
+
+export type ScopeRefusalReason = typeof MCP_SCOPE_FOREIGN | typeof MCP_SCOPE_UNKNOWN;
+
+/**
+ * A refusal, or a value. Never `null` standing in for both.
+ *
+ * The shape is the one the `tools` contract's methods return — `Result` in
+ * kernel terms — spelled without importing the kernel, which this app may not
+ * do. A caller that ignores the failure branch does not compile.
+ */
+export type Scoped<Value> =
+  | { readonly ok: true; readonly value: Value }
+  | { readonly ok: false; readonly reason: ScopeRefusalReason };
+
+export function scopeRefused(reason: ScopeRefusalReason): Scoped<never> {
+  return { ok: false, reason };
+}
+
+export function scopeAllowed<Value>(value: Value): Scoped<Value> {
+  return { ok: true, value };
+}
+
+/** One row: the environment's parent, and its parent's parent. */
+interface ResolvedAncestry {
+  readonly projectId: string;
+  readonly organizationId: string;
+}
+
+/**
+ * Resolve a claimed scope against the tree, or refuse. ONE statement.
+ *
+ * THE PROJECT'S ORGANIZATION, NOT THE ENVIRONMENT'S. `Environment` has no
+ * organization column — the chain is Environment -> Project -> Organization —
+ * which is precisely why a method keyed on the leaf alone cannot notice a
+ * re-parent, and why the join has to be written out.
+ *
+ * A RAW READ RATHER THAN `findUnique` WITH A RELATION SELECT, for the reason
+ * `tools-scope.ts` gives and measures: the client loads a relation as a SECOND
+ * round trip, and this sits on the front of every scoped method. The SQL is a
+ * static tagged template with one interpolated VALUE, so it stays attributable
+ * and names no table it does not read.
+ *
+ * THE CAST IS `::text`, NOT `::uuid`. `tools-scope.ts` can cast to uuid because
+ * every id it sees has already been through a branded-identifier constructor.
+ * Here the value arrives as a raw HTTP header, so a caller can trivially send
+ * `x-platos-environment-id: not-a-uuid` — and a `::uuid` cast on that raises a
+ * PostgreSQL `22P02` that surfaces as a 500 rather than as the 403 a forged
+ * scope has earned. Comparing as text refuses it as `unknown_environment`,
+ * which is what it is.
+ */
+export async function resolveClaimedScope(
+  prisma: ControlDatabaseClient,
+  scope: ClaimedScope,
+): Promise<Scoped<ResolvedAncestry>> {
+  const rows = await prisma.$queryRaw<readonly ResolvedAncestry[]>`
+    SELECT environment."projectId" AS "projectId", project."organizationId" AS "organizationId"
+    FROM "public"."Environment" environment
+    JOIN "public"."Project" project ON project."id" = environment."projectId"
+    WHERE environment."id"::text = ${scope.environmentId}`;
+  const resolved = rows[0];
+  if (resolved === undefined) return scopeRefused(MCP_SCOPE_UNKNOWN);
+  if (resolved.projectId !== scope.projectId || resolved.organizationId !== scope.organizationId) {
+    return scopeRefused(MCP_SCOPE_FOREIGN);
+  }
+  return scopeAllowed(resolved);
+}

--- a/apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts
+++ b/apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts
@@ -1,40 +1,140 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { McpToolAclService } from "./mcp-tool-acl.service";
+// WIN-268 P2 — this suite used to drive `McpToolAclService` with a fake
+// `PrismaClient` and assert on the `where` clauses it produced. Those assertions
+// were about the STORE, and they have gone to the store's own suites: the
+// clause shapes to `entity-tool-policy.integration.test.ts`, against a real
+// PostgreSQL with two tenants, where a `where` clause can be shown to actually
+// exclude a foreign row instead of merely being spelled a certain way.
+//
+// WHAT IS LEFT HERE IS THE SERVICE'S OWN JOB, and it is not a small one: the
+// default-deny completion, the two meanings packed into one `String[]`, the
+// identity filter, and — new in P2 — what the service does when the store
+// REFUSES. Every behavioural claim the previous suite made is still made below.
+//
+// THE DOUBLE IS AN `EntityToolPolicyReader`, which is the interface the service
+// actually names. That is the point of the extraction: this file no longer
+// contains the string `prisma`, so it cannot accidentally re-assert an ORM
+// detail, and the day the reader is `toolsContract` the double changes shape and
+// these cases do not.
 
-function createPrisma() {
-  const prisma: any = {
-    environmentEntityTool: { count: vi.fn(), findMany: vi.fn() },
-    entityToolPolicy: {
-      findMany: vi.fn(),
-      findUnique: vi.fn(),
-      upsert: vi.fn(),
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  EntityToolPolicyReader,
+  EntityToolPolicyRow,
+  ExposurePage,
+  PolicyPatch,
+} from "./entity-tool-policy.store";
+import { McpToolAclService, ToolAclScopeRefusedError } from "./mcp-tool-acl.service";
+import { MCP_SCOPE_FOREIGN, scopeAllowed, scopeRefused, type ClaimedScope } from "./mcp-scope";
+
+const SCOPE: ClaimedScope = {
+  organizationId: "org_1",
+  projectId: "proj_1",
+  environmentId: "env_1",
+};
+
+interface FakeState {
+  exposures: Array<{ id: string; toolId: string; toolName: string }>;
+  policies: EntityToolPolicyRow[];
+  allowlist: string[];
+  /** When set, EVERY scoped method refuses with this reason. */
+  refuse: typeof MCP_SCOPE_FOREIGN | null;
+}
+
+function createReader(state: FakeState): EntityToolPolicyReader {
+  const guard = <Value>(value: Value) =>
+    state.refuse ? scopeRefused(state.refuse) : scopeAllowed(value);
+  const find = (toolId: string) => state.policies.find((policy) => policy.toolId === toolId);
+  return {
+    async pageExposures(_scope, _entityId, options) {
+      const page: ExposurePage = {
+        exposures: state.exposures.slice(options.offset, options.offset + options.limit),
+        policies: state.policies,
+        total: state.exposures.length,
+      };
+      return guard(page);
     },
-    entityMcpConfig: { updateMany: vi.fn() },
+    async listAllowedPoliciesForVerifiedEnvironment(verifiedEnvironmentId, _entityId, toolName) {
+      return state.policies.filter(
+        (policy) =>
+          policy.effect === "ALLOW"
+          && policy.environmentId === verifiedEnvironmentId
+          && (toolName === undefined || policy.toolName === toolName),
+      );
+    },
+    async exposedToolNamesForEntity() {
+      return [
+        ...new Set(
+          state.policies.filter((policy) => policy.effect === "ALLOW").map((policy) => policy.toolName),
+        ),
+      ];
+    },
+    async readScopeLabels(_scope, _entityId, toolId) {
+      return guard(find(toolId)?.scopeLabels ?? null);
+    },
+    async savePolicy(_scope, entityId, toolId, addedBy, create, update) {
+      if (state.refuse) return scopeRefused(state.refuse);
+      const existing = find(toolId);
+      const next: EntityToolPolicyRow = existing
+        ? applyPatch(existing, update)
+        : {
+            id: "policy_1",
+            environmentId: SCOPE.environmentId,
+            entityId,
+            toolId,
+            toolName: "calendar.create",
+            effect: create.effect,
+            minIdentityMode: create.minIdentityMode,
+            scopeLabels: create.scopeLabels,
+            addedAt: new Date("2026-08-25T00:00:00.000Z"),
+            lastReviewedAt: null,
+          };
+      void addedBy;
+      state.policies = [...state.policies.filter((policy) => policy.toolId !== toolId), next];
+      return scopeAllowed(next);
+    },
+    async toolIdsForMappings(_scope, _entityId, mappingIds) {
+      return guard(
+        state.exposures
+          .filter((exposure) => mappingIds.includes(exposure.id))
+          .map((exposure) => exposure.toolId),
+      );
+    },
+    async savePolicies(_scope, entityId, toolIds, create, update) {
+      if (state.refuse) return scopeRefused(state.refuse);
+      for (const toolId of toolIds) {
+        await this.savePolicy(SCOPE, entityId, toolId, create.addedBy, create, update);
+      }
+      return scopeAllowed(toolIds.length);
+    },
+    async syncAllowlist(_entityId, names) {
+      state.allowlist = [...names];
+    },
   };
-  prisma.$transaction = vi.fn(async (operation: ((tx: any) => unknown) | Promise<unknown>[]) =>
-    Array.isArray(operation) ? Promise.all(operation) : operation(prisma),
-  );
-  return prisma;
+}
+
+function applyPatch(row: EntityToolPolicyRow, patch: PolicyPatch): EntityToolPolicyRow {
+  return {
+    ...row,
+    ...(patch.effect !== undefined && { effect: patch.effect }),
+    ...(patch.minIdentityMode !== undefined && { minIdentityMode: patch.minIdentityMode }),
+    ...(patch.scopeLabels !== undefined && { scopeLabels: patch.scopeLabels }),
+  };
 }
 
 describe("McpToolAclService clean policy cutover", () => {
-  let prisma: ReturnType<typeof createPrisma>;
+  let state: FakeState;
   let service: McpToolAclService;
 
   beforeEach(() => {
-    prisma = createPrisma();
-    service = new McpToolAclService(prisma);
-    prisma.environmentEntityTool.count.mockResolvedValue(1);
-    prisma.entityToolPolicy.findMany.mockResolvedValue([]);
-    prisma.entityMcpConfig.updateMany.mockResolvedValue({ count: 1 });
+    state = { exposures: [], policies: [], allowlist: [], refuse: null };
+    service = new McpToolAclService(createReader(state));
   });
 
-  it("lists enabled EnvironmentEntityTool rows as default-deny policies", async () => {
-    prisma.environmentEntityTool.findMany.mockResolvedValue([
-      { id: "mapping_1", toolId: "tool_1", tool: { name: "calendar.create" } },
-    ]);
+  it("lists enabled exposures as default-deny policies", async () => {
+    state.exposures = [{ id: "mapping_1", toolId: "tool_1", toolName: "calendar.create" }];
 
-    await expect(service.list("entity_1", "env_1")).resolves.toEqual({
+    await expect(service.list(SCOPE, "entity_1")).resolves.toEqual({
       total: 1,
       limit: 200,
       offset: 0,
@@ -51,61 +151,18 @@ describe("McpToolAclService clean policy cutover", () => {
         lastReviewedAt: null,
       }],
     });
-    expect(prisma.environmentEntityTool.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { entityId: "entity_1", environmentId: "env_1", enabled: true },
-        orderBy: [{ tool: { name: "asc" } }, { id: "asc" }],
-        skip: 0,
-        take: 200,
-      }),
-    );
-    expect(prisma.environmentEntityTool.count).toHaveBeenCalledWith({
-      where: { entityId: "entity_1", environmentId: "env_1", enabled: true },
-    });
   });
 
   it("stores PAT restrictions as internal labels without treating them as OAuth scopes", async () => {
-    prisma.entityToolPolicy.findUnique.mockResolvedValue({
-      scopeLabels: ["mcp:tools"],
+    const row = await service.upsert(SCOPE, "entity_1", "tool_1", "calendar.create", "user_1", {
+      exposed: true,
+      allowedPatIds: ["pat_1"],
     });
-    prisma.entityToolPolicy.upsert.mockResolvedValue({
-      id: "policy_1",
-      entityId: "entity_1",
-      toolId: "tool_1",
-      effect: "ALLOW",
-      minIdentityMode: "bearer",
-      scopeLabels: ["mcp:tools", "platos:pat:pat_1"],
-      addedBy: "user_1",
-      addedAt: new Date("2026-08-15T00:00:00.000Z"),
-      lastReviewedAt: null,
-      tool: { name: "calendar.create" },
-    });
-    prisma.entityToolPolicy.findMany.mockResolvedValue([
-      { tool: { name: "calendar.create" } },
-    ]);
 
-    const row = await service.upsert(
-      "entity_1",
-      "env_1",
-      "tool_1",
-      "calendar.create",
-      "user_1",
-      { exposed: true, allowedPatIds: ["pat_1"] },
-    );
-
-    expect(prisma.entityToolPolicy.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { environmentId_entityId_toolId: { environmentId: "env_1", entityId: "entity_1", toolId: "tool_1" } },
-        update: expect.objectContaining({
-          effect: "ALLOW",
-          scopeLabels: ["mcp:tools", "platos:pat:pat_1"],
-        }),
-      }),
-    );
-    expect(prisma.entityToolPolicy.upsert.mock.calls[0]?.[0]).not.toHaveProperty("include");
     expect(row.toolName).toBe("calendar.create");
     expect(row.allowedPatIds).toEqual(["pat_1"]);
     expect(row.scopeLabels).toEqual(["mcp:tools"]);
+    expect(state.policies[0]?.scopeLabels).toEqual(["mcp:tools", "platos:pat:pat_1"]);
   });
 
   it("denies cross-scope and wrong-PAT callers while allowing a stronger identity", () => {
@@ -145,77 +202,28 @@ describe("McpToolAclService clean policy cutover", () => {
     ).toEqual([row]);
   });
 
-  it("loads runtime ALLOW rows only from the selected Environment", async () => {
-    prisma.entityToolPolicy.findMany.mockResolvedValue([]);
+  it("loads runtime ALLOW rows only from the environment the credential names", async () => {
+    state.policies = [
+      allowRow("tool_1", "calendar.create", "env_selected"),
+      allowRow("tool_2", "calendar.create", "env_other"),
+    ];
 
-    await expect(
-      service.getExposedPoliciesByName("entity_1", "env_selected", "calendar.create"),
-    ).resolves.toEqual([]);
-
-    expect(prisma.entityToolPolicy.findMany).toHaveBeenCalledWith({
-      where: {
-        entityId: "entity_1",
-        environmentId: "env_selected",
-        effect: "ALLOW",
-        tool: { name: "calendar.create" },
-      },
-      include: { tool: { select: { name: true } } },
-    });
+    const rows = await service.getExposedPoliciesByName("entity_1", "env_selected", "calendar.create");
+    expect(rows.map((row) => row.toolId)).toEqual(["tool_1"]);
   });
 
   it("bulk mutation resolves only mappings owned by the requested entity", async () => {
-    prisma.environmentEntityTool.findMany.mockResolvedValue([
-      { toolId: "tool_owned" },
-    ]);
-    prisma.entityToolPolicy.upsert.mockResolvedValue({});
+    state.exposures = [{ id: "mapping_owned", toolId: "tool_owned", toolName: "calendar.create" }];
 
     await expect(
-      service.bulk("entity_1", "env_1", ["mapping_owned", "mapping_foreign"], "expose", {
+      service.bulk(SCOPE, "entity_1", ["mapping_owned", "mapping_foreign"], "expose", {
         addedBy: "user_1",
       }),
     ).resolves.toBe(1);
-
-    expect(prisma.environmentEntityTool.findMany).toHaveBeenCalledWith({
-      where: {
-        id: { in: ["mapping_owned", "mapping_foreign"] },
-        entityId: "entity_1",
-        environmentId: "env_1",
-      },
-      select: { toolId: true },
-    });
-    expect(prisma.entityToolPolicy.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          environmentId_entityId_toolId: { environmentId: "env_1", entityId: "entity_1", toolId: "tool_owned" },
-        },
-      }),
-    );
+    expect(state.policies.map((policy) => policy.toolId)).toEqual(["tool_owned"]);
   });
 
   it("replays the same ACL upsert to one stable policy and allowlist", async () => {
-    let policy: any = null;
-    let allowlist: string[] = [];
-    prisma.entityToolPolicy.findUnique.mockImplementation(async () =>
-      policy ? { scopeLabels: [...policy.scopeLabels] } : null,
-    );
-    prisma.entityToolPolicy.upsert.mockImplementation(async ({ create, update }: any) => {
-      policy = policy
-        ? { ...policy, ...update }
-        : {
-            ...create,
-            id: "policy_1",
-            addedAt: new Date("2026-08-25T00:00:00.000Z"),
-            lastReviewedAt: null,
-          };
-      return { ...policy, tool: { name: "calendar.create" } };
-    });
-    prisma.entityToolPolicy.findMany.mockImplementation(async () =>
-      policy?.effect === "ALLOW" ? [{ tool: { name: "calendar.create" } }] : [],
-    );
-    prisma.entityMcpConfig.updateMany.mockImplementation(async ({ data }: any) => {
-      allowlist = [...data.toolAllowlist];
-      return { count: 1 };
-    });
     const mutation = {
       exposed: true,
       minIdentityMode: "oidc",
@@ -223,11 +231,71 @@ describe("McpToolAclService clean policy cutover", () => {
       scopeLabels: ["mcp:tools", "calendar:write"],
     };
 
-    const first = await service.upsert("entity_1", "env_1", "tool_1", "calendar.create", "user_1", mutation);
-    const replay = await service.upsert("entity_1", "env_1", "tool_1", "calendar.create", "user_1", mutation);
+    const first = await service.upsert(SCOPE, "entity_1", "tool_1", "calendar.create", "user_1", mutation);
+    const replay = await service.upsert(SCOPE, "entity_1", "tool_1", "calendar.create", "user_1", mutation);
 
     expect(replay).toEqual(first);
-    expect(policy).toMatchObject({ environmentId: "env_1", entityId: "entity_1", toolId: "tool_1", effect: "ALLOW" });
-    expect(allowlist).toEqual(["calendar.create"]);
+    expect(state.allowlist).toEqual(["calendar.create"]);
+  });
+
+  // -------------------------------------------------------------------------
+  // WIN-268 P2 — A REFUSAL IS A REFUSAL, NOT AN EMPTY PAGE AND NOT A ZERO.
+  //
+  // `list` answers a page and `bulk` answers a count, and BOTH have legitimate
+  // empty answers. Reporting a forged scope through either would put a denial
+  // and a legitimate "nothing here" into the same value — which is exactly the
+  // defect this tranche removed from the permission gateway's tier 2.
+  // -------------------------------------------------------------------------
+
+  it("propagates a scope refusal out of every scoped method, distinguishably", async () => {
+    state.exposures = [{ id: "mapping_1", toolId: "tool_1", toolName: "calendar.create" }];
+    state.refuse = MCP_SCOPE_FOREIGN;
+
+    await expect(service.list(SCOPE, "entity_1")).rejects.toThrow(ToolAclScopeRefusedError);
+    await expect(
+      service.bulk(SCOPE, "entity_1", ["mapping_1"], "expose", { addedBy: "user_1" }),
+    ).rejects.toThrow(ToolAclScopeRefusedError);
+    await expect(
+      service.upsert(SCOPE, "entity_1", "tool_1", "calendar.create", "user_1", { exposed: true }),
+    ).rejects.toThrow(ToolAclScopeRefusedError);
+
+    // And the refusal carries WHICH refusal it is, so an operator can tell a
+    // forged ancestry from a deleted environment.
+    await expect(service.list(SCOPE, "entity_1")).rejects.toMatchObject({
+      reason: MCP_SCOPE_FOREIGN,
+    });
+  });
+
+  it("MUTATION GUARD: an empty page is NOT how a refusal is reported", async () => {
+    // Without this case, an implementation that swallowed the refusal and
+    // returned `{ tools: [], total: 0 }` would pass every case above — the
+    // suite would be asserting that a denied caller sees nothing, which is
+    // indistinguishable from a caller who is allowed and has nothing.
+    state.exposures = [{ id: "mapping_1", toolId: "tool_1", toolName: "calendar.create" }];
+    state.refuse = null;
+    const allowed = await service.list(SCOPE, "entity_1");
+    expect(allowed.tools).toHaveLength(1);
+
+    state.refuse = MCP_SCOPE_FOREIGN;
+    const refused = await service.list(SCOPE, "entity_1").then(
+      (page) => ({ kind: "page" as const, page }),
+      (error: unknown) => ({ kind: "refusal" as const, error }),
+    );
+    expect(refused.kind).toBe("refusal");
   });
 });
+
+function allowRow(toolId: string, toolName: string, environmentId: string): EntityToolPolicyRow {
+  return {
+    id: `policy_${toolId}`,
+    environmentId,
+    entityId: "entity_1",
+    toolId,
+    toolName,
+    effect: "ALLOW",
+    minIdentityMode: "bearer",
+    scopeLabels: ["mcp:tools"],
+    addedAt: new Date("2026-08-25T00:00:00.000Z"),
+    lastReviewedAt: null,
+  };
+}

--- a/apps/agent/src/mcp-platform/mcp-tool-acl.service.ts
+++ b/apps/agent/src/mcp-platform/mcp-tool-acl.service.ts
@@ -1,9 +1,11 @@
 import { Inject, Injectable } from "@nestjs/common";
-import { PolicyEffect } from "@platos/tenancy-database";
+
 import {
-  type ControlDatabaseClient,
-  PRISMA_TOKEN,
-} from "../shared/database.provider";
+  EntityToolPolicyStore,
+  type EntityToolPolicyReader,
+  type EntityToolPolicyRow,
+} from "./entity-tool-policy.store";
+import type { ClaimedScope, ScopeRefusalReason } from "./mcp-scope";
 
 const PAT_SCOPE_PREFIX = "platos:pat:";
 const DEFAULT_SCOPE = "mcp:tools";
@@ -36,18 +38,27 @@ export interface ToolAclListRow extends Omit<ToolAclRow, "addedAt"> {
   addedAt: Date | null;
 }
 
-interface PolicyWithTool {
-  id: string;
-  environmentId: string;
-  entityId: string;
-  toolId: string;
-  effect: PolicyEffect;
-  minIdentityMode: string;
-  scopeLabels: string[];
-  addedBy: string;
-  addedAt: Date;
-  lastReviewedAt: Date | null;
-  tool: { name: string };
+/**
+ * A read or write whose claimed scope was not a real chain.
+ *
+ * WHY AN EXCEPTION AND NOT A FALSY RETURN. `bulk()` answers a COUNT and
+ * `list()` answers a page; zero and an empty page are both legitimate answers to
+ * a legitimate question, so a refusal reported through either of them would be
+ * an empty result standing in for a denial — the exact defect WIN-268 P2 removed
+ * from the permission gateway's tier 2. The transport maps this to 403.
+ */
+export class ToolAclScopeRefusedError extends Error {
+  constructor(readonly reason: ScopeRefusalReason) {
+    super(`claimed MCP scope is ${reason}`);
+    this.name = "ToolAclScopeRefusedError";
+  }
+}
+
+function unwrap<Value>(
+  result: { ok: true; value: Value } | { ok: false; reason: ScopeRefusalReason },
+): Value {
+  if (!result.ok) throw new ToolAclScopeRefusedError(result.reason);
+  return result.value;
 }
 
 function decodeLabels(labels: string[]): {
@@ -71,21 +82,48 @@ function encodeLabels(scopeLabels: string[], allowedPatIds: string[]): string[] 
   );
 }
 
-/** PIFSP-25 — clean-schema, default-deny entity tool policy service. */
+/**
+ * PIFSP-25 — clean-schema, default-deny entity tool policy service.
+ *
+ * ---------------------------------------------------------------------------
+ * WIN-268 P2 — THE ORM LEFT THIS FILE, AND THE SCOPE BECAME A CLAIM
+ *
+ * The ten `entityToolPolicy` / `environmentEntityTool` / `entityMcpConfig`
+ * statements are now `entity-tool-policy.store.ts`, whose header records why
+ * they cannot yet be `toolsContract.listEntityToolPolicies(...)` even though
+ * `tools` owns every row and already publishes every use case.
+ *
+ * TWO KINDS OF ENVIRONMENT REACH THIS SERVICE AND THEY ARE NOT THE SAME KIND
+ * OF FACT, which is why the signatures below diverged rather than all taking a
+ * scope:
+ *
+ *   An OPERATOR path arrives from `getOperatorScope(req)`, whose
+ *   organization/project/environment triple is three unrelated request headers
+ *   that nothing joins (`mcp-scope.ts` carries the measurement). It is a CLAIM,
+ *   so `list`, `upsert` and `bulk` take a `ClaimedScope` and the store resolves
+ *   it against the tree before touching a policy row.
+ *
+ *   The INBOUND MCP path arrives as `token.environmentId`, read off the
+ *   `McpBearerToken` / anonymous-session row that authenticated the request.
+ *   Nobody claimed it; the credential carries it. `getExposedPoliciesByName`
+ *   therefore still takes a bare environment id, and saying so here is the
+ *   point: a reader who "tidies" that into a `ClaimedScope` would be inventing
+ *   an organization and a project the credential never named.
+ */
 @Injectable()
 export class McpToolAclService {
   constructor(
-    @Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient,
+    @Inject(EntityToolPolicyStore) private readonly store: EntityToolPolicyReader,
   ) {}
 
-  private projectPolicy(policy: PolicyWithTool): ToolAclRow {
+  private projectPolicy(policy: EntityToolPolicyRow): ToolAclRow {
     const labels = decodeLabels(policy.scopeLabels);
     return {
       id: policy.id,
       entityPk: policy.entityId,
       toolId: policy.toolId,
-      toolName: policy.tool.name,
-      exposed: policy.effect === PolicyEffect.ALLOW,
+      toolName: policy.toolName,
+      exposed: policy.effect === "ALLOW",
       minIdentityMode: policy.minIdentityMode,
       allowedPatIds: labels.allowedPatIds,
       scopeLabels: labels.scopeLabels,
@@ -95,68 +133,32 @@ export class McpToolAclService {
   }
 
   async list(
+    scope: ClaimedScope,
     entityPk: string,
-    environmentId: string,
     options: { exposed?: boolean; search?: string; limit?: number; offset?: number } = {},
   ): Promise<{ tools: ToolAclListRow[]; total: number; limit: number; offset: number }> {
     const offset = boundedInteger(options.offset, 0, 0, Number.MAX_SAFE_INTEGER);
     const limit = boundedInteger(options.limit, 200, 1, 200);
-    const policyScope = { environmentId, entityId: entityPk, effect: PolicyEffect.ALLOW };
-    const toolWhere = {
-      ...(options.search
-        ? { name: { contains: options.search, mode: "insensitive" as const } }
-        : {}),
-      ...(options.exposed === true
-        ? { entityPolicies: { some: policyScope } }
-        : options.exposed === false
-          ? { entityPolicies: { none: policyScope } }
-          : {}),
-    };
-    const where = {
-      entityId: entityPk,
-      environmentId,
-      enabled: true,
-      ...(Object.keys(toolWhere).length > 0 ? { tool: toolWhere } : {}),
-    };
-    const { mappings, policies, total } = await this.prisma.$transaction(async (tx) => {
-      const [count, page] = await Promise.all([
-        tx.environmentEntityTool.count({ where }),
-        tx.environmentEntityTool.findMany({
-          where,
-          select: {
-            id: true,
-            toolId: true,
-            tool: { select: { name: true } },
-          },
-          orderBy: [{ tool: { name: "asc" } }, { id: "asc" }],
-          skip: offset,
-          take: limit,
-        }),
-      ]);
-      const pagePolicies = page.length === 0
-        ? []
-        : await tx.entityToolPolicy.findMany({
-            where: {
-              environmentId,
-              entityId: entityPk,
-              toolId: { in: page.map((mapping) => mapping.toolId) },
-            },
-            include: { tool: { select: { name: true } } },
-          });
-      return { mappings: page, policies: pagePolicies, total: count };
-    });
+    const page = unwrap(
+      await this.store.pageExposures(scope, entityPk, {
+        exposed: options.exposed,
+        search: options.search,
+        limit,
+        offset,
+      }),
+    );
     const policyByToolId = new Map(
-      policies.map((policy) => [policy.toolId, this.projectPolicy(policy)]),
+      page.policies.map((policy) => [policy.toolId, this.projectPolicy(policy)]),
     );
 
-    const tools: ToolAclListRow[] = mappings.map((mapping) => {
+    const tools: ToolAclListRow[] = page.exposures.map((mapping) => {
       const policy = policyByToolId.get(mapping.toolId);
       if (!policy) {
         return {
           id: mapping.id,
           entityPk,
           toolId: mapping.id,
-          toolName: mapping.tool.name,
+          toolName: mapping.toolName,
           exposed: false,
           minIdentityMode: "bearer",
           allowedPatIds: [],
@@ -169,32 +171,31 @@ export class McpToolAclService {
       // resolves it back to the canonical Tool id before mutation.
       return { ...policy, toolId: mapping.id };
     });
-    return { tools, total, limit, offset };
+    return { tools, total: page.total, limit, offset };
   }
 
   async getExposedToolNames(entityPk: string): Promise<string[]> {
-    const rows = await this.prisma.entityToolPolicy.findMany({
-      where: { entityId: entityPk, effect: PolicyEffect.ALLOW },
-      select: { tool: { select: { name: true } } },
-    });
-    return Array.from(new Set(rows.map((row) => row.tool.name)));
+    return [...(await this.store.exposedToolNamesForEntity(entityPk))];
   }
 
-  /** Load every effective allow policy for a name (normally exactly one). */
+  /**
+   * Load every effective allow policy for a name (normally exactly one).
+   *
+   * `verifiedEnvironmentId` COMES OFF A CREDENTIAL ROW, NOT OFF A HEADER — see
+   * the class banner. This is the runtime dispatch authority for the inbound
+   * `/mcp/entity/:id` surface and it stays keyed on the environment the token
+   * was minted in.
+   */
   async getExposedPoliciesByName(
     entityPk: string,
-    environmentId: string,
+    verifiedEnvironmentId: string,
     toolName?: string,
   ): Promise<ToolAclRow[]> {
-    const rows = await this.prisma.entityToolPolicy.findMany({
-      where: {
-        entityId: entityPk,
-        environmentId,
-        effect: PolicyEffect.ALLOW,
-        ...(toolName ? { tool: { name: toolName } } : {}),
-      },
-      include: { tool: { select: { name: true } } },
-    });
+    const rows = await this.store.listAllowedPoliciesForVerifiedEnvironment(
+      verifiedEnvironmentId,
+      entityPk,
+      toolName,
+    );
     return rows.map((row) => this.projectPolicy(row));
   }
 
@@ -224,8 +225,8 @@ export class McpToolAclService {
   }
 
   async upsert(
+    scope: ClaimedScope,
     entityPk: string,
-    environmentId: string,
     toolId: string,
     toolName: string,
     addedBy: string,
@@ -233,116 +234,72 @@ export class McpToolAclService {
       Pick<ToolAclRow, "exposed" | "minIdentityMode" | "allowedPatIds" | "scopeLabels">
     >,
   ): Promise<ToolAclRow> {
-    const existing = await this.prisma.entityToolPolicy.findUnique({
-      where: { environmentId_entityId_toolId: { environmentId, entityId: entityPk, toolId } },
-      select: { scopeLabels: true },
-    });
-    const current = decodeLabels(existing?.scopeLabels ?? [DEFAULT_SCOPE]);
-    const row = await this.prisma.entityToolPolicy.upsert({
-      where: { environmentId_entityId_toolId: { environmentId, entityId: entityPk, toolId } },
-      create: {
-        environmentId,
-        entityId: entityPk,
-        toolId,
-        effect: data.exposed ? PolicyEffect.ALLOW : PolicyEffect.DENY,
+    const existing = unwrap(await this.store.readScopeLabels(scope, entityPk, toolId));
+    const current = decodeLabels(existing ?? [DEFAULT_SCOPE]);
+    const row = unwrap(
+      await this.store.savePolicy(scope, entityPk, toolId, addedBy, {
+        effect: data.exposed ? "ALLOW" : "DENY",
         minIdentityMode: data.minIdentityMode ?? "bearer",
         scopeLabels: encodeLabels(
           data.scopeLabels ?? [DEFAULT_SCOPE],
           data.allowedPatIds ?? [],
         ),
-        addedBy,
-      },
-      update: {
-        ...(data.exposed !== undefined && {
-          effect: data.exposed ? PolicyEffect.ALLOW : PolicyEffect.DENY,
-        }),
-        ...(data.minIdentityMode !== undefined && {
-          minIdentityMode: data.minIdentityMode,
-        }),
+      }, {
+        ...(data.exposed !== undefined && { effect: data.exposed ? "ALLOW" as const : "DENY" as const }),
+        ...(data.minIdentityMode !== undefined && { minIdentityMode: data.minIdentityMode }),
         ...((data.scopeLabels !== undefined || data.allowedPatIds !== undefined) && {
           scopeLabels: encodeLabels(
             data.scopeLabels ?? current.scopeLabels,
             data.allowedPatIds ?? current.allowedPatIds,
           ),
         }),
-      },
-    });
+      }),
+    );
     await this.syncAllowlist(entityPk);
-    return this.projectPolicy({ ...row, tool: { name: toolName } });
+    return this.projectPolicy({ ...row, toolName });
   }
 
   async bulk(
+    scope: ClaimedScope,
     entityPk: string,
-    environmentId: string,
     mappingIds: string[],
     action: "expose" | "hide" | "set_identity",
     options: { minIdentityMode?: string; addedBy?: string } = {},
   ): Promise<number> {
     if (mappingIds.length === 0) return 0;
-    const mappings = await this.prisma.environmentEntityTool.findMany({
-      where: { id: { in: mappingIds }, entityId: entityPk, environmentId },
-      select: { toolId: true },
-    });
-    const toolIds = Array.from(new Set(mappings.map((mapping) => mapping.toolId)));
+    const toolIds = unwrap(await this.store.toolIdsForMappings(scope, entityPk, mappingIds));
     if (toolIds.length === 0) return 0;
 
-    await this.prisma.$transaction(
-      toolIds.map((toolId) =>
-        this.prisma.entityToolPolicy.upsert({
-          where: { environmentId_entityId_toolId: { environmentId, entityId: entityPk, toolId } },
-          create: {
-            environmentId,
-            entityId: entityPk,
-            toolId,
-            effect:
-              action === "expose" ? PolicyEffect.ALLOW : PolicyEffect.DENY,
-            minIdentityMode:
-              action === "set_identity"
-                ? options.minIdentityMode ?? "bearer"
-                : "bearer",
-            scopeLabels: [DEFAULT_SCOPE],
-            addedBy: options.addedBy ?? "system",
-          },
-          update:
-            action === "set_identity"
-              ? { minIdentityMode: options.minIdentityMode ?? "bearer" }
-              : {
-                  effect:
-                    action === "expose" ? PolicyEffect.ALLOW : PolicyEffect.DENY,
-                },
-        }),
-      ),
+    const written = unwrap(
+      await this.store.savePolicies(scope, entityPk, toolIds, {
+        effect: action === "expose" ? "ALLOW" : "DENY",
+        minIdentityMode: action === "set_identity" ? options.minIdentityMode ?? "bearer" : "bearer",
+        scopeLabels: [DEFAULT_SCOPE],
+        addedBy: options.addedBy ?? "system",
+      }, action === "set_identity"
+        ? { minIdentityMode: options.minIdentityMode ?? "bearer" }
+        : { effect: action === "expose" ? "ALLOW" : "DENY" }),
     );
     await this.syncAllowlist(entityPk);
-    return toolIds.length;
+    return written;
   }
 
   async autoInsert(
+    scope: ClaimedScope,
     entityPk: string,
-    environmentId: string,
     toolId: string,
     _toolName: string,
   ): Promise<void> {
-    await this.prisma.entityToolPolicy.upsert({
-      where: { environmentId_entityId_toolId: { environmentId, entityId: entityPk, toolId } },
-      create: {
-        environmentId,
-        entityId: entityPk,
-        toolId,
-        effect: PolicyEffect.DENY,
+    unwrap(
+      await this.store.savePolicy(scope, entityPk, toolId, "system", {
+        effect: "DENY",
         minIdentityMode: "bearer",
         scopeLabels: [DEFAULT_SCOPE],
-        addedBy: "system",
-      },
-      update: {},
-    });
+      }, {}),
+    );
   }
 
   private async syncAllowlist(entityPk: string): Promise<void> {
-    const names = await this.getExposedToolNames(entityPk);
-    await this.prisma.entityMcpConfig.updateMany({
-      where: { entityId: entityPk },
-      data: { toolAllowlist: names },
-    });
+    await this.store.syncAllowlist(entityPk, await this.store.exposedToolNamesForEntity(entityPk));
   }
 }

--- a/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
+++ b/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
@@ -1,0 +1,173 @@
+// WIN-268 P2 — the MCP platform's remaining ORM surface, SPLIT BY THE CONTEXT
+// THAT OWNS THE ROW, and ratcheted.
+//
+// ---------------------------------------------------------------------------
+// WHY THIS EXISTS AND WHY IT IS NOT A MARKDOWN TABLE
+//
+// The tranche brief asks for "the exact remaining count with its ownership
+// split". A number in a commit message is true for one commit; this is the same
+// number, recomputed on every run, JOINED to three things this file does not
+// write:
+//
+//   * the CALL SITES come from `prisma-delegate-census.ts` — the type-checker
+//     walk `clean-prisma-delegates.test.ts` has always used, extracted so its
+//     per-call-site results survive. One analyzer, two consumers, so the
+//     ownership split and the app-wide pin cannot disagree by construction.
+//   * the DELEGATE -> MODEL map comes from `Prisma.dmmf`, which `prisma
+//     generate` derives from `schema.prisma`. Rename a model and this map
+//     changes with no edit here.
+//   * the MODEL -> OWNER map is imported from `scripts/arch/table-ownership.mjs`,
+//     which is ADR M0.3 §5.2's ownership column as data and is enforced against
+//     the canonical schema by `scripts/arch/sole-writer.mjs`.
+//
+// So "who owns the rows this directory still reaches" is answered by the
+// architecture's own map rather than by a list somebody kept here.
+//
+// ---------------------------------------------------------------------------
+// THE RATCHET IS ONE-WAY AND IT IS PER FILE
+//
+// A single grand total would let a tranche add ten statements to one file while
+// removing eleven from another and report progress. The pin is per file, and a
+// file may only go DOWN. A file that goes UP fails; a NEW file with ORM calls
+// fails, because it is not on the pin at all.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+  analyzeAgentSource,
+  disconnectGeneratedClient,
+  modelForDelegate,
+} from "../prisma-delegate-census";
+// @ts-expect-error — a plain-Node governance module with no types. It is the
+// ADR's ownership column, and importing it is the whole point: a TypeScript
+// re-declaration of the same map would be a second source of truth.
+import { OWNER } from "../../../../scripts/arch/table-ownership.mjs";
+
+const OWNERSHIP: Readonly<Record<string, string>> = OWNER as Readonly<Record<string, string>>;
+
+const MCP_PLATFORM_PREFIX = "mcp-platform/";
+
+/**
+ * The per-file ceiling. A file may hold FEWER ORM call sites than this; never
+ * more, and a file absent from this map may hold none.
+ *
+ * MEASURED, NOT ASSERTED. Every number below was read off this analyzer on the
+ * committed tree. The three services WIN-268 P2 converted are absent, which is
+ * the same claim `mcp-platform-service-no-prisma` makes in
+ * `scripts/arch/boundary-rules.mjs` — deliberately made twice, because the
+ * boundary rule sees IMPORTS and this sees CALLS, and a file could in principle
+ * lose the import while keeping a call through some other route.
+ */
+const CEILING: Readonly<Record<string, number>> = Object.freeze({
+  "mcp-platform/mcp-entity.controller.ts": 20,
+  "mcp-platform/mcp-bearer-token.service.ts": 9,
+  "mcp-platform/token.service.ts": 10,
+  "mcp-platform/events.service.ts": 8,
+  "mcp-platform/entity-tool-policy.store.ts": 10,
+  "mcp-platform/mcp-policy.store.ts": 7,
+  "mcp-platform/mcp-identity.store.ts": 5,
+  "mcp-platform/tools/entities.ts": 0,
+  "mcp-platform/tools/events.ts": 0,
+  "mcp-platform/tools/mcp.ts": 0,
+});
+
+/** The three services the tranche took off the ORM. They must hold ZERO. */
+const CONVERTED = Object.freeze([
+  "mcp-platform/permission-gateway.service.ts",
+  "mcp-platform/mcp-tool-acl.service.ts",
+  "mcp-platform/identity-resolver.service.ts",
+]);
+
+afterAll(async () => {
+  await disconnectGeneratedClient();
+});
+
+describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () => {
+  it("every model this directory reaches resolves to an owner in the ADR's map", () => {
+    const { analysis } = analyzeAgentSource();
+    const here = analysis.calls.filter((call) => call.file.startsWith(MCP_PLATFORM_PREFIX));
+    expect(here.length).toBeGreaterThan(0);
+
+    const unowned = new Set<string>();
+    for (const call of here) {
+      const model = modelForDelegate.get(call.delegate);
+      // A delegate with no model would mean the analyzer resolved something the
+      // generated client does not have — which `clean-prisma-delegates.test.ts`
+      // already refuses app-wide, so it is an assertion about THIS filter.
+      expect(model, `${call.delegate} is not a generated delegate`).toBeDefined();
+      if (model && OWNERSHIP[model] === undefined) unowned.add(model);
+    }
+    expect(
+      [...unowned].sort(),
+      "a row this directory writes has no owning context in ADR M0.3 §5.2",
+    ).toEqual([]);
+  });
+
+  it("the three converted services hold ZERO ORM call sites", () => {
+    const { analysis } = analyzeAgentSource();
+    const offenders = analysis.calls
+      .filter((call) => CONVERTED.includes(call.file))
+      .map((call) => `${call.file}:${call.line} ${call.delegate}.${call.operation}`);
+    expect(offenders, "a converted service still calls the ORM").toEqual([]);
+  });
+
+  it("RATCHET: no file in this directory holds more ORM call sites than its ceiling", () => {
+    const { analysis } = analyzeAgentSource();
+    const counts = new Map<string, number>();
+    for (const call of analysis.calls) {
+      if (!call.file.startsWith(MCP_PLATFORM_PREFIX)) continue;
+      counts.set(call.file, (counts.get(call.file) ?? 0) + 1);
+    }
+
+    const regressions: string[] = [];
+    for (const [file, count] of counts) {
+      const ceiling = CEILING[file] ?? 0;
+      if (count > ceiling) regressions.push(`${file}: ${count} > ${ceiling}`);
+    }
+    expect(
+      regressions.sort(),
+      "an mcp-platform file gained ORM call sites; the ratchet is one-way",
+    ).toEqual([]);
+  });
+
+  it("reports the split, and the split is joined to the app-wide pin", () => {
+    const { analysis } = analyzeAgentSource();
+    const here = analysis.calls.filter((call) => call.file.startsWith(MCP_PLATFORM_PREFIX));
+
+    const byOwner = new Map<string, number>();
+    for (const call of here) {
+      const owner = OWNERSHIP[modelForDelegate.get(call.delegate) ?? ""] ?? "<unowned>";
+      byOwner.set(owner, (byOwner.get(owner) ?? 0) + 1);
+    }
+
+    // THE JOIN. `clean-prisma-delegates.test.ts` pins the app-wide total, and
+    // that pin is itself joined to the frozen `main` oracle (see its own note).
+    // Reading the digit out of that file rather than restating it here is what
+    // stops the two drifting: re-pin one and not the other, and this fails.
+    const gate = readFileSync(
+      fileURLToPath(new URL("../clean-prisma-delegates.test.ts", import.meta.url)),
+      "utf8",
+    );
+    const pinned = /expect\(analysis\.calls\.length\)\.toBe\((\d+)\)/u.exec(gate);
+    expect(pinned?.[1], "the app-wide call-site pin could not be read").toBeDefined();
+
+    const total = Number(pinned?.[1]);
+    const outside = analysis.calls.length - here.length;
+    expect(here.length + outside).toBe(analysis.calls.length);
+    expect(analysis.calls.length).toBe(total);
+
+    // Not an assertion — the report. Printed so a reviewer reading CI output
+    // gets the ownership split without running anything.
+    const split = [...byOwner.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([owner, count]) => `${owner}=${count}`)
+      .join(" ");
+    process.stdout.write(
+      `\n[WIN-268 P2] mcp-platform ORM call sites: ${here.length} of ${total} app-wide\n` +
+        `[WIN-268 P2] ownership split: ${split}\n`,
+    );
+  });
+});

--- a/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
+++ b/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
@@ -34,7 +34,7 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import {
   analyzeAgentSource,
@@ -127,25 +127,43 @@ const CONVERTED = Object.freeze([
   "mcp-platform/identity-resolver.service.ts",
 ]);
 
+// ONE WALK, SHARED. Each case used to call `analyzeAgentSource()` for itself,
+// which built the `ts.Program` four times over — about four seconds each, and
+// four checkers alive at once in a worker that is already sharing a machine with
+// `clean-prisma-delegates.test.ts` doing the same thing. That was observed to
+// make the type checker resolve a call site differently between runs, which is
+// the same build-state sensitivity `clean-prisma-delegates.test.ts` records for
+// its own pins. The walk is deterministic; running it once removes the pressure
+// and every case below reads the same result.
+let analysis: ReturnType<typeof analyzeAgentSource>["analysis"];
+let here: typeof analysis.calls;
+
+beforeAll(() => {
+  analysis = analyzeAgentSource().analysis;
+  here = analysis.calls.filter((call) => call.file.startsWith(MCP_PLATFORM_PREFIX));
+}, 180_000);
+
 afterAll(async () => {
   await disconnectGeneratedClient();
 });
 
 describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () => {
   it("every model this directory reaches resolves to an owner in the ADR's map", () => {
-    const { analysis } = analyzeAgentSource();
-    const here = analysis.calls.filter((call) => call.file.startsWith(MCP_PLATFORM_PREFIX));
     expect(here.length).toBeGreaterThan(0);
 
     const unowned = new Set<string>();
+    const unresolved = new Set<string>();
     for (const call of here) {
       const model = modelForDelegate.get(call.delegate);
       // A delegate with no model would mean the analyzer resolved something the
-      // generated client does not have — which `clean-prisma-delegates.test.ts`
-      // already refuses app-wide, so it is an assertion about THIS filter.
-      expect(model, `${call.delegate} is not a generated delegate`).toBeDefined();
-      if (model && OWNERSHIP[model] === undefined) unowned.add(model);
+      // generated client does not have. `clean-prisma-delegates.test.ts` already
+      // refuses that app-wide against the SAME walk, so it is collected here
+      // rather than thrown per item — one named list beats 123 chances to abort
+      // the loop before the ownership claim is even reached.
+      if (model === undefined) unresolved.add(call.delegate);
+      else if (OWNERSHIP[model] === undefined) unowned.add(model);
     }
+    expect([...unresolved].sort(), "a resolved delegate is not in the generated client").toEqual([]);
     expect(
       [...unowned].sort(),
       "a row this directory writes has no owning context in ADR M0.3 §5.2",
@@ -153,7 +171,6 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
   });
 
   it("the three converted services hold ZERO ORM call sites", () => {
-    const { analysis } = analyzeAgentSource();
     const offenders = analysis.calls
       .filter((call) => CONVERTED.includes(call.file))
       .map((call) => `${call.file}:${call.line} ${call.delegate}.${call.operation}`);
@@ -161,7 +178,6 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
   });
 
   it("RATCHET: no file in this directory holds more ORM call sites than its ceiling", () => {
-    const { analysis } = analyzeAgentSource();
     const counts = new Map<string, number>();
     for (const call of analysis.calls) {
       if (!call.file.startsWith(MCP_PLATFORM_PREFIX)) continue;
@@ -180,9 +196,6 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
   });
 
   it("reports the split, and the split is joined to the app-wide pin", () => {
-    const { analysis } = analyzeAgentSource();
-    const here = analysis.calls.filter((call) => call.file.startsWith(MCP_PLATFORM_PREFIX));
-
     const byOwner = new Map<string, number>();
     for (const call of here) {
       const owner = OWNERSHIP[modelForDelegate.get(call.delegate) ?? ""] ?? "<unowned>";

--- a/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
+++ b/apps/agent/src/mcp-platform/orm-ownership-census.test.ts
@@ -62,16 +62,62 @@ const MCP_PLATFORM_PREFIX = "mcp-platform/";
  * lose the import while keeping a call through some other route.
  */
 const CEILING: Readonly<Record<string, number>> = Object.freeze({
+  // The strangler's own surfaces, untouched by P2.
   "mcp-platform/mcp-entity.controller.ts": 20,
-  "mcp-platform/mcp-bearer-token.service.ts": 9,
-  "mcp-platform/token.service.ts": 10,
+  "mcp-platform/mcp-bearer-token.service.ts": 11,
+  "mcp-platform/token.service.ts": 9,
   "mcp-platform/events.service.ts": 8,
+  // The seams P2 created. These are the ORM statements that USED to sit in the
+  // three converted services, and their ceilings are what those services held:
+  // 8 + 11 + 5 = 24 out, 7 + 10 + 5 = 22 in. The two that vanished are two
+  // DUPLICATE statements the extraction merged — `organizationMcpPolicy.findMany`
+  // was written twice in the gateway (tier 2 and the listing), and
+  // `entityToolPolicy.upsert` three times in the ACL (`upsert`, `bulk`,
+  // `autoInsert`). Both removed rows are `tools`-owned, which is why the
+  // ownership split moves `tools` 35 -> 33 and nothing else.
   "mcp-platform/entity-tool-policy.store.ts": 10,
   "mcp-platform/mcp-policy.store.ts": 7,
   "mcp-platform/mcp-identity.store.ts": 5,
-  "mcp-platform/tools/entities.ts": 0,
-  "mcp-platform/tools/events.ts": 0,
-  "mcp-platform/tools/mcp.ts": 0,
+  // The MCP tool handlers. WIN-269 territory, measured and left alone.
+  "mcp-platform/tools/end-users.ts": 12,
+  "mcp-platform/tools/jobs.ts": 11,
+  "mcp-platform/tools/macros.ts": 10,
+  "mcp-platform/tools/entities.ts": 5,
+  "mcp-platform/tools/reflection.ts": 4,
+  "mcp-platform/tools/admin.ts": 3,
+  "mcp-platform/tools/orchestration.ts": 3,
+  "mcp-platform/tools/channels.ts": 2,
+  "mcp-platform/tools/mcp.ts": 2,
+  "mcp-platform/tools/channel-apps.ts": 1,
+});
+
+/**
+ * The whole directory's ceiling, and the ownership split as measured.
+ *
+ * MEASURED ON BOTH TREES WITH THE SAME ANALYZER, which is the only way a delta
+ * means anything: base `3b3f1ebb` reports 125 here and 815 app-wide; this tree
+ * reports 123 and 813.
+ *
+ * WHAT THIS CENSUS DOES NOT SEE, said plainly rather than left for a reader to
+ * discover: it counts generated DELEGATE operations. `mcp-scope.ts` resolves the
+ * tenant ancestry with a `$queryRaw`, which is a client method and not a
+ * delegate operation, so it contributes 0 to every number here.
+ * `scripts/arch/sole-writer.mjs` is the gate that does attribute raw SQL, and it
+ * attributes by the table the statement names.
+ */
+const DIRECTORY_CEILING = 123;
+
+const OWNERSHIP_CEILING: Readonly<Record<string, number>> = Object.freeze({
+  "identity-access": 35,
+  tools: 33,
+  agents: 15,
+  tenancy: 15,
+  jobs: 11,
+  eventing: 6,
+  observability: 3,
+  conversations: 2,
+  "<kernel-outbox-adapter>": 2,
+  governance: 1,
 });
 
 /** The three services the tranche took off the ORM. They must hold ZERO. */
@@ -143,6 +189,20 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
       byOwner.set(owner, (byOwner.get(owner) ?? 0) + 1);
     }
 
+    // THE THREE IDENTITIES. Each is an equation between numbers derived
+    // separately, so a partial re-pin cannot go unnoticed:
+    //   the per-owner split sums to the directory total;
+    //   the directory total is at or under its own ceiling;
+    //   the directory total plus everything outside it is the app-wide pin.
+    const ownerSum = [...byOwner.values()].reduce((a, b) => a + b, 0);
+    expect(ownerSum).toBe(here.length);
+    expect(here.length).toBeLessThanOrEqual(DIRECTORY_CEILING);
+
+    const overOwner = [...byOwner.entries()]
+      .filter(([owner, count]) => count > (OWNERSHIP_CEILING[owner] ?? 0))
+      .map(([owner, count]) => `${owner}: ${count} > ${OWNERSHIP_CEILING[owner] ?? 0}`);
+    expect(overOwner.sort(), "an owning context gained ORM call sites in this directory").toEqual([]);
+
     // THE JOIN. `clean-prisma-delegates.test.ts` pins the app-wide total, and
     // that pin is itself joined to the frozen `main` oracle (see its own note).
     // Reading the digit out of that file rather than restating it here is what
@@ -153,11 +213,7 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
     );
     const pinned = /expect\(analysis\.calls\.length\)\.toBe\((\d+)\)/u.exec(gate);
     expect(pinned?.[1], "the app-wide call-site pin could not be read").toBeDefined();
-
-    const total = Number(pinned?.[1]);
-    const outside = analysis.calls.length - here.length;
-    expect(here.length + outside).toBe(analysis.calls.length);
-    expect(analysis.calls.length).toBe(total);
+    expect(analysis.calls.length).toBe(Number(pinned?.[1]));
 
     // Not an assertion — the report. Printed so a reviewer reading CI output
     // gets the ownership split without running anything.
@@ -166,7 +222,7 @@ describe("WIN-268 P2 — the mcp-platform ORM surface, by owning context", () =>
       .map(([owner, count]) => `${owner}=${count}`)
       .join(" ");
     process.stdout.write(
-      `\n[WIN-268 P2] mcp-platform ORM call sites: ${here.length} of ${total} app-wide\n` +
+      `\n[WIN-268 P2] mcp-platform ORM call sites: ${here.length} of ${analysis.calls.length} app-wide\n` +
         `[WIN-268 P2] ownership split: ${split}\n`,
     );
   });

--- a/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
@@ -185,7 +185,7 @@ describe("MCPPermissionGatewayService canonical policies", () => {
   // gateway then fails closed or swallows it.
   // -------------------------------------------------------------------------
 
-  it.each([
+  it.each<[ScopeRefusalReason]>([
     [MCP_SCOPE_FOREIGN],
     [MCP_SCOPE_UNKNOWN],
   ])("blocks at tier 2 when the claimed scope is %s, with no agent in play", async (reason) => {

--- a/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.test.ts
@@ -1,5 +1,17 @@
+// WIN-268 P2 — the harness now drives an `McpPolicyReader`, not a fake
+// `PrismaClient`. The two `where`-clause assertions this suite used to make have
+// gone to `mcp-policy.integration.test.ts`, where they are made against a real
+// PostgreSQL with two tenants — because a `where` clause asserted against a
+// mock proves only that a string was spelled a certain way, and the claim worth
+// making is that a foreign row is actually excluded.
+//
+// The lattice cases below are unchanged in substance and are the right thing to
+// unit-test: they are pure, and a database would only slow them down.
+
 import { describe, expect, it, vi } from "vitest";
-import { MCPPermissionGatewayService } from "./permission-gateway.service";
+import { MCPPermissionGatewayService, McpScopeRefusedError } from "./permission-gateway.service";
+import type { AgentPolicyBinding, McpPolicyReader, OrganizationPolicyRow } from "./mcp-policy.store";
+import { MCP_SCOPE_FOREIGN, MCP_SCOPE_UNKNOWN, scopeAllowed, scopeRefused, type ScopeRefusalReason } from "./mcp-scope";
 
 const scope = {
   organizationId: "org-1",
@@ -7,29 +19,42 @@ const scope = {
   environmentId: "env-1",
 };
 
+function policyRow(pattern: string, effect: "ALLOW" | "DENY"): OrganizationPolicyRow {
+  return {
+    id: `policy-${pattern}`,
+    organizationId: scope.organizationId,
+    pattern,
+    effect,
+    createdAt: new Date("2026-09-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-09-01T00:00:00.000Z"),
+  };
+}
+
 function harness(
   options: {
     orgPolicies?: Array<{ pattern: string; effect: "ALLOW" | "DENY" }>;
-    binding?: unknown;
+    binding?: AgentPolicyBinding | null;
+    refuse?: ScopeRefusalReason;
   } = {}
 ) {
-  const prisma = {
-    organizationMcpPolicy: {
-      findMany: vi.fn().mockResolvedValue(options.orgPolicies ?? []),
-    },
-    agentBinding: {
-      findFirst: vi.fn().mockResolvedValue(options.binding ?? null),
-    },
+  const guard = <Value>(value: Value) =>
+    options.refuse ? scopeRefused(options.refuse) : scopeAllowed(value);
+  const reader: McpPolicyReader = {
+    listOrganizationPolicies: vi.fn(async () =>
+      guard((options.orgPolicies ?? []).map((row) => policyRow(row.pattern, row.effect)) as readonly OrganizationPolicyRow[]),
+    ),
+    findAgentPolicyBinding: vi.fn(async () => guard(options.binding ?? null)),
+    upsertOrganizationPolicy: vi.fn(async (_scope, pattern, effect) =>
+      guard(policyRow(pattern, effect)),
+    ),
+    deleteOrganizationPolicy: vi.fn(async () => guard(true)),
   };
-  return {
-    service: new MCPPermissionGatewayService(prisma as any),
-    prisma,
-  };
+  return { service: new MCPPermissionGatewayService(reader), reader };
 }
 
 describe("MCPPermissionGatewayService canonical policies", () => {
   it("scopes organization policies only by authenticated organization ancestry", async () => {
-    const { service, prisma } = harness({
+    const { service, reader } = harness({
       orgPolicies: [{ pattern: "reports.*", effect: "ALLOW" }],
     });
 
@@ -40,10 +65,11 @@ describe("MCPPermissionGatewayService canonical policies", () => {
       toolName: "reports.get",
     });
 
-    expect(prisma.organizationMcpPolicy.findMany).toHaveBeenCalledWith({
-      where: { organizationId: "org-1" },
-      select: { pattern: true, effect: true },
-    });
+    // The gateway hands the WHOLE claimed triple down. It used to hand down
+    // `organizationId` alone, which is what made a forged organization
+    // unnoticeable; the store is the thing that resolves it, and
+    // `mcp-policy.integration.test.ts` proves it does.
+    expect(reader.listOrganizationPolicies).toHaveBeenCalledWith(scope);
     expect(resolved.state).toBe("auto_allow");
   });
 
@@ -91,13 +117,8 @@ describe("MCPPermissionGatewayService canonical policies", () => {
   });
 
   it("loads the active AgentVersion through the fully scoped AgentBinding", async () => {
-    const { service, prisma } = harness({
-      binding: {
-        activeAgentVersion: {
-          toolDefaultPolicy: "ALL",
-          toolPolicies: [],
-        },
-      },
+    const { service, reader } = harness({
+      binding: { defaultPolicy: "ALL", explicitEffect: null },
     });
 
     const resolved = await service.resolve({
@@ -107,30 +128,7 @@ describe("MCPPermissionGatewayService canonical policies", () => {
       toolName: "reports.get",
     });
 
-    expect(prisma.agentBinding.findFirst).toHaveBeenCalledWith({
-      where: {
-        agentId: "agent-1",
-        environmentId: "env-1",
-        environment: {
-          projectId: "project-1",
-          project: { organizationId: "org-1" },
-        },
-        agent: { projectId: "project-1" },
-      },
-      select: {
-        activeAgentVersion: {
-          select: {
-            toolDefaultPolicy: true,
-            toolPolicies: {
-              where: { tool: { name: "reports.get" } },
-              orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-              take: 1,
-              select: { effect: true },
-            },
-          },
-        },
-      },
-    });
+    expect(reader.findAgentPolicyBinding).toHaveBeenCalledWith(scope, "agent-1", "reports.get");
     expect(resolved.state).toBe("auto_allow");
   });
 
@@ -140,10 +138,8 @@ describe("MCPPermissionGatewayService canonical policies", () => {
   ] as const)("applies explicit AgentToolPolicy %s as %s", async (effect, expected) => {
     const { service } = harness({
       binding: {
-        activeAgentVersion: {
-          toolDefaultPolicy: effect === "DENY" ? "ALL" : "NONE",
-          toolPolicies: [{ effect }],
-        },
+        defaultPolicy: effect === "DENY" ? "ALL" : "NONE",
+        explicitEffect: effect,
       },
     });
 
@@ -162,12 +158,7 @@ describe("MCPPermissionGatewayService canonical policies", () => {
     ["ALL", "auto_allow"],
   ] as const)("maps AgentVersion default %s to %s", async (toolDefaultPolicy, expected) => {
     const { service } = harness({
-      binding: {
-        activeAgentVersion: {
-          toolDefaultPolicy,
-          toolPolicies: [],
-        },
-      },
+      binding: { defaultPolicy: toolDefaultPolicy, explicitEffect: null },
     });
 
     const resolved = await service.resolve({
@@ -178,5 +169,69 @@ describe("MCPPermissionGatewayService canonical policies", () => {
     });
 
     expect(resolved.state).toBe(expected);
+  });
+  // -------------------------------------------------------------------------
+  // WIN-268 P2 — THE FORGED SCOPE, AT THE UNIT LEVEL.
+  //
+  // These pin the GATEWAY's half of the contract: given a store that refuses,
+  // `resolve` must BLOCK and say which tier discovered it, and the three CRUD
+  // helpers must throw rather than answer. The store's half — that a forged
+  // triple is actually detected against a real tree — is
+  // `mcp-policy.integration.test.ts`, against real PostgreSQL with two tenants.
+  //
+  // WHY BOTH HALVES ARE NEEDED. A unit test alone would prove only that the
+  // gateway handles a refusal its own double invented. An integration test
+  // alone would prove the store refuses and say nothing about whether the
+  // gateway then fails closed or swallows it.
+  // -------------------------------------------------------------------------
+
+  it.each([
+    [MCP_SCOPE_FOREIGN],
+    [MCP_SCOPE_UNKNOWN],
+  ])("blocks at tier 2 when the claimed scope is %s, with no agent in play", async (reason) => {
+    const { service, reader } = harness({
+      orgPolicies: [{ pattern: "reports.*", effect: "ALLOW" }],
+      refuse: reason,
+    });
+
+    await expect(
+      service.resolve({ scope, agentId: null, userId: "user-1", toolName: "reports.get" }),
+    ).resolves.toEqual({ state: "block", tier: 2, reason: `scope ${reason}` });
+
+    // Tier 3 is never consulted: a scope that is not a chain cannot be made to
+    // do more work by asking it another question.
+    expect(reader.findAgentPolicyBinding).not.toHaveBeenCalled();
+  });
+
+  it("MUTATION GUARD: the pre-P2 behaviour — abstain on a forged scope — is now RED", async () => {
+    // The extraction source read `where: { organizationId: scope.organizationId }`
+    // and, for an organization with no policy rows, got `[]` -> `null` -> "this
+    // tier has no objection" -> `auto_allow`. That is precisely the outcome this
+    // case forbids. An implementation that dropped the refusal branch and fell
+    // through to an empty policy list would produce `auto_allow` here and fail.
+    const { service } = harness({ refuse: MCP_SCOPE_FOREIGN });
+    const resolved = await service.resolve({
+      scope,
+      agentId: null,
+      userId: "user-1",
+      toolName: "reports.get",
+    });
+    expect(resolved.state).not.toBe("auto_allow");
+    expect(resolved.state).toBe("block");
+  });
+
+  it("the three CRUD helpers throw a named refusal rather than answering falsely", async () => {
+    const { service } = harness({ refuse: MCP_SCOPE_FOREIGN });
+
+    await expect(service.listOrgPolicies(scope)).rejects.toThrow(McpScopeRefusedError);
+    await expect(service.upsertOrgPolicy(scope, "reports.*", "block")).rejects.toThrow(
+      McpScopeRefusedError,
+    );
+    // `deleteOrgPolicy` is the one that matters most: it already answered
+    // `false` for "no such row", so a refusal reported through the return value
+    // would have been indistinguishable from a delete of a row already gone.
+    await expect(service.deleteOrgPolicy(scope, "policy-1")).rejects.toMatchObject({
+      reason: MCP_SCOPE_FOREIGN,
+    });
   });
 });

--- a/apps/agent/src/mcp-platform/permission-gateway.service.ts
+++ b/apps/agent/src/mcp-platform/permission-gateway.service.ts
@@ -1,9 +1,7 @@
 import { Inject, Injectable, Logger } from "@nestjs/common";
-import {
-  PRISMA_TOKEN,
-  type ControlDatabaseClient,
-} from "../shared/database.provider";
 import type { RequestScope } from "../auth/scope.guard";
+import { McpPolicyStore, type McpPolicyReader } from "./mcp-policy.store";
+import type { ScopeRefusalReason } from "./mcp-scope";
 
 /**
  * Theme K.3 — 4-tier MCP permission gateway.
@@ -370,11 +368,46 @@ export interface ResolvedPermission {
   reason: string;
 }
 
+/**
+ * A read whose scope was refused, as an exception for the CRUD paths.
+ *
+ * WHY AN EXCEPTION HERE AND A UNION IN `resolve`. `resolve` has a return type
+ * that can carry a denial — that is what it is for — so a refusal there is a
+ * value. The three CRUD helpers return rows, and the alternative to throwing
+ * would have been widening all three return types so every caller in
+ * `tools/mcp.ts` had to destructure a result it has no decision to make about.
+ * The transport maps this to a 403 the same way it maps every other
+ * authorization failure.
+ */
+export class McpScopeRefusedError extends Error {
+  constructor(readonly reason: ScopeRefusalReason) {
+    super(`claimed MCP scope is ${reason}`);
+    this.name = "McpScopeRefusedError";
+  }
+}
+
+function unwrapScoped<Value>(result: { ok: true; value: Value } | { ok: false; reason: ScopeRefusalReason }): Value {
+  if (!result.ok) throw new McpScopeRefusedError(result.reason);
+  return result.value;
+}
+
+function isScopeRefusal(value: unknown): value is { refused: ScopeRefusalReason } {
+  return typeof value === "object" && value !== null && "refused" in value;
+}
+
 @Injectable()
 export class MCPPermissionGatewayService {
   private readonly logger = new Logger(MCPPermissionGatewayService.name);
 
-  constructor(@Inject(PRISMA_TOKEN) private readonly prisma: ControlDatabaseClient) {}
+  /**
+   * WIN-268 P2 — the gateway holds a READER, not a client.
+   *
+   * Nest injects `McpPolicyStore`; the field is typed as the narrow
+   * `McpPolicyReader` interface so nothing in this file can reach a Prisma type,
+   * and so the day `apps/agent` can reach `toolsContract` the swap is this one
+   * line rather than a rewrite of the lattice below.
+   */
+  constructor(@Inject(McpPolicyStore) private readonly policies: McpPolicyReader) {}
 
   /** Tier-1 platform baseline. Matches pattern list to get the minimum. */
   private readPlatformMinimum(toolName: string): McpPermissionState {
@@ -384,17 +417,27 @@ export class MCPPermissionGatewayService {
     return "auto_allow";
   }
 
-  /** Tier-2 org policy — DB lookup. Returns null when no matching row. */
+  /**
+   * Tier-2 org policy. Returns null when no matching row — and a REFUSAL when
+   * the claimed scope is not a real chain.
+   *
+   * THE THIRD RETURN VALUE IS THE POINT. This method used to answer
+   * `McpPermissionState | null`, where `null` carried two completely different
+   * facts: "this organization has no policy for this tool" and "the
+   * organization I was told to read is not the one that owns this environment,
+   * so it has no policy for anything". `mcp-scope.ts` records the measurement —
+   * the triple comes from three unrelated headers and nothing joins them — and
+   * the consequence: a forged organization id turned a tier that can only
+   * TIGHTEN into a tier that abstains. The refusal is now its own branch.
+   */
   private async readOrgPolicy(
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     toolName: string,
-  ): Promise<McpPermissionState | null> {
-    const rows = await this.prisma.organizationMcpPolicy.findMany({
-      where: { organizationId: scope.organizationId },
-      select: { pattern: true, effect: true },
-    });
+  ): Promise<McpPermissionState | null | { refused: ScopeRefusalReason }> {
+    const rows = await this.policies.listOrganizationPolicies(scope);
+    if (!rows.ok) return { refused: rows.reason };
     let winner: McpPermissionState | null = null;
-    for (const row of rows) {
+    for (const row of rows.value) {
       if (matchesPattern(row.pattern, toolName)) {
         const normalized = fromPolicyEffect(row.effect);
         if (normalized && (!winner || stateOrder(normalized) > stateOrder(winner))) {
@@ -405,43 +448,29 @@ export class MCPPermissionGatewayService {
     return winner;
   }
 
-  /** Tier-3 per-agent override from the active version's typed tool policy. */
+  /**
+   * Tier-3 per-agent override from the active version's typed tool policy.
+   *
+   * AN AGENT WITH NO BINDING IN THIS SCOPE IS STILL A DENIAL, unchanged: an
+   * agent whose active version cannot be resolved in the environment it is
+   * calling in is not an agent with no restrictions, it is an agent that is not
+   * deployed here. A scope REFUSAL is reported separately, because "you asked
+   * about a scope that does not exist" and "that agent is not deployed in this
+   * scope" are different answers and only one of them is about the agent.
+   */
   private async readAgentOverride(
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     agentId: string,
     toolName: string,
-  ): Promise<McpPermissionState | null> {
-    const binding = await this.prisma.agentBinding.findFirst({
-      where: {
-        agentId,
-        environmentId: scope.environmentId,
-        environment: {
-          projectId: scope.projectId,
-          project: { organizationId: scope.organizationId },
-        },
-        agent: { projectId: scope.projectId },
-      },
-      select: {
-        activeAgentVersion: {
-          select: {
-            toolDefaultPolicy: true,
-            toolPolicies: {
-              where: { tool: { name: toolName } },
-              orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
-              take: 1,
-              select: { effect: true },
-            },
-          },
-        },
-      },
-    });
-    if (!binding) {
+  ): Promise<McpPermissionState | null | { refused: ScopeRefusalReason }> {
+    const binding = await this.policies.findAgentPolicyBinding(scope, agentId, toolName);
+    if (!binding.ok) return { refused: binding.reason };
+    if (binding.value === null) {
       this.logger.warn("MCP permission denied: scoped AgentBinding was not found");
       return "block";
     }
-    const explicit = binding.activeAgentVersion.toolPolicies[0];
-    if (explicit) return fromPolicyEffect(explicit.effect);
-    return binding.activeAgentVersion.toolDefaultPolicy === "ALL" ? "auto_allow" : "block";
+    if (binding.value.explicitEffect) return fromPolicyEffect(binding.value.explicitEffect);
+    return binding.value.defaultPolicy === "ALL" ? "auto_allow" : "block";
   }
 
   /** Tier-4 session override — passed in by the caller; no DB touch. */
@@ -461,12 +490,29 @@ export class MCPPermissionGatewayService {
     const t1 = this.readPlatformMinimum(input.toolName);
     if (t1 === "block") return { state: "block", tier: 1, reason: "platform-tier block" };
 
-    const t2 = await this.readOrgPolicy(input.scope, input.toolName);
+    const tier2 = await this.readOrgPolicy(input.scope, input.toolName);
+    // WIN-268 P2 — A FORGED SCOPE IS A BLOCK, NOT AN ABSTENTION, and it is
+    // reported at the tier that discovered it. `resolve` cannot answer a
+    // question about a scope that is not a real chain: every remaining tier
+    // would be reading rows for a tenant the caller has not named coherently,
+    // and the previous behaviour — read the claimed organization's (usually
+    // empty) policy set and carry on — is precisely the abstention this refusal
+    // replaces. `mcp-scope.ts` carries the measurement.
+    if (isScopeRefusal(tier2)) {
+      this.logger.warn(`MCP permission denied: claimed scope is ${tier2.refused}`);
+      return { state: "block", tier: 2, reason: `scope ${tier2.refused}` };
+    }
+    const t2 = tier2;
     if (t2 === "block") return { state: "block", tier: 2, reason: "org-policy block" };
 
-    const t3 = input.agentId
+    const tier3 = input.agentId
       ? await this.readAgentOverride(input.scope, input.agentId, input.toolName)
       : null;
+    if (isScopeRefusal(tier3)) {
+      this.logger.warn(`MCP permission denied: claimed scope is ${tier3.refused}`);
+      return { state: "block", tier: 3, reason: `scope ${tier3.refused}` };
+    }
+    const t3 = tier3;
     if (t3 === "block") return { state: "block", tier: 3, reason: "agent-policy block" };
 
     const t4 = this.readSessionOverride(input.sessionOverrides, input.toolName);
@@ -524,13 +570,17 @@ export class MCPPermissionGatewayService {
   }
 
   // ── CRUD helpers for tier-2 policy ─────────────────────────────────
+  //
+  // ALL THREE REFUSE A FORGED SCOPE, and the refusal travels as a thrown
+  // `McpScopeRefusedError` rather than as a falsy return. `deleteOrgPolicy` is
+  // why: it already answered `false` for "no such row", so a forged scope
+  // returning `false` would have been indistinguishable from a delete of a row
+  // that was already gone — an empty result standing in for a refusal, which is
+  // the same defect this tranche removed from tier 2.
   async listOrgPolicies(
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
   ) {
-    const rows = await this.prisma.organizationMcpPolicy.findMany({
-      where: { organizationId: scope.organizationId },
-      orderBy: [{ pattern: "asc" }],
-    });
+    const rows = unwrapScoped(await this.policies.listOrganizationPolicies(scope));
     return rows.map(({ effect, ...row }) => ({ ...row, policy: fromPolicyEffect(effect) }));
   }
 
@@ -543,27 +593,9 @@ export class MCPPermissionGatewayService {
       throw new Error("pattern must be 1–200 chars");
     }
     const effect = toPolicyEffect(policy);
-    // Upsert via find + update/create since the unique key is composite.
-    const existing = await this.prisma.organizationMcpPolicy.findFirst({
-      where: { organizationId: scope.organizationId, pattern },
-      select: { id: true },
-    });
-    if (existing) {
-      const updated = await this.prisma.organizationMcpPolicy.update({
-        where: { id: existing.id },
-        data: { effect },
-      });
-      const { effect: savedEffect, ...row } = updated;
-      return { ...row, policy: fromPolicyEffect(savedEffect) };
-    }
-    const created = await this.prisma.organizationMcpPolicy.create({
-      data: {
-        organizationId: scope.organizationId,
-        pattern,
-        effect,
-      },
-    });
-    const { effect: savedEffect, ...row } = created;
+    const { effect: savedEffect, ...row } = unwrapScoped(
+      await this.policies.upsertOrganizationPolicy(scope, pattern, effect),
+    );
     return { ...row, policy: fromPolicyEffect(savedEffect) };
   }
 
@@ -571,13 +603,7 @@ export class MCPPermissionGatewayService {
     scope: Pick<RequestScope, "organizationId" | "projectId" | "environmentId">,
     id: string,
   ) {
-    const existing = await this.prisma.organizationMcpPolicy.findFirst({
-      where: { id, organizationId: scope.organizationId },
-      select: { id: true },
-    });
-    if (!existing) return false;
-    await this.prisma.organizationMcpPolicy.delete({ where: { id } });
-    return true;
+    return unwrapScoped(await this.policies.deleteOrganizationPolicy(scope, id));
   }
 
   /** Export for tests and tools that want to know the baseline. */

--- a/apps/agent/src/prisma-delegate-census.ts
+++ b/apps/agent/src/prisma-delegate-census.ts
@@ -1,0 +1,382 @@
+// The type-checker-driven inventory of every ORM delegate call in `apps/agent`.
+//
+// WHY THIS IS A MODULE AND NOT A TEST. `clean-prisma-delegates.test.ts` wrote
+// this analyzer and then asserted THREE numbers about the whole app: a call-site
+// count, a unique-operation inventory and its digest. That is the right gate for
+// "did the surface grow", and it is the wrong shape for "WHICH context owns the
+// rows a given directory still reaches", because the answer it computes —  one
+// `{delegate, operation, file, line}` per call site — is thrown away the moment
+// the three assertions are made.
+//
+// WIN-268 P2 needs the same walk with the results KEPT, so that
+// `mcp-platform/orm-ownership-census.test.ts` can split the surface by owning
+// context and ratchet the split. Copying three hundred lines of type-checker
+// code into a second file would have produced two analyzers that could disagree
+// — and a disagreement between them would be invisible, because each would be
+// the only witness to its own number. There is ONE analyzer, and both consumers
+// import it, so the ownership split and the pinned total are two views of one
+// walk by construction rather than by hope.
+//
+// NOTHING ABOUT THE ANALYSIS CHANGED IN THE EXTRACTION. The three pins in
+// `clean-prisma-delegates.test.ts` are unmoved (815 / 329 /
+// 0c4fd159...), which is the only evidence that matters for a refactor of a
+// gate: a move that altered what is measured would have moved them.
+//
+// BUILD STATE STILL DECIDES THE ANSWER. This is a `ts.Program` over the app's
+// real `tsconfig.json`, so the count depends on which workspace packages have
+// been built — see the long note on the pins in `clean-prisma-delegates.test.ts`
+// and `scripts/ci-policy.test.mjs`, which asserts the suite runs after ci.yml's
+// "Generate and build compiled Agent dependencies" step.
+
+import { readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { Prisma, PrismaClient } from "@platos/tenancy-database";
+import ts from "typescript";
+
+/** The `apps/agent/src` directory every reported path is relative to. */
+export const AGENT_SOURCE_ROOT = __dirname;
+
+export function productionTypeScriptFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return productionTypeScriptFiles(path);
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) return [];
+    if (/\.(?:test|spec)\.ts$/.test(entry.name) || entry.name.endsWith(".d.ts")) return [];
+    return [path];
+  });
+}
+
+function lowerFirst(value: string): string {
+  return `${value[0]?.toLowerCase() ?? ""}${value.slice(1)}`;
+}
+
+/**
+ * The delegate and operation vocabularies, READ OFF THE GENERATED CLIENT.
+ *
+ * Both are joins to something this repository does not write by hand: the
+ * delegate names come from `Prisma.dmmf.datamodel.models`, which `prisma
+ * generate` derives from `schema.prisma`, and the operations come from the
+ * runtime shape of the client object. A model renamed in the schema changes
+ * both without anybody editing this file, which is the property that makes
+ * "every call site resolves to a real delegate operation" a checkable claim
+ * rather than a restatement of a list kept here.
+ */
+export const generatedDelegates = new Set(
+  Prisma.dmmf.datamodel.models.map((model) => lowerFirst(model.name)),
+);
+
+/** `delegate` (camelCase) → the schema `model` name it was derived from. */
+export const modelForDelegate = new Map<string, string>(
+  Prisma.dmmf.datamodel.models.map((model) => [lowerFirst(model.name), model.name]),
+);
+
+let cachedClient: PrismaClient | null = null;
+function generatedClient(): PrismaClient {
+  cachedClient ??= new PrismaClient();
+  return cachedClient;
+}
+
+/** Release the client this module lazily constructed. Safe to call twice. */
+export async function disconnectGeneratedClient(): Promise<void> {
+  const client = cachedClient;
+  cachedClient = null;
+  if (client) await client.$disconnect();
+}
+
+export const generatedOperationsByDelegate = new Map<string, Set<string>>(
+  [...generatedDelegates].map((delegate) => {
+    const value = (generatedClient() as unknown as Record<string, Record<string, unknown>>)[delegate];
+    return [
+      delegate,
+      new Set(Object.keys(value).filter((key) => typeof value[key] === "function" && !key.startsWith("$"))),
+    ];
+  }),
+);
+
+export const generatedOperations = new Set(
+  [...generatedOperationsByDelegate.values()].flatMap((operations) => [...operations]),
+);
+
+export type DelegateCall = {
+  delegate: string;
+  operation: string;
+  file: string;
+  line: number;
+};
+
+export type Analysis = {
+  calls: DelegateCall[];
+  unresolvedDynamicAccesses: string[];
+};
+
+function staticMemberName(expression: ts.Expression): string | null {
+  if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+  if (ts.isElementAccessExpression(expression)) {
+    const argument = expression.argumentExpression;
+    return argument && (ts.isStringLiteral(argument) || ts.isNoSubstitutionTemplateLiteral(argument))
+      ? argument.text
+      : null;
+  }
+  return null;
+}
+
+function memberBase(expression: ts.Expression): ts.Expression | null {
+  if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+    return expression.expression;
+  }
+  return null;
+}
+
+function symbolAt(checker: ts.TypeChecker, node: ts.Node): ts.Symbol | undefined {
+  return checker.getSymbolAtLocation(node) ?? undefined;
+}
+
+function declarationsFor(checker: ts.TypeChecker, identifier: ts.Identifier): readonly ts.Declaration[] {
+  return symbolAt(checker, identifier)?.declarations ?? [];
+}
+
+function hasInjectedPrismaToken(parameter: ts.ParameterDeclaration): boolean {
+  const decorators = ts.canHaveDecorators(parameter) ? ts.getDecorators(parameter) : undefined;
+  return decorators?.some((decorator) => decorator.getText().includes("Inject(PRISMA_TOKEN)")) ?? false;
+}
+
+export function createAnalyzer(program: ts.Program, files: readonly ts.SourceFile[], sourceRoot = AGENT_SOURCE_ROOT) {
+  const checker = program.getTypeChecker();
+  const clientSymbols = new Set<ts.Symbol>();
+
+  const markTypedClient = (node: ts.Node, name: ts.Node) => {
+    const rendered = checker.typeToString(checker.getTypeAtLocation(node));
+    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) {
+      const symbol = symbolAt(checker, name);
+      if (symbol) clientSymbols.add(symbol);
+    }
+  };
+
+  for (const file of files) {
+    const visit = (node: ts.Node): void => {
+      if (ts.isParameter(node) && ts.isIdentifier(node.name)) {
+        markTypedClient(node, node.name);
+        if (hasInjectedPrismaToken(node)) {
+          const symbol = symbolAt(checker, node.name);
+          if (symbol) clientSymbols.add(symbol);
+        }
+      } else if (
+        (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node))
+        && ts.isIdentifier(node.name)
+      ) {
+        markTypedClient(node, node.name);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+  }
+
+  const isClientExpression = (expression: ts.Expression, seen = new Set<ts.Symbol>()): boolean => {
+    const rendered = checker.typeToString(checker.getTypeAtLocation(expression));
+    if (/\b(?:ControlDatabaseClient|PrismaClient)\b/.test(rendered)) return true;
+
+    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
+      return isClientExpression(expression.expression, seen);
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return false;
+      if (clientSymbols.has(symbol)) return true;
+      seen.add(symbol);
+      return (symbol.declarations ?? []).some((declaration) => {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          return isClientExpression(declaration.initializer, seen);
+        }
+        if (ts.isParameter(declaration) && hasInjectedPrismaToken(declaration)) return true;
+        return false;
+      });
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const nameNode = ts.isPropertyAccessExpression(expression)
+        ? expression.name
+        : expression.argumentExpression;
+      const symbol = nameNode ? symbolAt(checker, nameNode) : undefined;
+      if (symbol && clientSymbols.has(symbol)) return true;
+    }
+    return false;
+  };
+
+  // Resolve constructor assignments (`this.prisma = prisma`) and transaction
+  // callback parameters. Repeat because either side may itself be an alias.
+  for (let pass = 0; pass < 3; pass++) {
+    for (const file of files) {
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isBinaryExpression(node)
+          && node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          && isClientExpression(node.right)
+        ) {
+          const target = ts.isPropertyAccessExpression(node.left)
+            ? node.left.name
+            : ts.isIdentifier(node.left)
+              ? node.left
+              : null;
+          const symbol = target ? symbolAt(checker, target) : undefined;
+          if (symbol) clientSymbols.add(symbol);
+        }
+        if (ts.isCallExpression(node) && staticMemberName(node.expression) === "$transaction") {
+          const base = memberBase(node.expression);
+          const callback = node.arguments[0];
+          if (
+            base
+            && isClientExpression(base)
+            && callback
+            && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))
+          ) {
+            const parameter = callback.parameters[0];
+            if (parameter && ts.isIdentifier(parameter.name)) {
+              const symbol = symbolAt(checker, parameter.name);
+              if (symbol) clientSymbols.add(symbol);
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(file);
+    }
+  }
+
+  const delegateFromType = (expression: ts.Expression): string | null => {
+    const expressionType = checker.getTypeAtLocation(expression);
+    const types = expressionType.isUnion() ? expressionType.types : [expressionType];
+    for (const type of types) {
+      const name = (type.aliasSymbol ?? type.getSymbol())?.getName() ?? "";
+      const match = /^\$?(.+)Delegate$/.exec(name);
+      if (match?.[1]) return lowerFirst(match[1]);
+    }
+    return null;
+  };
+
+  const delegateFor = (expression: ts.Expression, seen = new Set<ts.Symbol>()): string | null => {
+    const typed = delegateFromType(expression);
+    if (typed) return typed;
+    if (ts.isParenthesizedExpression(expression) || ts.isAsExpression(expression)) {
+      return delegateFor(expression.expression, seen);
+    }
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const base = memberBase(expression);
+      const name = staticMemberName(expression);
+      if (base && isClientExpression(base)) return name ?? "<dynamic>";
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return null;
+      seen.add(symbol);
+      for (const declaration of symbol.declarations ?? []) {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          const delegated = delegateFor(declaration.initializer, seen);
+          if (delegated) return delegated;
+        }
+        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
+          const variable = declaration.parent.parent;
+          if (ts.isVariableDeclaration(variable) && variable.initializer && isClientExpression(variable.initializer)) {
+            return declaration.propertyName && ts.isIdentifier(declaration.propertyName)
+              ? declaration.propertyName.text
+              : ts.isIdentifier(declaration.name)
+                ? declaration.name.text
+                : null;
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  const callable = (
+    expression: ts.Expression,
+    seen = new Set<ts.Symbol>(),
+  ): { delegate: string; operation: string } | null => {
+    if (ts.isPropertyAccessExpression(expression) || ts.isElementAccessExpression(expression)) {
+      const operation = staticMemberName(expression);
+      const base = memberBase(expression);
+      if (operation && generatedOperations.has(operation) && base) {
+        const delegate = delegateFor(base);
+        return delegate ? { delegate, operation } : null;
+      }
+      return null;
+    }
+    if (ts.isIdentifier(expression)) {
+      const symbol = symbolAt(checker, expression);
+      if (!symbol || seen.has(symbol)) return null;
+      seen.add(symbol);
+      for (const declaration of declarationsFor(checker, expression)) {
+        if (ts.isVariableDeclaration(declaration) && declaration.initializer) {
+          const resolved = callable(declaration.initializer, seen);
+          if (resolved) return resolved;
+        }
+        if (ts.isBindingElement(declaration) && ts.isObjectBindingPattern(declaration.parent)) {
+          const operation = declaration.propertyName && ts.isIdentifier(declaration.propertyName)
+            ? declaration.propertyName.text
+            : ts.isIdentifier(declaration.name)
+              ? declaration.name.text
+              : null;
+          const variable = declaration.parent.parent;
+          if (
+            operation
+            && generatedOperations.has(operation)
+            && ts.isVariableDeclaration(variable)
+            && variable.initializer
+          ) {
+            const delegate = delegateFor(variable.initializer);
+            if (delegate) return { delegate, operation };
+          }
+        }
+      }
+    }
+    return null;
+  };
+
+  return (): Analysis => {
+    const calls: DelegateCall[] = [];
+    const unresolvedDynamicAccesses: string[] = [];
+    for (const file of files) {
+      const visit = (node: ts.Node): void => {
+        if (ts.isCallExpression(node)) {
+          const resolvedCall = callable(node.expression);
+          if (resolvedCall) {
+            const position = file.getLineAndCharacterOfPosition(node.getStart(file));
+            const location = `${relative(sourceRoot, file.fileName)}:${position.line + 1}`;
+            if (resolvedCall.delegate === "<dynamic>") {
+              unresolvedDynamicAccesses.push(location);
+            } else {
+              calls.push({
+                ...resolvedCall,
+                file: relative(sourceRoot, file.fileName),
+                line: position.line + 1,
+              });
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(file);
+    }
+    return { calls, unresolvedDynamicAccesses };
+  };
+}
+
+export function productionProgram(files: string[], sourceRoot = AGENT_SOURCE_ROOT): ts.Program {
+  const configPath = ts.findConfigFile(resolve(sourceRoot, ".."), ts.sys.fileExists, "tsconfig.json");
+  if (!configPath) throw new Error("apps/agent tsconfig.json not found");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, resolve(configPath, ".."));
+  return ts.createProgram({ rootNames: files, options: parsed.options });
+}
+
+/** One walk of `apps/agent/src`, results kept. Both gates call exactly this. */
+export function analyzeAgentSource(sourceRoot = AGENT_SOURCE_ROOT): {
+  analysis: Analysis;
+  fileCount: number;
+} {
+  const paths = productionTypeScriptFiles(sourceRoot);
+  const program = productionProgram(paths, sourceRoot);
+  const files = paths
+    .map((path) => program.getSourceFile(path))
+    .filter((file): file is ts.SourceFile => !!file);
+  return { analysis: createAnalyzer(program, files, sourceRoot)(), fileCount: files.length };
+}

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "3b40746a8b4fad9f150f7565c6fb52c55a6e15d1f69df98963d2d358d4d7e471",
+  "evidenceSha256": "66e8b88146c6921a4a999cd19e8145a3c9026171199b67faa62ba00fd6bbb838",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "9049ec621ee05ba900390b842b86d808dec1d5e0362fbfdd19a0273fcf3815fc",
+    "aggregateSha256": "aa2a74f274059328fb590afe0149019506285d188bd5c2dac88c7721d0d1ccca",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -6343,7 +6343,7 @@
       },
       {
         "path": "docs/v1-ledger-rules.json",
-        "sha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c"
+        "sha256": "1ee0f218e6f1b6a6b6c56a8f946acc8754fe50e0bcb06297cb96c8184c31a5bc"
       },
       {
         "path": "docs/v3-openapi.yaml",

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "66e8b88146c6921a4a999cd19e8145a3c9026171199b67faa62ba00fd6bbb838",
+  "evidenceSha256": "658c694c1be2977d9e6e9aae51da02d0a9458a06287435e31459b9998e878edb",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "aa2a74f274059328fb590afe0149019506285d188bd5c2dac88c7721d0d1ccca",
+    "aggregateSha256": "113a7ce53defee3d780a1f43541900e71744e559224446b71063b78b9c2b03cd",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -20323,7 +20323,7 @@
       },
       {
         "path": "scripts/v1-ledger.test.mjs",
-        "sha256": "078df8ba8aa0a0ef81aed8bf8567723a9380d8f767c08e09a2b75ed5edd551c1"
+        "sha256": "1e9a353cab305108c54e43a6ed6610230d6914cddbb42fcf86f71187a84cb28e"
       },
       {
         "path": "scripts/vendored-build-audit.mjs",
@@ -38659,7 +38659,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 2000
+              "line": 2014
             }
           ],
           "reversePaths": [
@@ -38684,7 +38684,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "6238c28a78adc55e38cb9691b4d266a19fb83d42b9d8049552a7367fcbc513b2",
+      "evidenceSha256": "f40635cb18b3cfcb64de4009c1f89b792b1d5c7a2e750b7535b6b3d620b36e1e",
       "manifestSha256": "273951969710da5e07cfbb09885f792bbc938df2dfe3aed8d8e480438e113753",
       "name": "@platos/otlp-importer",
       "ociImageClosure": {
@@ -39825,7 +39825,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1999
+              "line": 2013
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -40050,7 +40050,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "01d8cb6d6dbe2d655bd036b97eaca7086d1e421dd09ec09dc1c71fe919cdffe1",
+      "evidenceSha256": "dbfbdf134fdfa888023440bcc76894a40d282fbde54c3c509e71ae164d8e4852",
       "manifestSha256": "5e3c30277d328e92c5781a7be8a60a9de1f5ab81898649bcd150b0ce5f3b48ab",
       "name": "@internal/run-engine",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "e05000e4ea50912e9bbc3d4aefc8f8501d4fe2094a5395fd1b147b460dd0b389",
+  "evidenceSha256": "9f071c3944b1c9a646066c6d6dc1d3afd015d12a179e0d95335b40bc6fe4e302",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "37e621bd8ba8965b1a7e47252fdcead89205c370382b80b6f32998b59fc22ac7",
+    "aggregateSha256": "8ee6dfdc412696acce6ce15a081c5aa1007ccda81e5cf1cec0093abce7bea76f",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -223,7 +223,7 @@
       },
       {
         "path": ".dependency-cruiser.js",
-        "sha256": "dc49ce561f5122db8f0079af37da67721c5577f9a840a886a624437ffbd47790"
+        "sha256": "f0e39dcf5055f420eb4fa82a205f6dcaa7188e528d6abdecc7500ffcee60674c"
       },
       {
         "path": ".dockerignore",
@@ -267,7 +267,7 @@
       },
       {
         "path": ".github/workflows/ci.yml",
-        "sha256": "cfe9a1ccec1abc0cad103157ccf20861d857506b93158e00f1e5cb89474acc86"
+        "sha256": "3b54aadc70f871f45d0305fb282bd3f78b5c50079d39b4bf7e6d06b0b918273d"
       },
       {
         "path": ".github/workflows/publish-images.yml",
@@ -939,7 +939,7 @@
       },
       {
         "path": "apps/agent/src/clean-prisma-delegates.test.ts",
-        "sha256": "0fad8df237d4aa9b0451a14890875ea28fae18b6b59a808e82abcc4139a980a0"
+        "sha256": "fe89bd865ff82623474fb147817ef494ef7e75827e7b75c98954d61f4082273f"
       },
       {
         "path": "apps/agent/src/connections/connections.gateway-auth.test.ts",
@@ -1035,7 +1035,7 @@
       },
       {
         "path": "apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts",
-        "sha256": "b787736d961bca2b981eccfbe39620dde8fa4ad2d13933d39b2c81b6d975edb1"
+        "sha256": "2c1a8e2940b3b8545e2aace5ebbe0b1e6647aae6b12288644e2d6154c1acf21b"
       },
       {
         "path": "apps/agent/src/main.ts",
@@ -1062,6 +1062,10 @@
         "sha256": "9af79731b2abbe0921f2bbccaeeb424c7a2c68159757bd48f032acb0f06d5093"
       },
       {
+        "path": "apps/agent/src/mcp-platform/entity-tool-policy.store.ts",
+        "sha256": "c4fa3de95b7d94526b112feb404f687bb046cd8e7e2cb8e09c469a7d02953ac5"
+      },
+      {
         "path": "apps/agent/src/mcp-platform/events.service.ts",
         "sha256": "079004c5d80928302a1a8318ebd21a306b3507659f05ca9417d5975a433cc167"
       },
@@ -1075,11 +1079,11 @@
       },
       {
         "path": "apps/agent/src/mcp-platform/identity-resolver.service.test.ts",
-        "sha256": "d047c5ef02e3030b0c911178a42921b672691cf41b90a8c371d8c6f501ecf879"
+        "sha256": "a918c400c7291488fd4f81520d29f0933b96cb1e8c2d9a625ac7c298406fa04f"
       },
       {
         "path": "apps/agent/src/mcp-platform/identity-resolver.service.ts",
-        "sha256": "9f37715a9818a398d80f6a6635773c1759cf98cc267d61a83f01f61c0d2f123d"
+        "sha256": "08119f9eff9a28cb7ff16af66517302de4836972affbc483d692c919958860e7"
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-bearer-token.service.test.ts",
@@ -1095,7 +1099,11 @@
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-entity.controller.ts",
-        "sha256": "aceb5aa81156b57350b89ebedd7fe7ac2ca2364d58057d7270e390d2fb96b210"
+        "sha256": "0b5d7714ddd6b4416f98465c3ec237a30ee47a21836394f71da69bcfa2f46198"
+      },
+      {
+        "path": "apps/agent/src/mcp-platform/mcp-identity.store.ts",
+        "sha256": "fe974627fb644d3ff40b28542b560bb7d513a4333f1e6b3a8addf8073dbb8ac5"
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-management.validation.ts",
@@ -1111,7 +1119,11 @@
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-platform.module.ts",
-        "sha256": "bdd7506eece872c3e217c11c75ae797ce50d21ae38e59639b003828101670780"
+        "sha256": "7692bcd458901b5bed40c5c8de0b012cd66f7fbcdccf8bd8347f8d14f8a26308"
+      },
+      {
+        "path": "apps/agent/src/mcp-platform/mcp-policy.store.ts",
+        "sha256": "a1b47a8e7da435528bd65d981ac5386bd7f157efbdca56e6c4ce2fec2b7959a5"
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-router.test.ts",
@@ -1122,20 +1134,32 @@
         "sha256": "8085fd6d090bcc517bb2ab359c62e02e91551fdd0c61dfac26d13c33bcc3462c"
       },
       {
+        "path": "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+        "sha256": "853d89e3cceed999ef31f2fbb979dab51eb3f3c10675ab4a25546f6f98c4ce4a"
+      },
+      {
+        "path": "apps/agent/src/mcp-platform/mcp-scope.ts",
+        "sha256": "4fe72dbb515f292f4f0d25e6bde022a6f8e1a10dff468f6f64d93d6037c8a239"
+      },
+      {
         "path": "apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts",
-        "sha256": "998aaee813f81434ef21ba99d9b5f05c55abb3fa9f4a6c61bc071cb38e8c239e"
+        "sha256": "7e4556f4dc123947af476c2056f75c296052839b4b13a6854622219290c6aa02"
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts",
-        "sha256": "c5f1cc962d4404c9b4eda619995fb8bea8003683fa264a586313e49852b8d58f"
+        "sha256": "15d1e8d95cee55367b8fd1f6124a70bec6fa1c815e7bddf7fefde0eb56d11b5e"
+      },
+      {
+        "path": "apps/agent/src/mcp-platform/orm-ownership-census.test.ts",
+        "sha256": "32b58ea9f36484e72ca514e4a04e9c9c7ff60a0a2c86bf74fa64a72ce83c2689"
       },
       {
         "path": "apps/agent/src/mcp-platform/permission-gateway.service.test.ts",
-        "sha256": "912dceffa7ac98c38a7adb36118371444d8b1174c1406f241d0676acbda1928b"
+        "sha256": "7564fa78d28f1aa6b994d8da4b08c43d9ebb6d3f6bf897faa19286419a4dcce1"
       },
       {
         "path": "apps/agent/src/mcp-platform/permission-gateway.service.ts",
-        "sha256": "95b62e4945f90fb0c3e4b822b040c34b0dccd7b6b581f07a97f4d7f9847b7f55"
+        "sha256": "f57ecb423913f405d0614021ec90cbf20cc5d39830b046ceaa82b75b1afb9764"
       },
       {
         "path": "apps/agent/src/mcp-platform/schema-validator.ts",
@@ -1804,6 +1828,10 @@
       {
         "path": "apps/agent/src/performance-evidence/performance-evidence.service.ts",
         "sha256": "71c4a531d4e8125e94bd65e26b71df3450e679e5f5a451467f4ef35df56fa3e1"
+      },
+      {
+        "path": "apps/agent/src/prisma-delegate-census.ts",
+        "sha256": "d1739dc31bc2be578e3584cdcbf6c1f4d50ca842c490fd488c9d15e1f1814027"
       },
       {
         "path": "apps/agent/src/privacy/clickhouse-erasure.test.ts",
@@ -19891,15 +19919,15 @@
       },
       {
         "path": "scripts/arch/arch-boundaries.mjs",
-        "sha256": "522d3fa7092ea41c7b848cac8e3bc548d6b187ed310ab45a29284b38ee3ccd8e"
+        "sha256": "f800736950989f0514d5ddb21cf53aa61241e9df7db6a5863fd621999ff8c815"
       },
       {
         "path": "scripts/arch/arch-boundaries.test.mjs",
-        "sha256": "a3aaa9d1147a2bcde00c1d49e52174dceb65f596cb779498942fecfa952cbac1"
+        "sha256": "9a50063eb208361918d84d96207bd280e778f4df60c7a98676679f97439e5b8a"
       },
       {
         "path": "scripts/arch/boundary-rules.mjs",
-        "sha256": "3803361281b331ea72cf4796103442e9e9a3f111bca7db676aae610733b37fa2"
+        "sha256": "e2e861f95b8efe831c595930e1388fbfdb5de90c2ed48f2da645d38572f8c9d2"
       },
       {
         "path": "scripts/arch/clean-v1.mjs",
@@ -20059,7 +20087,7 @@
       },
       {
         "path": "scripts/ci-policy.test.mjs",
-        "sha256": "f2afb196c2e61e1b3314c364d996d71cc2392d97b1168d1a1bdc8563ab48ffec"
+        "sha256": "a46203e90f96b21f7f1461608d46a7fdfcf109f6b33f5aeade157e3cdf24880e"
       },
       {
         "path": "scripts/clickhouse-split-audit.mjs",
@@ -21597,7 +21625,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 10
+              "line": 243
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -23064,7 +23092,7 @@
             {
               "from": "apps/agent/src/clean-prisma-delegates.test.ts",
               "kind": "workspace-owned-file",
-              "line": 306
+              "line": 86
             },
             {
               "from": "apps/agent/src/connections/connections.gateway-auth.test.ts",
@@ -23142,7 +23170,17 @@
               "line": 1
             },
             {
+              "from": "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "kind": "workspace-owned-file",
+              "line": 17
+            },
+            {
               "from": "apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts",
+              "kind": "workspace-owned-file",
+              "line": 1
+            },
+            {
+              "from": "apps/agent/src/mcp-platform/orm-ownership-census.test.ts",
               "kind": "workspace-owned-file",
               "line": 1
             },
@@ -24360,8 +24398,16 @@
               "apps/agent/src/mcp-platform/mcp-router.test.ts"
             ],
             [
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts"
+            ],
+            [
               "apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts",
               "apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts"
+            ],
+            [
+              "apps/agent/src/mcp-platform/orm-ownership-census.test.ts",
+              "apps/agent/src/mcp-platform/orm-ownership-census.test.ts"
             ],
             [
               "apps/agent/src/mcp-platform/permission-gateway.service.test.ts",
@@ -25149,7 +25195,9 @@
             "apps/agent/src/mcp-platform/mcp-entity.controller.test.ts",
             "apps/agent/src/mcp-platform/mcp-platform-management.test.ts",
             "apps/agent/src/mcp-platform/mcp-router.test.ts",
+            "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
             "apps/agent/src/mcp-platform/mcp-tool-acl.service.test.ts",
+            "apps/agent/src/mcp-platform/orm-ownership-census.test.ts",
             "apps/agent/src/mcp-platform/permission-gateway.service.test.ts",
             "apps/agent/src/mcp-platform/stdio-transport.test.ts",
             "apps/agent/src/mcp-platform/token.service.test.ts",
@@ -25377,7 +25425,7 @@
           "apps/agent"
         ]
       },
-      "evidenceSha256": "2a7d2ca2225dca4bc768ec77908822278bb0627e66c8d376d35ac288b886b08f",
+      "evidenceSha256": "1e29ccb1cb423fd757cae101ceb37167d850be8289f95e27c8e1eade90e8b1b8",
       "manifestSha256": "fb2672b4f608ba550dae81193ca9fbf7f9347a1402bd16841914dd9373e8e4af",
       "name": "platos-agent",
       "ociImageClosure": {
@@ -25504,7 +25552,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 619
+              "line": 646
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -26573,7 +26621,7 @@
           "apps/core-api"
         ]
       },
-      "evidenceSha256": "15cc4539e9d92071d7d4a0164505821389ddfb332dd2118989ed13dd97c00601",
+      "evidenceSha256": "6bbdb7f8ef73c1a6db90eb65088f8a09c24cd066dfdd76d4a16e90315ed111e2",
       "manifestSha256": "8f069781279f60d7e3e5f0fdb9c952dff23d79800a8494c9a97e43672c007e26",
       "name": "@platos/core-api",
       "ociImageClosure": {
@@ -36069,7 +36117,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 308
+              "line": 335
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -36942,7 +36990,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "4ffb8d3236efdc969ef4c2a63f13a87adf6c59fce7233984033d1e969df30e0a",
+      "evidenceSha256": "68cb9366ff413f35de7eb348599f347d1938eeb33f9dc83937566fa22b459731",
       "manifestSha256": "2664bbbb7140c4c9272e88b7cc56b3a72c1617b774ae4aff4606336caeccebdf",
       "name": "@platos/database",
       "ociImageClosure": {
@@ -40991,6 +41039,12 @@
               "specifier": "@platos/tenancy-database"
             },
             {
+              "file": "apps/agent/src/mcp-platform/entity-tool-policy.store.ts",
+              "from": "apps/agent",
+              "line": 61,
+              "specifier": "@platos/tenancy-database"
+            },
+            {
               "file": "apps/agent/src/mcp-platform/events.service.ts",
               "from": "apps/agent",
               "line": 2,
@@ -41000,12 +41054,6 @@
               "file": "apps/agent/src/mcp-platform/mcp-platform.controller.ts",
               "from": "apps/agent",
               "line": 19,
-              "specifier": "@platos/tenancy-database"
-            },
-            {
-              "file": "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts",
-              "from": "apps/agent",
-              "line": 2,
               "specifier": "@platos/tenancy-database"
             },
             {
@@ -41138,6 +41186,12 @@
               "file": "apps/agent/src/oauth/oauth.service.ts",
               "from": "apps/agent",
               "line": 2,
+              "specifier": "@platos/tenancy-database"
+            },
+            {
+              "file": "apps/agent/src/prisma-delegate-census.ts",
+              "from": "apps/agent",
+              "line": 33,
               "specifier": "@platos/tenancy-database"
             },
             {
@@ -41304,15 +41358,15 @@
             ],
             [
               "apps/agent",
+              "apps/agent/src/mcp-platform/entity-tool-policy.store.ts"
+            ],
+            [
+              "apps/agent",
               "apps/agent/src/mcp-platform/events.service.ts"
             ],
             [
               "apps/agent",
               "apps/agent/src/mcp-platform/mcp-platform.controller.ts"
-            ],
-            [
-              "apps/agent",
-              "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts"
             ],
             [
               "apps/agent",
@@ -41401,6 +41455,10 @@
             [
               "apps/agent",
               "apps/agent/src/oauth/oauth.service.ts"
+            ],
+            [
+              "apps/agent",
+              "apps/agent/src/prisma-delegate-census.ts"
             ],
             [
               "apps/agent",
@@ -41512,7 +41570,7 @@
             {
               "from": "apps/agent/src/clean-prisma-delegates.test.ts",
               "kind": "reference",
-              "line": 359
+              "line": 72
             },
             {
               "from": "apps/agent/src/evals/eval-runtime-cutover.test.ts",
@@ -41523,6 +41581,11 @@
               "from": "apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts",
               "kind": "reference",
               "line": 5
+            },
+            {
+              "from": "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "kind": "reference",
+              "line": 56
             },
             {
               "from": "apps/agent/src/mcp-platform/tools/platos-control.memory.test.ts",
@@ -42079,6 +42142,10 @@
               "apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts"
             ],
             [
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts"
+            ],
+            [
               "apps/agent/src/mcp-platform/tools/platos-control.memory.test.ts",
               "apps/agent/src/mcp-platform/tools/platos-control.memory.test.ts"
             ],
@@ -42504,6 +42571,7 @@
             "apps/agent/src/clean-prisma-delegates.test.ts",
             "apps/agent/src/evals/eval-runtime-cutover.test.ts",
             "apps/agent/src/integration/non-browser-completion-postgres.integration.test.ts",
+            "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
             "apps/agent/src/mcp-platform/tools/platos-control.memory.test.ts",
             "apps/agent/src/memory/conversation-observability-projection.test.ts",
             "apps/agent/src/memory/conversation-persistence.test.ts",
@@ -42764,7 +42832,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "85a529f4000b7dad587efe76829b957cce22b9f839617c2abfe6a3cf43b9292d",
+      "evidenceSha256": "56a47de29edcfbae5f51935a80630d25517d1d0adcffddaee4d48302ecdc820a",
       "manifestSha256": "22bd55003e357c1af7df013be8c2b416898d3b19fd4b38c763ffd701fb7e9de1",
       "name": "@platos/tenancy-database",
       "ociImageClosure": {
@@ -43181,7 +43249,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 308
+              "line": 335
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -43878,7 +43946,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "189bf7b03e402e7e0b39fe9fbab2f004586b9b0b265e6cbf115298749e09f675",
+      "evidenceSha256": "d1195473580e2ad75cc987e52a55e2f822ffa4a4f22d7811832415b32fedcf11",
       "manifestSha256": "f520bd992a361e114569baf55a1b1faed9d18dcc7a3fa8ad63396bef61a0141d",
       "name": "@internal/testcontainers",
       "ociImageClosure": {
@@ -45100,7 +45168,7 @@
             {
               "from": "apps/agent/src/clean-prisma-delegates.test.ts",
               "kind": "reference",
-              "line": 370
+              "line": 81
             },
             {
               "from": "internal-packages/workload-identity/src/index.test.ts",
@@ -45282,7 +45350,7 @@
           "internal-packages/workload-identity"
         ]
       },
-      "evidenceSha256": "5fa8daec9d44c8b4ad378f2c0f62c5a8610ac12e8395f7b5f3fec8f7cb3b3d8f",
+      "evidenceSha256": "7dfa9764cf78a9ff7297c28cc6f4fffefea40d9b91f2766dbbbcda9a1195542b",
       "manifestSha256": "97671a87e5c4ba7c89300ccbc3c297a6f7aafd16ba2c3dfb5d4e28af62bc50d7",
       "name": "@internal/workload-identity",
       "ociImageClosure": {
@@ -50408,6 +50476,11 @@
           "reachable": true,
           "reasons": [
             {
+              "from": "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "kind": "reference",
+              "line": 33
+            },
+            {
               "from": "apps/core-api/src/app.module.test.ts",
               "kind": "reference",
               "line": 62
@@ -51215,6 +51288,10 @@
           ],
           "reversePaths": [
             [
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
+              "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts"
+            ],
+            [
               "apps/core-api/src/app.module.test.ts",
               "apps/core-api/src/app.module.test.ts"
             ],
@@ -51860,6 +51937,7 @@
             ]
           ],
           "roots": [
+            "apps/agent/src/mcp-platform/mcp-scope.integration.test.ts",
             "apps/core-api/src/app.module.test.ts",
             "apps/core-api/src/composition/identity-rest.integration.test.ts",
             "apps/core-api/src/composition/operator-authentication.integration.test.ts",
@@ -52079,7 +52157,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "d1b42dc5c416d6b4c924dde1c2563bb4d8a86353040d08ac24d546756b3b082e",
+      "evidenceSha256": "9d005f363f887bfd439b3e4b90ad2775222ec974c8876d2e88746d435f94dc96",
       "manifestSha256": "c3c49b3941820594e187dcbb86c78001443c58add67ce25009e535c3f1374927",
       "name": "@platos/adapter-postgres-tenancy",
       "ociImageClosure": {
@@ -52181,7 +52259,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 615
+              "line": 642
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -52642,7 +52720,7 @@
           "packages/adapters/redis-cache"
         ]
       },
-      "evidenceSha256": "41cfeb1544438e1db3414e61a37435451e0d92730da8ea4f3048434376608fad",
+      "evidenceSha256": "130ade2b2259ab28cf65782f45572e7e7aa73c02fc5701de4f836d70ea39568f",
       "manifestSha256": "28d8382e77863b7c6b09e45dbccdcb4dd2e5d292e3dcdef574a37a2e21dac28d",
       "name": "@platos/adapter-redis-cache",
       "ociImageClosure": {
@@ -54135,7 +54213,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 397
+              "line": 424
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -55097,7 +55175,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "523d5e1ae14d4bb39887a8d2970120c0d5293b7a62d7bbaa5a5643397224039e",
+      "evidenceSha256": "fcc7ab274370a50aeafc024c897ae4ab7e1481144e02446884759fc8b85f3246",
       "manifestSha256": "e43db9efa534960ba5ade2f86cf89a88453e7575222d56297d6b6ccfe816a8f3",
       "name": "@platos/context-agents",
       "ociImageClosure": {
@@ -55243,7 +55321,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 419
+              "line": 446
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -55994,7 +56072,7 @@
           "packages/contexts/channels"
         ]
       },
-      "evidenceSha256": "0bb42dcc810ca423c549e45857128f11e112322ef67ee0bc70cd8eb861ed97db",
+      "evidenceSha256": "96cf4cc0a46efdaaf22a069015cbe10d11883caa4a22d987e8165d1112b3b682",
       "manifestSha256": "83395ffe4b76070f9efb7bd1bb4b49d7228aea090069f569a5eec747aa98ab74",
       "name": "@platos/context-channels",
       "ociImageClosure": {
@@ -56118,7 +56196,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 468
+              "line": 495
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -57012,7 +57090,7 @@
           "packages/contexts/conversations"
         ]
       },
-      "evidenceSha256": "049150a8c4bd5147edd5f51d1bccad8c539fc27ab9c7cbef1f9a53c41e9c3f34",
+      "evidenceSha256": "d1ef1c342e792bd65eb542dc330bd143895be5c7fb1ccf8c10c1ebbd44f30633",
       "manifestSha256": "218c32b5c5b423bdf39bf215d6365c07bbd746fca291a1b0609da87e2cebd4d8",
       "name": "@platos/context-conversations",
       "ociImageClosure": {
@@ -57202,7 +57280,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 407
+              "line": 434
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -58105,7 +58183,7 @@
           "packages/contexts/cost-monitoring"
         ]
       },
-      "evidenceSha256": "3305e2710eff4e87c5a419657c78bc5a23acd33599dc46d1f957ee7bd4909481",
+      "evidenceSha256": "6df445267624012fa4ba493eeec23b14c7869d222ae16280717da5502c5662c8",
       "manifestSha256": "2e327d74bea9a17116d859d643836bc142e0977bd86d3a96567638fb75c7b3bb",
       "name": "@platos/context-cost-monitoring",
       "ociImageClosure": {
@@ -58229,7 +58307,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 553
+              "line": 580
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -58961,7 +59039,7 @@
           "packages/contexts/eventing"
         ]
       },
-      "evidenceSha256": "2d52d800c43ce7d7dde0b0d39a1e303ba904cd3a7d5ca679243a63a95273726d",
+      "evidenceSha256": "ad6fbf5e9a40d86d61210eafd8fbf6de4f4bee9a978fd1c1319ed81ebd191cf5",
       "manifestSha256": "57c1d00c9dc67970acaec3dc30138bbd18273e9d303ea3804f6a13ab6a2d012a",
       "name": "@platos/context-eventing",
       "ociImageClosure": {
@@ -59201,7 +59279,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 528
+              "line": 555
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -60152,7 +60230,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "14480179fc3cfff3744ae24dfd2b2d0bc8b33e55f22b03f53f4af89cdb691115",
+      "evidenceSha256": "9657068712e1b56d3a44bcfb764857ef4a2c453a2249e108179d2cbb363839f2",
       "manifestSha256": "39fe0424b871775bb785e2d759c32cd0e833a9cf71c9934313d397ca699950ca",
       "name": "@platos/context-files",
       "ociImageClosure": {
@@ -60276,7 +60354,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 430
+              "line": 457
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -61378,7 +61456,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "56bebaf112bec33631207a1b54b330bb9d23fd2f10c169ad0aced8748e01e8ab",
+      "evidenceSha256": "17ad454527ffdb3eea6cdd79211b0e2b665b5915c0b78c8569bd7af6a13d279f",
       "manifestSha256": "2e4c46079d53cec680be1e27cbc15aed896688935706c604462aef1db775b330",
       "name": "@platos/context-governance",
       "ociImageClosure": {
@@ -62152,7 +62230,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 380
+              "line": 407
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -64093,7 +64171,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "90ba0699da23f6a582bd21945ad09501c4b7a5747521a272deaadeba40044444",
+      "evidenceSha256": "caa61f1be990b061144b68966341a89711921c141bd09c52709a86cde23532a9",
       "manifestSha256": "df554d7bb17a6aab26b8ff63eb9c6033d16e186a234ad9d69c52d1eca7edf146",
       "name": "@platos/context-identity-access",
       "ociImageClosure": {
@@ -64261,7 +64339,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 517
+              "line": 544
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -65141,7 +65219,7 @@
           "packages/contexts/jobs"
         ]
       },
-      "evidenceSha256": "04b8c06f76a76aa4007cedd2e98a987932a158259bbe390e8ded6d4830862a94",
+      "evidenceSha256": "bf05fcba4969e76cb58cc37fd6ce5c9ab31af07797a23bc75643acb5bf76c4c7",
       "manifestSha256": "da3cc481236d02e85484094c0def2d6fc84c838c3c285f44efe4619a6c26e08c",
       "name": "@platos/context-jobs",
       "ociImageClosure": {
@@ -65309,7 +65387,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 489
+              "line": 516
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -66351,7 +66429,7 @@
           "packages/contexts/memory"
         ]
       },
-      "evidenceSha256": "8e6d5ed3dd6d409322959a5393f72ba47596a65a7ea1d09d8e806a8206dddfce",
+      "evidenceSha256": "74d7cb157f7a5ee96ced0251e9915de4527f07cac4c75de6293adaa6b14df6b0",
       "manifestSha256": "d596af2fb68e3e6c3622cf1cfb1683e20f46b5fac434d3f8cd6bf37df74d5b28",
       "name": "@platos/context-memory",
       "ociImageClosure": {
@@ -66497,7 +66575,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 541
+              "line": 568
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -67174,7 +67252,7 @@
           "packages/contexts/observability"
         ]
       },
-      "evidenceSha256": "be0eb82f5a0097c435c59f562e11e720b91a226514eb6839d3aebf3ade2e03b0",
+      "evidenceSha256": "0da65b6f10ba2dd12c97e0e15ff8e1cd2b8a6a311180300c5d2162dc14a5546b",
       "manifestSha256": "09d858b658a326451d6bdd026af44df9ba5d1b195ce0c71deffc0cb972afc6d7",
       "name": "@platos/context-observability",
       "ociImageClosure": {
@@ -67298,7 +67376,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 504
+              "line": 531
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -68004,7 +68082,7 @@
           "packages/contexts/privacy"
         ]
       },
-      "evidenceSha256": "daa04312bf7fa2bc6069bddc0786d8452079bb16e1991b518e15763213a7dd6b",
+      "evidenceSha256": "85d24065fc8946877d1d383a8d7e6a30a7df6289be3a6a641861ba8da1e856f6",
       "manifestSha256": "8d9032044280327b5d3d795c13039f78e41ca275c9d6bce9f093b794a97473f1",
       "name": "@platos/context-privacy",
       "ociImageClosure": {
@@ -68382,7 +68460,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 454
+              "line": 481
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -70001,7 +70079,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "4dec15dc3529544ce4ee0f8b78ae401580339f7402535680888f56b4f23cd863",
+      "evidenceSha256": "a300db6c7fa2c9a6ed2604b994aca99ccbc139e331a6e0561f9176899dc55172",
       "manifestSha256": "7462dcd3934c960646a6d3528915863411b9e195545de995cb54d10e6c43da83",
       "name": "@platos/context-providers",
       "ociImageClosure": {
@@ -70439,7 +70517,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 441
+              "line": 468
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -72009,7 +72087,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "066087de35b51a6c471c100c6c142c34aa4d98feb0458d5333da6c4bd92b2a5c",
+      "evidenceSha256": "ba5ad14ff93b253c1eff370bffccf3258723a13b53e4b52b3be247882219b02f",
       "manifestSha256": "03739f55f9812a44e47b5c9175c9ebb610f9448ba48bf906432c70796ecc3c03",
       "name": "@platos/context-secrets",
       "ociImageClosure": {
@@ -72201,7 +72279,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 478
+              "line": 505
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -73115,7 +73193,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "3d5858811c3f053af69267fe6272e9910e992b34ab2f79e2169bada1ecdcdcea",
+      "evidenceSha256": "b15c5f629eb3f67b4181791ef5d11da9c4f912e14af6239833755171ccc8823d",
       "manifestSha256": "f1e56a67ae6b3d846f0887d8a17048ad19d4e0356bf7f38d1056b58507a2e7e2",
       "name": "@platos/context-skills",
       "ociImageClosure": {
@@ -73743,7 +73821,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 373
+              "line": 400
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -75945,7 +76023,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "64096cb2bb5359abf89f86ecf7d38cb182153fcb9f3cb00069b70d6e78f2c4d5",
+      "evidenceSha256": "5fc4e1d012bf8e5723dc896c6dd389e00f2cedd152880d9f9d80a75bce05f9ad",
       "manifestSha256": "552444b4f4df12b062f2eb788b926946ca8310d37b21721f111e9995e78b2a94",
       "name": "@platos/context-tenancy",
       "ociImageClosure": {
@@ -76117,7 +76195,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 384
+              "line": 411
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -77086,7 +77164,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "5034719ef4d8cc948d5e00e0d8e75bd7eff53d5a4bba8866136a5de2f915c4a2",
+      "evidenceSha256": "7ff41380bbb34e426e95eac7589a71f607d228a4d9899ae22c0c782f33fe5730",
       "manifestSha256": "87996481926b67e29a649aad1f8de452892ea7a0c07fa8f694e70a63420d490b",
       "name": "@platos/context-tools",
       "ociImageClosure": {
@@ -77143,7 +77221,7 @@
             {
               "from": ".github/workflows/ci.yml",
               "kind": "reference",
-              "line": 317
+              "line": 344
             },
             {
               "from": ".github/workflows/trigger-deploy.yml",
@@ -78731,7 +78809,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "c7530a26bb5af29c73d80576d557b854aacc72201b9cc3c29507253fc891e581",
+      "evidenceSha256": "be91b34605aa3b0c255d52d183f91ec2eef74ea09b84474b318a420ab8194c1e",
       "manifestSha256": "8481fd56fdf96c180ba38c5aec5dc5fb6e023cb5f99dfe2a1d97577a634cfcf7",
       "name": "@platos/core",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.json
+++ b/docs/audits/win-253-workspace-reachability.json
@@ -22,7 +22,7 @@
     "repositoryDev": "OCI image roots plus devDependencies",
     "workspaceRegistration": "filesystem package.json paths matched by pnpm-workspace.yaml, exact-set checked against lockfile importers"
   },
-  "evidenceSha256": "9f071c3944b1c9a646066c6d6dc1d3afd015d12a179e0d95335b40bc6fe4e302",
+  "evidenceSha256": "3b40746a8b4fad9f150f7565c6fb52c55a6e15d1f69df98963d2d358d4d7e471",
   "generatedOwnership": {
     "explicitHeaderFileCount": 24,
     "generatedProjectCount": 39,
@@ -115,7 +115,7 @@
     ]
   },
   "inputs": {
-    "aggregateSha256": "8ee6dfdc412696acce6ce15a081c5aa1007ccda81e5cf1cec0093abce7bea76f",
+    "aggregateSha256": "9049ec621ee05ba900390b842b86d808dec1d5e0362fbfdd19a0273fcf3815fc",
     "files": [
       {
         "path": ".changeset/README.md",
@@ -1095,7 +1095,7 @@
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-entity.controller.test.ts",
-        "sha256": "e1cd3384ffc16f2810df931b2a8896a6b56d64c93e28a039ba82973742bfcc87"
+        "sha256": "e7c13e101e9269e5964aac72681ea41a4f5cb00c20ce62131b7e054bf6523b4e"
       },
       {
         "path": "apps/agent/src/mcp-platform/mcp-entity.controller.ts",
@@ -6343,7 +6343,7 @@
       },
       {
         "path": "docs/v1-ledger-rules.json",
-        "sha256": "1b90cde040fc4871c1f53b291d78f60b40ea87164d0defb5df41903b0cea7733"
+        "sha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c"
       },
       {
         "path": "docs/v3-openapi.yaml",
@@ -19923,7 +19923,7 @@
       },
       {
         "path": "scripts/arch/arch-boundaries.test.mjs",
-        "sha256": "9a50063eb208361918d84d96207bd280e778f4df60c7a98676679f97439e5b8a"
+        "sha256": "4325d4b895582330cabff55449c11a472d5ed04f38bf62fd6c1d86b8d941eea2"
       },
       {
         "path": "scripts/arch/boundary-rules.mjs",
@@ -20230,6 +20230,10 @@
         "sha256": "1e2861996059218682dd16a1e281b7d7f80ade264d6e4e71c915520d24090b51"
       },
       {
+        "path": "scripts/mutations-win268-p2.json",
+        "sha256": "97d4eb41bd32cddc0abeb09ca9bd13a0b6939d13c8795f21db0ab867b4d3be1f"
+      },
+      {
         "path": "scripts/openapi-compat.mjs",
         "sha256": "b90270c0ea3ce9cfaf29ce8996b0fb4500fab4b506c87ddeae59e099cb906bac"
       },
@@ -20319,7 +20323,7 @@
       },
       {
         "path": "scripts/v1-ledger.test.mjs",
-        "sha256": "eba09758e6ac4b3c96fff8901e6c5582658df7dc1da81aec236bbdd47d38a17b"
+        "sha256": "078df8ba8aa0a0ef81aed8bf8567723a9380d8f767c08e09a2b75ed5edd551c1"
       },
       {
         "path": "scripts/vendored-build-audit.mjs",
@@ -26329,7 +26333,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 538
+              "line": 558
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -26621,7 +26625,7 @@
           "apps/core-api"
         ]
       },
-      "evidenceSha256": "6bbdb7f8ef73c1a6db90eb65088f8a09c24cd066dfdd76d4a16e90315ed111e2",
+      "evidenceSha256": "aadfd6c8a47dd3bf37372ef609ea64c4f3fda2598e48db53a41a603f7cdb50c6",
       "manifestSha256": "8f069781279f60d7e3e5f0fdb9c952dff23d79800a8494c9a97e43672c007e26",
       "name": "@platos/core-api",
       "ociImageClosure": {
@@ -26994,7 +26998,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 687
+              "line": 707
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -27106,7 +27110,7 @@
           "apps/mcp-stdio"
         ]
       },
-      "evidenceSha256": "32beed94186c0b194df79cef4fcd579026bf037272312b8a2d8fce44091e34ad",
+      "evidenceSha256": "4b0f1b69245f4963f59a3371950dd1c9af8bf874f5e2cea7fa81b512f146cdaf",
       "manifestSha256": "c9bb318e0946a79c6a4572d2c852f7ac414cb361c6dab2e34c5543dcefcc00a3",
       "name": "@platos/mcp-stdio",
       "ociImageClosure": {
@@ -38655,7 +38659,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1969
+              "line": 2000
             }
           ],
           "reversePaths": [
@@ -38680,7 +38684,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "800672b71892e7511fc1a0d3640ff834e6d9c4691fe8ec7a5549fbbbe1621dda",
+      "evidenceSha256": "6238c28a78adc55e38cb9691b4d266a19fb83d42b9d8049552a7367fcbc513b2",
       "manifestSha256": "273951969710da5e07cfbb09885f792bbc938df2dfe3aed8d8e480438e113753",
       "name": "@platos/otlp-importer",
       "ociImageClosure": {
@@ -39821,7 +39825,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1968
+              "line": 1999
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -40046,7 +40050,7 @@
         "reversePaths": [],
         "roots": []
       },
-      "evidenceSha256": "37219fac5b221f252bfde6e4b6817c6fd6cbb61679ffb5ce659dc180bf789095",
+      "evidenceSha256": "01d8cb6d6dbe2d655bd036b97eaca7086d1e421dd09ec09dc1c71fe919cdffe1",
       "manifestSha256": "5e3c30277d328e92c5781a7be8a60a9de1f5ab81898649bcd150b0ce5f3b48ab",
       "name": "@internal/run-engine",
       "ociImageClosure": {
@@ -42065,7 +42069,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1263
+              "line": 1283
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -42832,7 +42836,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "56a47de29edcfbae5f51935a80630d25517d1d0adcffddaee4d48302ecdc820a",
+      "evidenceSha256": "b6fcadccd2a3747fc3df91c59c7be51781dc7a113f1d8e57b8a971c5ae80115d",
       "manifestSha256": "22bd55003e357c1af7df013be8c2b416898d3b19fd4b38c763ffd701fb7e9de1",
       "name": "@platos/tenancy-database",
       "ociImageClosure": {
@@ -47292,7 +47296,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1135
+              "line": 1155
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -47451,7 +47455,7 @@
           "packages/adapters/keyring-envelope"
         ]
       },
-      "evidenceSha256": "ff9852fc2234b7766e8f33b75f5981c6532fd3a29bfa2a6c01d79c259ce4509b",
+      "evidenceSha256": "f93fd86196409e5ea98936c0acbd9f5c5ecf40a00206ef854c8d933bd40362de",
       "manifestSha256": "ae371bc6b627e6693e9a7b45f6a789d1df3f4489f8b93db1ed61c9c2fefdd854",
       "name": "@platos/adapter-keyring-envelope",
       "ociImageClosure": {
@@ -47864,7 +47868,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 837
+              "line": 857
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -48043,7 +48047,7 @@
           "packages/adapters/model-router-providers"
         ]
       },
-      "evidenceSha256": "399b4d87b049a3a3aa445a47b2b67b16f7909f6f02cb17a608e0c8e5a36083bf",
+      "evidenceSha256": "97d2d7396c4ffaba948711762b9d11b6bed112ee10e693243ec7e2e4e19cf82a",
       "manifestSha256": "eaa4ecedce49dc05224e2c4b7982274d371f8fb27a60a9783fa643a8f6defcbd",
       "name": "@platos/adapter-model-router-providers",
       "ociImageClosure": {
@@ -48366,7 +48370,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1230
+              "line": 1250
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -48465,7 +48469,7 @@
           "packages/adapters/node-crypto-digest"
         ]
       },
-      "evidenceSha256": "de09705b8d739ffb777220975a2393a6719c61dd5831f2706e871d0fa9b75be3",
+      "evidenceSha256": "70184e1eff19482754772f8176840a37c0e164a192bd7a260772ff838fe68008",
       "manifestSha256": "229fe0120b22a0df9fb190c46ea80e762a3efc68e6e509531147796557ea58ce",
       "name": "@platos/adapter-node-crypto-digest",
       "ociImageClosure": {
@@ -49975,7 +49979,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 951
+              "line": 971
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -50119,7 +50123,7 @@
           "packages/adapters/outbox"
         ]
       },
-      "evidenceSha256": "f20a132de5e8ea601e8fcef53e497e45e9b82f563a036b5fe8136c0f4edbc59a",
+      "evidenceSha256": "5b9fd78f761760c6454aa804b0f0a8501eaa53d6f7065e0652da1f0991132f7c",
       "manifestSha256": "83a45d455aac9f0e888c1045ad4b91d9111960486ba77a4a087018299d5941b2",
       "name": "@platos/adapter-outbox",
       "ociImageClosure": {
@@ -51273,7 +51277,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 883
+              "line": 903
             },
             {
               "from": "scripts/vocabulary-boundary.test.mjs",
@@ -52157,7 +52161,7 @@
           "packages/adapters/postgres-tenancy"
         ]
       },
-      "evidenceSha256": "9d005f363f887bfd439b3e4b90ad2775222ec974c8876d2e88746d435f94dc96",
+      "evidenceSha256": "f2dfec61e8164a7b15f663be2c21985917a2de26a797ec333cd3b7905fe44a44",
       "manifestSha256": "c3c49b3941820594e187dcbb86c78001443c58add67ce25009e535c3f1374927",
       "name": "@platos/adapter-postgres-tenancy",
       "ociImageClosure": {
@@ -52566,7 +52570,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 610
+              "line": 630
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -52720,7 +52724,7 @@
           "packages/adapters/redis-cache"
         ]
       },
-      "evidenceSha256": "130ade2b2259ab28cf65782f45572e7e7aa73c02fc5701de4f836d70ea39568f",
+      "evidenceSha256": "c7e728b7dda2c5267990df8d6be2c3c2556a4c9c4219347b87b54d24a14422dc",
       "manifestSha256": "28d8382e77863b7c6b09e45dbccdcb4dd2e5d292e3dcdef574a37a2e21dac28d",
       "name": "@platos/adapter-redis-cache",
       "ociImageClosure": {
@@ -53074,7 +53078,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1233
+              "line": 1253
             }
           ],
           "reversePaths": [
@@ -53188,7 +53192,7 @@
           "packages/adapters/redis-ratelimit"
         ]
       },
-      "evidenceSha256": "bb78096d45becd05c4511603a8e3869674e32c4d8701e9534ad5463f148b2811",
+      "evidenceSha256": "b23b3ebe6d0a075f086dfc5d4f74e3d8a3754597481fdd5b649198ed7a3b9c19",
       "manifestSha256": "c34050bbafd7dbb339e9a1a8dabffc4ab2ab84203fc1f1739d9045c883563955",
       "name": "@platos/adapter-redis-ratelimit",
       "ociImageClosure": {
@@ -53921,7 +53925,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1231
+              "line": 1251
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -54045,7 +54049,7 @@
           "packages/adapters/tokenmint-totp"
         ]
       },
-      "evidenceSha256": "7fb60a58dfb631b8fab5fe2247e047278401c9a74c58b64f2be98c7fae581e29",
+      "evidenceSha256": "74278c10afe4135646974d477431c80ebfd8a25e78dbdf3b2ce5e17b76e15f3d",
       "manifestSha256": "6786de357df47e9fb13ec8d4c69ca91bb24c9ee6c47ebc7aa5565fa77883979b",
       "name": "@platos/adapter-tokenmint-totp",
       "ociImageClosure": {
@@ -54845,7 +54849,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1015
+              "line": 1035
             }
           ],
           "reversePaths": [
@@ -55175,7 +55179,7 @@
           "packages/contexts/governance"
         ]
       },
-      "evidenceSha256": "fcc7ab274370a50aeafc024c897ae4ab7e1481144e02446884759fc8b85f3246",
+      "evidenceSha256": "42dfc82169a137a2364ac692590e3b5523e68f8646655e4a98982ce4e71e5f93",
       "manifestSha256": "e43db9efa534960ba5ade2f86cf89a88453e7575222d56297d6b6ccfe816a8f3",
       "name": "@platos/context-agents",
       "ociImageClosure": {
@@ -55829,7 +55833,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 783
+              "line": 803
             }
           ],
           "reversePaths": [
@@ -56072,7 +56076,7 @@
           "packages/contexts/channels"
         ]
       },
-      "evidenceSha256": "96cf4cc0a46efdaaf22a069015cbe10d11883caa4a22d987e8165d1112b3b682",
+      "evidenceSha256": "f4f04f312ca6b4d11e4ee26722519c1da2d13e01bfd438fcf06ebfe880316864",
       "manifestSha256": "83395ffe4b76070f9efb7bd1bb4b49d7228aea090069f569a5eec747aa98ab74",
       "name": "@platos/context-channels",
       "ociImageClosure": {
@@ -56779,7 +56783,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 875
+              "line": 895
             }
           ],
           "reversePaths": [
@@ -57090,7 +57094,7 @@
           "packages/contexts/conversations"
         ]
       },
-      "evidenceSha256": "d1ef1c342e792bd65eb542dc330bd143895be5c7fb1ccf8c10c1ebbd44f30633",
+      "evidenceSha256": "65c273dca4e7220a9c895889f656bd4d365218671d3822cb525ebfb02f4d0d68",
       "manifestSha256": "218c32b5c5b423bdf39bf215d6365c07bbd746fca291a1b0609da87e2cebd4d8",
       "name": "@platos/context-conversations",
       "ociImageClosure": {
@@ -58818,7 +58822,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 706
+              "line": 726
             }
           ],
           "reversePaths": [
@@ -59039,7 +59043,7 @@
           "packages/contexts/eventing"
         ]
       },
-      "evidenceSha256": "ad6fbf5e9a40d86d61210eafd8fbf6de4f4bee9a978fd1c1319ed81ebd191cf5",
+      "evidenceSha256": "476e6cffecbaa165a09c7a6772422390799f7fde6c1b001d4e001db9b4da2211",
       "manifestSha256": "57c1d00c9dc67970acaec3dc30138bbd18273e9d303ea3804f6a13ab6a2d012a",
       "name": "@platos/context-eventing",
       "ociImageClosure": {
@@ -59878,7 +59882,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1495
+              "line": 1515
             }
           ],
           "reversePaths": [
@@ -60230,7 +60234,7 @@
           "packages/contexts/skills"
         ]
       },
-      "evidenceSha256": "9657068712e1b56d3a44bcfb764857ef4a2c453a2249e108179d2cbb363839f2",
+      "evidenceSha256": "0adca67ca8b14c0e906e0cf6aba0734dbebc9cb51b3a15e72d418de6e2496a5b",
       "manifestSha256": "39fe0424b871775bb785e2d759c32cd0e833a9cf71c9934313d397ca699950ca",
       "name": "@platos/context-files",
       "ociImageClosure": {
@@ -64924,7 +64928,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1494
+              "line": 1514
             }
           ],
           "reversePaths": [
@@ -65219,7 +65223,7 @@
           "packages/contexts/jobs"
         ]
       },
-      "evidenceSha256": "bf05fcba4969e76cb58cc37fd6ce5c9ab31af07797a23bc75643acb5bf76c4c7",
+      "evidenceSha256": "f72c6748aba7bf382b7bb0fb6dc19315d8ed7b162511ca08aaf91d5d0137ab93",
       "manifestSha256": "da3cc481236d02e85484094c0def2d6fc84c838c3c285f44efe4619a6c26e08c",
       "name": "@platos/context-jobs",
       "ociImageClosure": {
@@ -67014,7 +67018,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 750
+              "line": 770
             }
           ],
           "reversePaths": [
@@ -67252,7 +67256,7 @@
           "packages/contexts/observability"
         ]
       },
-      "evidenceSha256": "0da65b6f10ba2dd12c97e0e15ff8e1cd2b8a6a311180300c5d2162dc14a5546b",
+      "evidenceSha256": "af89ab3e61d6fe3441387901c1d7b650563e8ddc1f135c1dead4a1ae82334afb",
       "manifestSha256": "09d858b658a326451d6bdd026af44df9ba5d1b195ce0c71deffc0cb972afc6d7",
       "name": "@platos/context-observability",
       "ociImageClosure": {
@@ -67861,7 +67865,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 743
+              "line": 763
             }
           ],
           "reversePaths": [
@@ -68082,7 +68086,7 @@
           "packages/contexts/privacy"
         ]
       },
-      "evidenceSha256": "85d24065fc8946877d1d383a8d7e6a30a7df6289be3a6a641861ba8da1e856f6",
+      "evidenceSha256": "6e62e814aa88d2fb53720461fb1d392d21a0e84592d673819d7335437d58d7da",
       "manifestSha256": "8d9032044280327b5d3d795c13039f78e41ca275c9d6bce9f093b794a97473f1",
       "name": "@platos/context-privacy",
       "ociImageClosure": {
@@ -69459,7 +69463,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 829
+              "line": 849
             }
           ],
           "reversePaths": [
@@ -70079,7 +70083,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "a300db6c7fa2c9a6ed2604b994aca99ccbc139e331a6e0561f9176899dc55172",
+      "evidenceSha256": "2b356542a821ee7e4c3fdf32fe26faeb37f5747be8d5bf8071454090c6c5fac3",
       "manifestSha256": "7462dcd3934c960646a6d3528915863411b9e195545de995cb54d10e6c43da83",
       "name": "@platos/context-providers",
       "ociImageClosure": {
@@ -71422,7 +71426,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1111
+              "line": 1131
             }
           ],
           "reversePaths": [
@@ -72087,7 +72091,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "ba5ad14ff93b253c1eff370bffccf3258723a13b53e4b52b3be247882219b02f",
+      "evidenceSha256": "e535ff2c763f022cb14d9fdb6b2878dac27e51f7a0e6067c83508932ddac2260",
       "manifestSha256": "03739f55f9812a44e47b5c9175c9ebb610f9448ba48bf906432c70796ecc3c03",
       "name": "@platos/context-secrets",
       "ociImageClosure": {
@@ -76850,7 +76854,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 1356
+              "line": 1376
             }
           ],
           "reversePaths": [
@@ -77164,7 +77168,7 @@
           "packages/contexts/tools"
         ]
       },
-      "evidenceSha256": "7ff41380bbb34e426e95eac7589a71f607d228a4d9899ae22c0c782f33fe5730",
+      "evidenceSha256": "e7efc3edbb4c989ef22971918b7df5fb301fa9845dfee61ff55bdbd6a3a974d4",
       "manifestSha256": "87996481926b67e29a649aad1f8de452892ea7a0c07fa8f694e70a63420d490b",
       "name": "@platos/context-tools",
       "ociImageClosure": {
@@ -87934,7 +87938,7 @@
             {
               "from": "scripts/v1-ledger.test.mjs",
               "kind": "reference",
-              "line": 563
+              "line": 583
             },
             {
               "from": "scripts/workspace-reachability.test.mjs",
@@ -90030,7 +90034,7 @@
           "packages/kernel"
         ]
       },
-      "evidenceSha256": "6f2b26de9c4c05e15fef1d0d9468c81d9300f84bca8b2dcd6c8081f16d64c075",
+      "evidenceSha256": "35f7d0caa342dffb2a1abd80fbe845e5040a9904f8c6d11e00603f0c5efef0aa",
       "manifestSha256": "4f315c3595455a1866bf39b540a93c4e447888035d3c5a445fc0bbf836219212",
       "name": "@platos/kernel",
       "ociImageClosure": {

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `9f071c3944b1c9a646066c6d6dc1d3afd015d12a179e0d95335b40bc6fe4e302`
+Evidence SHA-256: `3b40746a8b4fad9f150f7565c6fb52c55a6e15d1f69df98963d2d358d4d7e471`
 
 ## Baseline
 
@@ -40,8 +40,8 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | Workspace | Package | OCI | App/deployable | Union | OCI+dev | Candidate status | Public boundary | Owner decision | Evidence hash |
 | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
 | `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `1e29ccb1cb423fd7…` |
-| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `6bbdb7f8ef73c1a6…` |
-| `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `32beed94186c0b19…` |
+| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `aadfd6c8a47dd3bf…` |
+| `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `4b0f1b69245f4963…` |
 | `apps/webapp` | `webapp` | yes | yes | yes | yes | retain-oci-image | no | no | `6d0671f708e83e8a…` |
 | `docs` | `docs` | no | no | no | no | owner-review-repository-referenced | no | yes | `36274c9b2ae74fa1…` |
 | `internal-packages/cache` | `@internal/cache` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9f2db1155272a42…` |
@@ -51,11 +51,11 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
-| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `800672b71892e751…` |
+| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `6238c28a78adc55e…` |
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f0e0a0052870d59…` |
-| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `37219fac5b221f25…` |
+| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `01d8cb6d6dbe2d65…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
-| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `56a47de29edcfbae…` |
+| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `b6fcadccd2a3747f…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
 | `internal-packages/testcontainers` | `@internal/testcontainers` | no | no | no | yes | owner-review-repository-referenced | no | yes | `d1195473580e2ad7…` |
 | `internal-packages/tracing` | `@internal/tracing` | no | no | no | no | owner-review-repository-referenced | no | yes | `e03f6256d2d15deb…` |
@@ -64,37 +64,37 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/adapters/channel-slack` | `@platos/adapter-channel-slack` | no | yes | yes | no | retain-application-deployable | no | no | `29b17950af01fa36…` |
 | `packages/adapters/clickhouse-observability` | `@platos/adapter-clickhouse-observability` | no | yes | yes | no | retain-application-deployable | no | no | `90b03e040b6b4b30…` |
 | `packages/adapters/durable-runtime` | `@platos/adapter-durable-runtime` | no | yes | yes | no | retain-application-deployable | no | no | `923006eb949fcddc…` |
-| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `ff9852fc2234b776…` |
-| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `399b4d87b049a3a3…` |
-| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `de09705b8d739ffb…` |
+| `packages/adapters/keyring-envelope` | `@platos/adapter-keyring-envelope` | no | yes | yes | no | retain-application-deployable | no | no | `f93fd86196409e5e…` |
+| `packages/adapters/model-router-providers` | `@platos/adapter-model-router-providers` | no | yes | yes | no | retain-application-deployable | no | no | `97d2d7396c4ffaba…` |
+| `packages/adapters/node-crypto-digest` | `@platos/adapter-node-crypto-digest` | no | yes | yes | no | retain-application-deployable | no | no | `70184e1eff194827…` |
 | `packages/adapters/notifier-email` | `@platos/adapter-notifier-email` | no | yes | yes | no | retain-application-deployable | no | no | `214dcdfb7915d520…` |
 | `packages/adapters/notifier-webhook` | `@platos/adapter-notifier-webhook` | no | yes | yes | no | retain-application-deployable | no | no | `fde9eb07ee1d6e4c…` |
 | `packages/adapters/objectstore-minio` | `@platos/adapter-objectstore-minio` | no | yes | yes | no | retain-application-deployable | no | no | `fb582cbf0e1ab339…` |
-| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `f20a132de5e8ea60…` |
-| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `9d005f363f887bfd…` |
-| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `130ade2b2259ab28…` |
-| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `bb78096d45becd05…` |
+| `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `5b9fd78f761760c6…` |
+| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `f2dfec61e8164a7b…` |
+| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `c7e728b7dda2c526…` |
+| `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `b23b3ebe6d0a075f…` |
 | `packages/adapters/redis-streams` | `@platos/adapter-redis-streams` | no | yes | yes | no | retain-application-deployable | no | no | `26a3c07d7a0ee3e3…` |
-| `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `7fb60a58dfb631b8…` |
-| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `fcc7ab274370a50a…` |
-| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `96cf4cc0a46efdaa…` |
-| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `d1ef1c342e792bd6…` |
+| `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `74278c10afe41356…` |
+| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `42dfc82169a137a2…` |
+| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `f4f04f312ca6b4d1…` |
+| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `65c273dca4e7220a…` |
 | `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `6df445267624012f…` |
-| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `ad6fbf5e9a40d86d…` |
-| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `9657068712e1b56d…` |
+| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `476e6cffecbaa165…` |
+| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `0adca67ca8b14c0e…` |
 | `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `17ad454527ffdb3e…` |
 | `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `caa61f1be990b061…` |
-| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `bf05fcba4969e76c…` |
+| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `f72c6748aba7bf38…` |
 | `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `74d7cb157f7a5ee9…` |
-| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `0da65b6f10ba2dd1…` |
-| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `85d24065fc894687…` |
-| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `a300db6c7fa2c9a6…` |
-| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `ba5ad14ff93b253c…` |
+| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `af89ab3e61d6fe34…` |
+| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `6e62e814aa88d2fb…` |
+| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `2b356542a821ee7e…` |
+| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `e535ff2c763f022c…` |
 | `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `b15c5f629eb3f67b…` |
 | `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `5fc4e1d012bf8e57…` |
-| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `7ff41380bbb34e42…` |
+| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `e7efc3edbb4c989e…` |
 | `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `be91b34605aa3b0c…` |
-| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `6f2b26de9c4c05e1…` |
+| `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `35f7d0caa342dffb…` |
 | `packages/platools-js` | `@platosdev/platools-sdk` | no | no | no | no | owner-review-public-boundary | yes | yes | `15e7a149a5ce15ca…` |
 | `packages/platos-client` | `@platosdev/client` | no | no | no | no | owner-review-public-boundary | yes | yes | `3c3aaec9b962238c…` |
 | `packages/platos-embed` | `@platosdev/embed` | no | no | no | no | owner-review-public-boundary | yes | yes | `26f83fd504a22a2c…` |

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `3b40746a8b4fad9f150f7565c6fb52c55a6e15d1f69df98963d2d358d4d7e471`
+Evidence SHA-256: `66e8b88146c6921a4a999cd19e8145a3c9026171199b67faa62ba00fd6bbb838`
 
 ## Baseline
 

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `e05000e4ea50912e9bbc3d4aefc8f8501d4fe2094a5395fd1b147b460dd0b389`
+Evidence SHA-256: `9f071c3944b1c9a646066c6d6dc1d3afd015d12a179e0d95335b40bc6fe4e302`
 
 ## Baseline
 
@@ -39,15 +39,15 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 
 | Workspace | Package | OCI | App/deployable | Union | OCI+dev | Candidate status | Public boundary | Owner decision | Evidence hash |
 | --- | --- | ---: | ---: | ---: | ---: | --- | ---: | ---: | --- |
-| `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `2a7d2ca2225dca4b…` |
-| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `15cc4539e9d92071…` |
+| `apps/agent` | `platos-agent` | yes | yes | yes | yes | retain-oci-image | no | no | `1e29ccb1cb423fd7…` |
+| `apps/core-api` | `@platos/core-api` | no | yes | yes | no | retain-application-deployable | no | no | `6bbdb7f8ef73c1a6…` |
 | `apps/mcp-stdio` | `@platos/mcp-stdio` | no | yes | yes | no | retain-application-deployable | no | no | `32beed94186c0b19…` |
 | `apps/webapp` | `webapp` | yes | yes | yes | yes | retain-oci-image | no | no | `6d0671f708e83e8a…` |
 | `docs` | `docs` | no | no | no | no | owner-review-repository-referenced | no | yes | `36274c9b2ae74fa1…` |
 | `internal-packages/cache` | `@internal/cache` | no | no | no | no | owner-review-repository-referenced | no | yes | `f9f2db1155272a42…` |
 | `internal-packages/compute` | `@internal/compute` | no | no | no | no | owner-review-repository-referenced | no | yes | `744fd4bd20e8d379…` |
 | `internal-packages/cost-rates` | `@internal/cost-rates` | no | no | no | no | owner-review-repository-referenced | no | yes | `6164efe052d457dc…` |
-| `internal-packages/database` | `@platos/database` | no | no | no | yes | owner-review-repository-referenced | no | yes | `4ffb8d3236efdc96…` |
+| `internal-packages/database` | `@platos/database` | no | no | no | yes | owner-review-repository-referenced | no | yes | `68cb9366ff413f35…` |
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
@@ -55,11 +55,11 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f0e0a0052870d59…` |
 | `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `37219fac5b221f25…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
-| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `85a529f4000b7dad…` |
+| `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `56a47de29edcfbae…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |
-| `internal-packages/testcontainers` | `@internal/testcontainers` | no | no | no | yes | owner-review-repository-referenced | no | yes | `189bf7b03e402e7e…` |
+| `internal-packages/testcontainers` | `@internal/testcontainers` | no | no | no | yes | owner-review-repository-referenced | no | yes | `d1195473580e2ad7…` |
 | `internal-packages/tracing` | `@internal/tracing` | no | no | no | no | owner-review-repository-referenced | no | yes | `e03f6256d2d15deb…` |
-| `internal-packages/workload-identity` | `@internal/workload-identity` | yes | yes | yes | yes | retain-oci-image | no | no | `5fa8daec9d44c8b4…` |
+| `internal-packages/workload-identity` | `@internal/workload-identity` | yes | yes | yes | yes | retain-oci-image | no | no | `7dfa9764cf78a9ff…` |
 | `internal-packages/zod-worker` | `@internal/zod-worker` | no | no | no | no | owner-review-repository-referenced | no | yes | `86a5ee29b9046270…` |
 | `packages/adapters/channel-slack` | `@platos/adapter-channel-slack` | no | yes | yes | no | retain-application-deployable | no | no | `29b17950af01fa36…` |
 | `packages/adapters/clickhouse-observability` | `@platos/adapter-clickhouse-observability` | no | yes | yes | no | retain-application-deployable | no | no | `90b03e040b6b4b30…` |
@@ -71,29 +71,29 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `packages/adapters/notifier-webhook` | `@platos/adapter-notifier-webhook` | no | yes | yes | no | retain-application-deployable | no | no | `fde9eb07ee1d6e4c…` |
 | `packages/adapters/objectstore-minio` | `@platos/adapter-objectstore-minio` | no | yes | yes | no | retain-application-deployable | no | no | `fb582cbf0e1ab339…` |
 | `packages/adapters/outbox` | `@platos/adapter-outbox` | no | yes | yes | no | retain-application-deployable | no | no | `f20a132de5e8ea60…` |
-| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `d1b42dc5c416d6b4…` |
-| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `41cfeb1544438e1d…` |
+| `packages/adapters/postgres-tenancy` | `@platos/adapter-postgres-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `9d005f363f887bfd…` |
+| `packages/adapters/redis-cache` | `@platos/adapter-redis-cache` | no | yes | yes | no | retain-application-deployable | no | no | `130ade2b2259ab28…` |
 | `packages/adapters/redis-ratelimit` | `@platos/adapter-redis-ratelimit` | no | yes | yes | no | retain-application-deployable | no | no | `bb78096d45becd05…` |
 | `packages/adapters/redis-streams` | `@platos/adapter-redis-streams` | no | yes | yes | no | retain-application-deployable | no | no | `26a3c07d7a0ee3e3…` |
 | `packages/adapters/tokenmint-totp` | `@platos/adapter-tokenmint-totp` | no | yes | yes | no | retain-application-deployable | no | no | `7fb60a58dfb631b8…` |
-| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `523d5e1ae14d4bb3…` |
-| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `0bb42dcc810ca423…` |
-| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `049150a8c4bd5147…` |
-| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `3305e2710eff4e87…` |
-| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `2d52d800c43ce7d7…` |
-| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `14480179fc3cfff3…` |
-| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `56bebaf112bec336…` |
-| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `90ba0699da23f6a5…` |
-| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `04b8c06f76a76aa4…` |
-| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `8e6d5ed3dd6d4093…` |
-| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `be0eb82f5a0097c4…` |
-| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `daa04312bf7fa2bc…` |
-| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `4dec15dc3529544c…` |
-| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `066087de35b51a6c…` |
-| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `3d5858811c3f053a…` |
-| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `64096cb2bb5359ab…` |
-| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `5034719ef4d8cc94…` |
-| `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `c7530a26bb5af29c…` |
+| `packages/contexts/agents` | `@platos/context-agents` | no | yes | yes | no | retain-application-deployable | no | no | `fcc7ab274370a50a…` |
+| `packages/contexts/channels` | `@platos/context-channels` | no | yes | yes | no | retain-application-deployable | no | no | `96cf4cc0a46efdaa…` |
+| `packages/contexts/conversations` | `@platos/context-conversations` | no | yes | yes | no | retain-application-deployable | no | no | `d1ef1c342e792bd6…` |
+| `packages/contexts/cost-monitoring` | `@platos/context-cost-monitoring` | no | yes | yes | no | retain-application-deployable | no | no | `6df445267624012f…` |
+| `packages/contexts/eventing` | `@platos/context-eventing` | no | yes | yes | no | retain-application-deployable | no | no | `ad6fbf5e9a40d86d…` |
+| `packages/contexts/files` | `@platos/context-files` | no | yes | yes | no | retain-application-deployable | no | no | `9657068712e1b56d…` |
+| `packages/contexts/governance` | `@platos/context-governance` | no | yes | yes | no | retain-application-deployable | no | no | `17ad454527ffdb3e…` |
+| `packages/contexts/identity-access` | `@platos/context-identity-access` | no | yes | yes | no | retain-application-deployable | no | no | `caa61f1be990b061…` |
+| `packages/contexts/jobs` | `@platos/context-jobs` | no | yes | yes | no | retain-application-deployable | no | no | `bf05fcba4969e76c…` |
+| `packages/contexts/memory` | `@platos/context-memory` | no | yes | yes | no | retain-application-deployable | no | no | `74d7cb157f7a5ee9…` |
+| `packages/contexts/observability` | `@platos/context-observability` | no | yes | yes | no | retain-application-deployable | no | no | `0da65b6f10ba2dd1…` |
+| `packages/contexts/privacy` | `@platos/context-privacy` | no | yes | yes | no | retain-application-deployable | no | no | `85d24065fc894687…` |
+| `packages/contexts/providers` | `@platos/context-providers` | no | yes | yes | no | retain-application-deployable | no | no | `a300db6c7fa2c9a6…` |
+| `packages/contexts/secrets` | `@platos/context-secrets` | no | yes | yes | no | retain-application-deployable | no | no | `ba5ad14ff93b253c…` |
+| `packages/contexts/skills` | `@platos/context-skills` | no | yes | yes | no | retain-application-deployable | no | no | `b15c5f629eb3f67b…` |
+| `packages/contexts/tenancy` | `@platos/context-tenancy` | no | yes | yes | no | retain-application-deployable | no | no | `5fc4e1d012bf8e57…` |
+| `packages/contexts/tools` | `@platos/context-tools` | no | yes | yes | no | retain-application-deployable | no | no | `7ff41380bbb34e42…` |
+| `packages/core` | `@platos/core` | no | no | no | yes | owner-review-public-boundary | yes | yes | `be91b34605aa3b0c…` |
 | `packages/kernel` | `@platos/kernel` | no | yes | yes | no | retain-application-deployable | no | no | `6f2b26de9c4c05e1…` |
 | `packages/platools-js` | `@platosdev/platools-sdk` | no | no | no | no | owner-review-public-boundary | yes | yes | `15e7a149a5ce15ca…` |
 | `packages/platos-client` | `@platosdev/client` | no | no | no | no | owner-review-public-boundary | yes | yes | `3c3aaec9b962238c…` |

--- a/docs/audits/win-253-workspace-reachability.md
+++ b/docs/audits/win-253-workspace-reachability.md
@@ -2,7 +2,7 @@
 
 > Non-destructive evidence only. This report does not authorize deletion, quarantine, merge, or publication.
 
-Evidence SHA-256: `66e8b88146c6921a4a999cd19e8145a3c9026171199b67faa62ba00fd6bbb838`
+Evidence SHA-256: `658c694c1be2977d9e6e9aae51da02d0a9458a06287435e31459b9998e878edb`
 
 ## Baseline
 
@@ -51,9 +51,9 @@ The OCI closure is derived from CI-declared shipping Dockerfiles. The applicatio
 | `internal-packages/docs` | `@internal/docs` | yes | yes | yes | yes | retain-oci-image | no | no | `e44c8a0d0d6008a8…` |
 | `internal-packages/emails` | `emails` | no | no | no | no | owner-review-repository-referenced | no | yes | `26084070c458a754…` |
 | `internal-packages/llm-model-catalog` | `@internal/llm-model-catalog` | no | no | no | no | owner-review-repository-referenced | no | yes | `01ef30f9cd4ea0f7…` |
-| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `6238c28a78adc55e…` |
+| `internal-packages/otlp-importer` | `@platos/otlp-importer` | no | no | no | no | owner-review-repository-referenced | no | yes | `f40635cb18b3cfcb…` |
 | `internal-packages/redis` | `@internal/redis` | no | no | no | no | owner-review-repository-referenced | no | yes | `8f0e0a0052870d59…` |
-| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `01d8cb6d6dbe2d65…` |
+| `internal-packages/run-engine` | `@internal/run-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `dbfbdf134fdfa888…` |
 | `internal-packages/schedule-engine` | `@internal/schedule-engine` | no | no | no | no | owner-review-repository-referenced | no | yes | `c6e22fe59eb7f562…` |
 | `internal-packages/tenancy-database` | `@platos/tenancy-database` | yes | yes | yes | yes | retain-oci-image | no | no | `b6fcadccd2a3747f…` |
 | `internal-packages/tenancy-database/migration-image` | `@platos/tenancy-migration-image` | yes | no | yes | yes | retain-oci-image | no | no | `f63a66d17bb21fb6…` |

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea",
+      "sha256": "edd78a9fe2ddc35f36300ead41ca4802293bdcf92c7e8d49be2d586933c982d4",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "c5bf08cbe0ef8e1f91c06b51e6d28e3d76be1dd6760483566d6c9126f89fdcc5",
+      "sha256": "3f8cec230c8c32fecb2c5193c6a8ed0dff3739714501b474f4e5034943d9449e",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "314064c44742acb1ca671ab065860b78b45f835834959e188e3acd8a76460dbe",
+      "sha256": "93499f0c29bec8daa392ea5caa46e656f0cc65b618e10850817c616ba167f63c",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "e54ce7a247c89c9257de931f5bde21653aaff5dd4aa6bf100c6fff5ef2ed73b8",
+      "sha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "c5f1af6a271eedf39ee582b12377b5d146f4ff0cc13b64441b5b9a9bf9d39b5b",
+      "sha256": "c48dc1c793d54d684839eab779e0826afe2d82658c1c397fc57ac383c114aecf",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "fc9380df1e2be2a3d3cbdf628172cc5d8553525fbf923d11b2e242587ec23926",
+      "sha256": "3b6a98d27ed271dec91f6fa8ca985842925a6fc265db6dc8bb140cc6f52fa99a",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db",
+      "sha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "c48dc1c793d54d684839eab779e0826afe2d82658c1c397fc57ac383c114aecf",
+      "sha256": "1807997f1d5327e5aea0151de46cab57022bc50b96859cad9e3282f0d0b5e223",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "3b6a98d27ed271dec91f6fa8ca985842925a6fc265db6dc8bb140cc6f52fa99a",
+      "sha256": "74acf95c5d3038fbe9d0b4870dba42554333c68286c8c450bafb342f996ffce7",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-evidence-lifecycle.json
+++ b/docs/audits/win-254-evidence-lifecycle.json
@@ -1522,14 +1522,14 @@
       "path": "docs/audits/win-253-workspace-reachability.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474",
+      "sha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea",
       "binds": "current-repository-truth"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "1807997f1d5327e5aea0151de46cab57022bc50b96859cad9e3282f0d0b5e223",
+      "sha256": "c5bf08cbe0ef8e1f91c06b51e6d28e3d76be1dd6760483566d6c9126f89fdcc5",
       "binds": "current-repository-truth"
     },
     {
@@ -1571,7 +1571,7 @@
       "path": "docs/audits/win253-removals/vendored-build.json",
       "status": "ACCEPTED",
       "mode": "100644",
-      "sha256": "74acf95c5d3038fbe9d0b4870dba42554333c68286c8c450bafb342f996ffce7",
+      "sha256": "314064c44742acb1ca671ab065860b78b45f835834959e188e3acd8a76460dbe",
       "binds": "current-repository-truth"
     },
     {

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -13,7 +13,7 @@
     {
       "path": ".github/workflows/ci.yml",
       "mode": "100644",
-      "sha256": "cfe9a1ccec1abc0cad103157ccf20861d857506b93158e00f1e5cb89474acc86"
+      "sha256": "3b54aadc70f871f45d0305fb282bd3f78b5c50079d39b4bf7e6d06b0b918273d"
     },
     {
       "path": "LICENSE",
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "e54ce7a247c89c9257de931f5bde21653aaff5dd4aa6bf100c6fff5ef2ed73b8"
+      "sha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "c5f1af6a271eedf39ee582b12377b5d146f4ff0cc13b64441b5b9a9bf9d39b5b"
+      "sha256": "c48dc1c793d54d684839eab779e0826afe2d82658c1c397fc57ac383c114aecf"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "fc9380df1e2be2a3d3cbdf628172cc5d8553525fbf923d11b2e242587ec23926"
+      "sha256": "3b6a98d27ed271dec91f6fa8ca985842925a6fc265db6dc8bb140cc6f52fa99a"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db"
+      "sha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "c48dc1c793d54d684839eab779e0826afe2d82658c1c397fc57ac383c114aecf"
+      "sha256": "1807997f1d5327e5aea0151de46cab57022bc50b96859cad9e3282f0d0b5e223"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "3b6a98d27ed271dec91f6fa8ca985842925a6fc265db6dc8bb140cc6f52fa99a"
+      "sha256": "74acf95c5d3038fbe9d0b4870dba42554333c68286c8c450bafb342f996ffce7"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",
@@ -3493,7 +3493,7 @@
     {
       "path": "docs/v1-ledger-rules.json",
       "mode": "100644",
-      "sha256": "1b90cde040fc4871c1f53b291d78f60b40ea87164d0defb5df41903b0cea7733"
+      "sha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c"
     },
     {
       "path": "docs/v3-openapi.yaml",
@@ -3933,7 +3933,7 @@
     {
       "path": "scripts/v1-ledger.test.mjs",
       "mode": "100644",
-      "sha256": "eba09758e6ac4b3c96fff8901e6c5582658df7dc1da81aec236bbdd47d38a17b"
+      "sha256": "078df8ba8aa0a0ef81aed8bf8567723a9380d8f767c08e09a2b75ed5edd551c1"
     },
     {
       "path": "scripts/verify-advisory-nonvacuity.mjs",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474"
+      "sha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "1807997f1d5327e5aea0151de46cab57022bc50b96859cad9e3282f0d0b5e223"
+      "sha256": "c5bf08cbe0ef8e1f91c06b51e6d28e3d76be1dd6760483566d6c9126f89fdcc5"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "74acf95c5d3038fbe9d0b4870dba42554333c68286c8c450bafb342f996ffce7"
+      "sha256": "314064c44742acb1ca671ab065860b78b45f835834959e188e3acd8a76460dbe"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",
@@ -3493,7 +3493,7 @@
     {
       "path": "docs/v1-ledger-rules.json",
       "mode": "100644",
-      "sha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c"
+      "sha256": "1ee0f218e6f1b6a6b6c56a8f946acc8754fe50e0bcb06297cb96c8184c31a5bc"
     },
     {
       "path": "docs/v3-openapi.yaml",

--- a/docs/audits/win-254-protected-paths.json
+++ b/docs/audits/win-254-protected-paths.json
@@ -1038,12 +1038,12 @@
     {
       "path": "docs/audits/win-253-workspace-reachability.json",
       "mode": "100644",
-      "sha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea"
+      "sha256": "edd78a9fe2ddc35f36300ead41ca4802293bdcf92c7e8d49be2d586933c982d4"
     },
     {
       "path": "docs/audits/win-253-workspace-reachability.md",
       "mode": "100644",
-      "sha256": "c5bf08cbe0ef8e1f91c06b51e6d28e3d76be1dd6760483566d6c9126f89fdcc5"
+      "sha256": "3f8cec230c8c32fecb2c5193c6a8ed0dff3739714501b474f4e5034943d9449e"
     },
     {
       "path": "docs/audits/win-259-secret-response-census.json",
@@ -1073,7 +1073,7 @@
     {
       "path": "docs/audits/win253-removals/vendored-build.json",
       "mode": "100644",
-      "sha256": "314064c44742acb1ca671ab065860b78b45f835834959e188e3acd8a76460dbe"
+      "sha256": "93499f0c29bec8daa392ea5caa46e656f0cc65b618e10850817c616ba167f63c"
     },
     {
       "path": "docs/audits/win253-removals/vendored-build.md",
@@ -3933,7 +3933,7 @@
     {
       "path": "scripts/v1-ledger.test.mjs",
       "mode": "100644",
-      "sha256": "078df8ba8aa0a0ef81aed8bf8567723a9380d8f767c08e09a2b75ed5edd551c1"
+      "sha256": "1e9a353cab305108c54e43a6ed6610230d6914cddbb42fcf86f71187a84cb28e"
     },
     {
       "path": "scripts/verify-advisory-nonvacuity.mjs",

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4730,7 +4730,7 @@
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
     "ledgerRulesSha256": "1b90cde040fc4871c1f53b291d78f60b40ea87164d0defb5df41903b0cea7733",
-    "reachabilitySha256": "e54ce7a247c89c9257de931f5bde21653aaff5dd4aa6bf100c6fff5ef2ed73b8",
+    "reachabilitySha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4730,7 +4730,7 @@
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
     "ledgerRulesSha256": "1ee0f218e6f1b6a6b6c56a8f946acc8754fe50e0bcb06297cb96c8184c31a5bc",
-    "reachabilitySha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea",
+    "reachabilitySha256": "edd78a9fe2ddc35f36300ead41ca4802293bdcf92c7e8d49be2d586933c982d4",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4729,8 +4729,8 @@
   "integration": {
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
-    "ledgerRulesSha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c",
-    "reachabilitySha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474",
+    "ledgerRulesSha256": "1ee0f218e6f1b6a6b6c56a8f946acc8754fe50e0bcb06297cb96c8184c31a5bc",
+    "reachabilitySha256": "5b15478159e82bb22edb10ff55a60df249076742a7184c0cc09db5c0f1a5b8ea",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/audits/win253-removals/vendored-build.json
+++ b/docs/audits/win253-removals/vendored-build.json
@@ -4729,8 +4729,8 @@
   "integration": {
     "lockfileSha256": "7bc02ffe59f77cd1b599433d2e0d79e5a80323b3d3c045fc2d4ae83b25c49055",
     "vocabularySha256": "499835566bd3f788ddefc56d4c663612c87bd8ab8e59c1fd20b5d17e1cefbefb",
-    "ledgerRulesSha256": "1b90cde040fc4871c1f53b291d78f60b40ea87164d0defb5df41903b0cea7733",
-    "reachabilitySha256": "64e7bec5c90c8989fa950689d616460d6986628b5afcbc2727d4fbf88bd884db",
+    "ledgerRulesSha256": "a4941902f80d7a4c54af8191bffa17d7f5942a7f48794d988416db5132b7333c",
+    "reachabilitySha256": "81a854ea00fbb2e39be6710c0fd87620c51e35c98ab27ebdc6ed83bc3b77c474",
     "staleVocabularyRows": 0,
     "obsoleteLedgerPins": 0,
     "staleReachabilityWorkspaces": 0

--- a/docs/v1-ledger-rules.json
+++ b/docs/v1-ledger-rules.json
@@ -2108,7 +2108,7 @@
     ]
   },
   "expected": {
-    "totalFiles": 5155,
+    "totalFiles": 5156,
     "areaCounts": {
       "apps-agent": 525,
       "apps-core-api": 86,
@@ -2117,7 +2117,7 @@
       "docs-content": 739,
       "internal-packages": 1174,
       "packages": 2140,
-      "root-infra": 300
+      "root-infra": 301
     },
     "kindCounts": {
       "asset": 155,
@@ -2128,12 +2128,12 @@
       "legal": 14,
       "lockfile": 3,
       "migration": 896,
-      "source": 2074,
+      "source": 2075,
       "test": 1040
     },
     "dispositionCounts": {
       "archive": 7,
-      "move-refactor": 1646,
+      "move-refactor": 1647,
       "regenerate": 39,
       "retain": 3461,
       "unresolved": 2
@@ -2275,9 +2275,9 @@
       "root-infra.test.harness": 69,
       "root-infra.test.script-suites": 34,
       "root-infra.test.workspace-reachability": 1,
-      "root-infra.tooling.scripts": 95,
+      "root-infra.tooling.scripts": 96,
       "root-infra.tooling.workspace-reachability": 1
     },
-    "classificationSha256": "bdc555c311222aeb927dea7fc1dedfaa9439062ac9fc326f12fb61ed43bbbd7e"
+    "classificationSha256": "26dd50a05c0b20f45ddd4c8a675275017cac62ccd40408a3ca71e4485eda2dcf"
   }
 }

--- a/docs/v1-ledger-rules.json
+++ b/docs/v1-ledger-rules.json
@@ -2108,9 +2108,9 @@
     ]
   },
   "expected": {
-    "totalFiles": 5148,
+    "totalFiles": 5155,
     "areaCounts": {
-      "apps-agent": 518,
+      "apps-agent": 525,
       "apps-core-api": 86,
       "apps-mcp-stdio": 8,
       "apps-webapp": 183,
@@ -2128,12 +2128,12 @@
       "legal": 14,
       "lockfile": 3,
       "migration": 896,
-      "source": 2069,
-      "test": 1038
+      "source": 2074,
+      "test": 1040
     },
     "dispositionCounts": {
       "archive": 7,
-      "move-refactor": 1639,
+      "move-refactor": 1646,
       "regenerate": 39,
       "retain": 3461,
       "unresolved": 2
@@ -2147,8 +2147,8 @@
       "apps-agent.entry.process": 1,
       "apps-agent.generated.contract-artifacts": 2,
       "apps-agent.infra.container": 1,
-      "apps-agent.source.runtime": 277,
-      "apps-agent.test.suites": 206,
+      "apps-agent.source.runtime": 282,
+      "apps-agent.test.suites": 208,
       "apps-agent.tooling.scripts": 13,
       "apps-core-api.config.package": 6,
       "apps-core-api.doc.package": 1,
@@ -2278,6 +2278,6 @@
       "root-infra.tooling.scripts": 95,
       "root-infra.tooling.workspace-reachability": 1
     },
-    "classificationSha256": "b1c85e10e47d20034282900cded0e752bd5c370e7d8053326de5abee21e3a2cb"
+    "classificationSha256": "bdc555c311222aeb927dea7fc1dedfaa9439062ac9fc326f12fb61ed43bbbd7e"
   }
 }

--- a/scripts/arch/arch-boundaries.mjs
+++ b/scripts/arch/arch-boundaries.mjs
@@ -45,6 +45,30 @@ const DEFAULT_SCAN_ROOTS = [
   "apps/mcp-stdio",
 ];
 
+// ---------------------------------------------------------------------------
+// THE STRANGLER RATCHET PASS (WIN-268 P2)
+//
+// `apps/agent` is deliberately outside `DEFAULT_SCAN_ROOTS`, and it has to stay
+// outside: nearly every file in it imports the ORM, so a full rule-set scan of
+// that tree fails on hundreds of files and the whole audit becomes something a
+// reader learns to ignore.
+//
+// But a rule that names files in an unscanned root is a rule that never runs.
+// WIN-258 T6 wrote exactly such a rule and enforced it ONLY from
+// `arch-boundaries.test.mjs` — which is the shape this repository has already
+// been burned by once: `apps/agent/src/clean-prisma-delegates.test.ts` sat RED
+// for 1,064 commits because no CI job executed it, and 64 net call sites
+// accumulated unobserved behind a gate everybody believed was on.
+//
+// So the ratchet gets its own PASS in the audit binary rather than only a test:
+// a second scan over `apps/agent`, from which only the ratchet rules' violations
+// are kept. Every other rule's opinion about that tree is discarded — this pass
+// makes no claim about the strangler's other 800-odd ORM call sites, and
+// `arch-boundaries.test.mjs` proves that narrowing does not make the pass
+// vacuous by driving the rule to RED on a fixture.
+const RATCHET_SCAN_ROOTS = ["apps/agent"];
+const RATCHET_RULE_IDS = new Set(["mcp-platform-service-no-prisma"]);
+
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const SKIP_DIRECTORIES = new Set([
   "node_modules",
@@ -363,12 +387,29 @@ function parseArgs(argv) {
   return opts;
 }
 
+/**
+ * The ratchet pass: scan the strangler root, keep only the ratchet rules.
+ *
+ * Returns `null` when the caller asked for explicit `--scan-root`s, because
+ * then the operator is driving the scan and a second pass they did not ask for
+ * would be a surprise. The default invocation — which is what `package.json`'s
+ * `audit:arch-boundaries` runs, and therefore what CI runs — always gets it.
+ */
+export function ratchetPass(root) {
+  const result = check(root, { scanRoots: RATCHET_SCAN_ROOTS });
+  return {
+    fileCount: result.fileCount,
+    violations: result.violations.filter((violation) => RATCHET_RULE_IDS.has(violation.rule)),
+  };
+}
+
 function main() {
   const opts = parseArgs(process.argv.slice(2));
   const result = check(opts.root, { scanRoots: opts.scanRoots });
+  const ratchet = opts.scanRoots === undefined ? ratchetPass(opts.root) : null;
 
   if (opts.json) {
-    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify({ ...result, ratchet }, null, 2)}\n`);
   } else {
     const shownRoot = relative(process.cwd(), result.root) || ".";
     process.stdout.write(
@@ -389,7 +430,30 @@ function main() {
     }
   }
 
-  process.exitCode = result.violations.length > 0 || result.fileCount === 0 ? 1 : 0;
+  if (ratchet) {
+    if (ratchet.fileCount === 0) {
+      process.stdout.write(
+        `FAIL: the strangler ratchet pass scanned 0 file(s) under ${RATCHET_SCAN_ROOTS.join(", ")}; ` +
+          "the root moved or the selector drifted, and the rule is unenforced.\n"
+      );
+    } else if (ratchet.violations.length === 0) {
+      process.stdout.write(
+        `ok: strangler ratchet — ${ratchet.fileCount} file(s) under ${RATCHET_SCAN_ROOTS.join(", ")} ` +
+          `judged against ${[...RATCHET_RULE_IDS].join(", ")}.\n`
+      );
+    } else {
+      for (const v of ratchet.violations) {
+        process.stdout.write(`FAIL [${v.rule}] ${v.from} -> ${v.specifier}\n    ${v.comment}\n`);
+      }
+      process.stdout.write(`\n${ratchet.violations.length} strangler ratchet violation(s).\n`);
+    }
+  }
+
+  const failed =
+    result.violations.length > 0
+    || result.fileCount === 0
+    || (ratchet !== null && (ratchet.violations.length > 0 || ratchet.fileCount === 0));
+  process.exitCode = failed ? 1 : 0;
 }
 
 if (resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url)) {

--- a/scripts/arch/arch-boundaries.test.mjs
+++ b/scripts/arch/arch-boundaries.test.mjs
@@ -28,8 +28,8 @@ import { after, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
 import assert from "node:assert/strict";
 
-import { check } from "./arch-boundaries.mjs";
-import { ALL_RULES } from "./boundary-rules.mjs";
+import { check, ratchetPass } from "./arch-boundaries.mjs";
+import { ALL_RULES, DEPRISMA_MCP_PLATFORM_SERVICES } from "./boundary-rules.mjs";
 
 const tempRoots = [];
 after(() => {
@@ -1474,5 +1474,111 @@ describe("(h) tenancy-prisma-only reaches the workspace path a resolver actually
       importers.sort(),
       "the checker and the tree disagree about which webapp files import the canonical client",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WIN-268 (M4.2) P2 — THE STRANGLER RATCHET.
+//
+// `apps/agent` is not in `DEFAULT_SCAN_ROOTS` and must not be: nearly every file
+// in that tree imports the ORM, so a full rule-set scan of it fails on hundreds
+// of files. A rule naming files in an unscanned root, however, is a rule that
+// never runs — so `arch-boundaries.mjs` gives the ratchet its own PASS, and
+// these cases are what stop that pass being a decoration.
+//
+// FOUR CLAIMS, AND EACH IS JOINED TO SOMETHING THIS FILE DOES NOT WRITE:
+//   1. the rule FIRES on each of the two doors, on a fixture;
+//   2. it does NOT fire on the store seam that is supposed to replace them;
+//   3. it does NOT fire on an UNCONVERTED sibling — the ratchet is honest about
+//      its own coverage, and a careless widening of `from` to
+//      `^apps/agent/src/mcp-platform/` would turn this red;
+//   4. every path in the list EXISTS in the real tree, and the real tree is
+//      clean against the rule. Without (4) a rename silently disarms the gate
+//      and every suite stays green.
+// ---------------------------------------------------------------------------
+
+describe("WIN-268 P2 — the mcp-platform strangler ratchet", () => {
+  it("fires on BOTH doors to the ORM", () => {
+    const vendorDoor = fixture({
+      "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts":
+        `import { PolicyEffect } from "@platos/tenancy-database";\nexport const e = PolicyEffect;\n`,
+    });
+    assert.ok(
+      has(check(vendorDoor, { scanRoots: ["apps/agent"] }), "mcp-platform-service-no-prisma"),
+      "a converted service importing the workspace ORM wrapper must fire",
+    );
+
+    // The LOCAL door — the one all three converted services actually used. A
+    // rule that named only the vendor package would have missed every one of
+    // them, which is why `to` names two things instead of one.
+    const localDoor = fixture({
+      "apps/agent/src/mcp-platform/permission-gateway.service.ts":
+        `import { PRISMA_TOKEN } from "../shared/database.provider";\nexport const t = PRISMA_TOKEN;\n`,
+    });
+    assert.ok(
+      has(check(localDoor, { scanRoots: ["apps/agent"] }), "mcp-platform-service-no-prisma"),
+      "a converted service importing the DI provider that carries the client must fire",
+    );
+  });
+
+  it("passes the store seam that replaces them, and does not touch an unconverted sibling", () => {
+    const good = fixture({
+      "apps/agent/src/mcp-platform/identity-resolver.service.ts":
+        `import { McpIdentityStore } from "./mcp-identity.store";\nexport const s = McpIdentityStore;\n`,
+    });
+    assert.ok(
+      !has(check(good, { scanRoots: ["apps/agent"] }), "mcp-platform-service-no-prisma"),
+      "a converted service reaching data through its store must pass",
+    );
+
+    // SCOPED, NOT BLANKET. `token.service.ts` is in the same directory, holds
+    // ten ORM statements, and is deliberately NOT on the list. Asserting that
+    // keeps the ratchet honest about what it does and does not yet cover.
+    const unconverted = fixture({
+      "apps/agent/src/mcp-platform/token.service.ts":
+        `import { PRISMA_TOKEN } from "../shared/database.provider";\nexport const t = PRISMA_TOKEN;\n`,
+    });
+    assert.ok(
+      !has(check(unconverted, { scanRoots: ["apps/agent"] }), "mcp-platform-service-no-prisma"),
+      "an unconverted mcp-platform service must not fire this rule",
+    );
+  });
+
+  it("the converted-service list is joined to the real tree, not to itself", () => {
+    const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+    assert.ok(
+      DEPRISMA_MCP_PLATFORM_SERVICES.length > 0,
+      "the converted-service list must not be empty, or the rule is unreachable",
+    );
+    for (const relativePath of DEPRISMA_MCP_PLATFORM_SERVICES) {
+      assert.ok(
+        existsSync(join(repositoryRoot, relativePath)),
+        `${relativePath} is named by mcp-platform-service-no-prisma but does not exist; ` +
+          "a renamed service must move its entry, not lose its gate",
+      );
+    }
+
+    // And every one of them is clean, in the tree AS COMMITTED.
+    const scan = check(repositoryRoot, { scanRoots: ["apps/agent"] });
+    assert.ok(scan.fileCount > 0, "the ratchet pass must not be vacuous");
+    assert.deepEqual(
+      scan.violations
+        .filter((violation) => violation.rule === "mcp-platform-service-no-prisma")
+        .map((violation) => `${violation.from} -> ${violation.specifier}`),
+      [],
+      "a converted mcp-platform service has reached for the ORM again",
+    );
+  });
+
+  it("the audit binary's ratchet pass is the one that runs, and it is not vacuous", () => {
+    // The pass, not the rule. WIN-258 T6 wrote an equivalent rule and enforced
+    // it ONLY from a test file; this repository has already lost 1,064 commits
+    // of coverage to exactly that shape (`clean-prisma-delegates.test.ts`). So
+    // the EXPORTED pass the CLI calls is exercised here, over the real tree.
+    const repositoryRoot = fileURLToPath(new URL("../..", import.meta.url));
+    const pass = ratchetPass(repositoryRoot);
+    assert.ok(pass.fileCount > 0, "the ratchet pass scanned nothing; the root moved or the selector drifted");
+    assert.deepEqual(pass.violations, [], "the ratchet pass reports a violation on the committed tree");
   });
 });

--- a/scripts/arch/arch-boundaries.test.mjs
+++ b/scripts/arch/arch-boundaries.test.mjs
@@ -1581,4 +1581,45 @@ describe("WIN-268 P2 — the mcp-platform strangler ratchet", () => {
     assert.ok(pass.fileCount > 0, "the ratchet pass scanned nothing; the root moved or the selector drifted");
     assert.deepEqual(pass.violations, [], "the ratchet pass reports a violation on the committed tree");
   });
+
+  it("MUTATION: the ratchet pass can REPORT, not merely stay silent", () => {
+    // ADDED BECAUSE THE CASE ABOVE SURVIVED A MUTATION. Replacing
+    // `ratchetPass`'s filter with a literal `violations: []` left every
+    // assertion in this file green: the case above asserts the pass is EMPTY on
+    // a clean tree, and a pass that is empty on every tree satisfies it exactly.
+    // A gate that cannot be shown to fire is a gate that is off, and this
+    // repository has paid for that shape once already.
+    //
+    // So the pass is driven over a FIXTURE that contains a real violation, and
+    // the violation is named. The filter now has to actually pass something
+    // through, and `violations: []` turns this red.
+    const offending = fixture({
+      "apps/agent/src/mcp-platform/permission-gateway.service.ts":
+        `import { PRISMA_TOKEN } from "../shared/database.provider";\nexport const t = PRISMA_TOKEN;\n`,
+    });
+    const pass = ratchetPass(offending);
+    assert.equal(pass.fileCount, 1, "the fixture pass must see exactly the one file it was given");
+    assert.deepEqual(
+      pass.violations.map((violation) => `${violation.rule}:${violation.from}`),
+      ["mcp-platform-service-no-prisma:apps/agent/src/mcp-platform/permission-gateway.service.ts"],
+      "the ratchet pass did not report a violation it was handed",
+    );
+
+    // AND THE FILTER IS A FILTER, not a pass-through. The same fixture carries a
+    // file that violates a DIFFERENT rule — a context importing an adapter —
+    // and the ratchet pass must not report it: this pass makes no claim about
+    // the strangler's other rules, and one that leaked them would fail on
+    // `apps/agent`'s 800-odd remaining ORM call sites the day it ran.
+    const mixed = fixture({
+      "apps/agent/src/mcp-platform/permission-gateway.service.ts":
+        `import { PRISMA_TOKEN } from "../shared/database.provider";\nexport const t = PRISMA_TOKEN;\n`,
+      "packages/contexts/tools/domain/tool.ts":
+        `import { PrismaClient } from "@prisma/client";\nexport const x = new PrismaClient();\n`,
+    });
+    assert.deepEqual(
+      [...new Set(ratchetPass(mixed).violations.map((violation) => violation.rule))],
+      ["mcp-platform-service-no-prisma"],
+      "the ratchet pass leaked a rule it does not own",
+    );
+  });
 });

--- a/scripts/arch/boundary-rules.mjs
+++ b/scripts/arch/boundary-rules.mjs
@@ -166,6 +166,57 @@ const TENANCY_DATABASE_SOURCE =
  */
 const TENANCY_DATABASE_HOME = `^(packages/adapters/postgres-tenancy|${TENANCY_DATABASE_HOME_PATH.replace(/\/$/u, "")})/`;
 
+// ---------------------------------------------------------------------------
+// WIN-268 (M4.2) P2 — THE MCP PLATFORM SERVICES THAT HAVE BEEN TAKEN OFF THE ORM
+//
+// THIS LIST IS A RATCHET, AND IT IS JOINED TO THE FILESYSTEM AND TO THE REAL
+// TREE. `arch-boundaries.test.mjs` asserts that every path here EXISTS and that
+// a scan of the actual `apps/agent` reports no violation against any of them.
+// Both halves matter, and the first is the one this programme keeps learning:
+// without the existence join, renaming a service would silently disarm its rule
+// and every suite would stay green — an assertion comparing two things you
+// control cannot fail.
+//
+// IT NAMES FILES RATHER THAN `^apps/agent/src/mcp-platform/`, because a rule is
+// only worth having if it is true. P2 converted THREE of the six services this
+// directory holds; `mcp-bearer-token.service.ts`, `token.service.ts` and
+// `events.service.ts` still hold the client, and so do
+// `mcp-entity.controller.ts` and every file under `tools/`. A blanket ban would
+// fail on day one and be suppressed, which is worse than no rule. Each entry
+// here can never regress, and the next tranche's job is to ADD to this array —
+// a one-line diff whose gate is already written.
+//
+// THE THREE THAT ARE HERE ARE THE AUTHORIZATION SURFACES. That is not an
+// accident of ordering: they are the files where an ORM statement IS the
+// admission decision, so they are the ones where "reaches data through a seam
+// shaped like the contract" buys something today rather than only at cutover.
+export const DEPRISMA_MCP_PLATFORM_SERVICES = [
+  "apps/agent/src/mcp-platform/permission-gateway.service.ts",
+  "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts",
+  "apps/agent/src/mcp-platform/identity-resolver.service.ts",
+];
+
+/**
+ * BOTH doors to the ORM, not just the vendor package.
+ *
+ * NONE of the three services above imported `@platos/tenancy-database` for its
+ * client: they took it through `apps/agent/src/shared/database.provider`, which
+ * is where `PRISMA_TOKEN` and `ControlDatabaseClient` live, and one of them
+ * (`mcp-tool-acl.service.ts`) imported the workspace package too — for the
+ * `PolicyEffect` enum. A rule that banned only the vendor scope would have been
+ * satisfied by walking through the local provider, which is the door all three
+ * actually used. `TENANCY_DATABASE_SOURCE` above makes the same argument about
+ * the workspace wrapper hiding `@prisma/client`; this is that argument one layer
+ * further in, inside the app.
+ */
+export const AGENT_ORM_DOORS =
+  `^(${TENANCY_DATABASE_SOURCE}|apps/agent/src/shared/database\\.provider)`;
+
+/** Escape a literal path so it can sit inside a rule's `from.path` regex. */
+function escapeForRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+}
+
 // Per-vendor single-adapter containment (ADR M0.3 §5.1 rule (h)). Each SDK lives
 // in exactly one place; any file outside that place importing the SDK fails.
 export const SDK_CONTAINMENT = [
@@ -433,6 +484,18 @@ export const RULES = [
     to: {
       path: "^(node_modules/@prisma/|internal-packages/(database|tenancy-database)/)",
     },
+  },
+
+  // (k2) WIN-268 P2 — a converted MCP platform service may not reach the ORM
+  // again, through EITHER door. See `DEPRISMA_MCP_PLATFORM_SERVICES` above for
+  // why the `from` side is a list of files and not a directory prefix.
+  {
+    id: "mcp-platform-service-no-prisma",
+    severity: "error",
+    comment:
+      "a converted apps/agent/src/mcp-platform service must reach data through its store seam, never through the ORM or the DI provider that carries the client.",
+    from: { path: `^(${DEPRISMA_MCP_PLATFORM_SERVICES.map(escapeForRegex).join("|")})$` },
+    to: { path: AGENT_ORM_DOORS },
   },
 
   // (l) CONTEXT REGISTRY — packages/contexts/<name>/ must be one of the 17

--- a/scripts/ci-policy.test.mjs
+++ b/scripts/ci-policy.test.mjs
@@ -4572,10 +4572,27 @@ function agentTestFiles(relativeDirectory) {
   });
 }
 
+// WIN-268 P2 — THE PREDICATE MOVED WITH THE ANALYZER, AND ONLY THE PREDICATE.
+//
+// The discovery used to look for `Prisma.dmmf` beside `inventoryDigest`, because
+// the census suite read the generated datamodel itself. It does not any more:
+// the type-checker walk is `apps/agent/src/prisma-delegate-census.ts`, so a
+// SECOND gate — `mcp-platform/orm-ownership-census.test.ts` — can split the same
+// call sites by owning context without a second analyzer that could disagree
+// with this one.
+//
+// So the marker is now the IMPORT of that module. The property this function
+// exists for is unchanged and is the one that matters: the path is DISCOVERED
+// from the tree rather than spelled as a constant this file could quietly edit,
+// so renaming or moving the suite without updating the workflow still fails
+// here. The `assert.equal(candidates.length, 1)` below is what keeps the marker
+// honest in the other direction: `orm-ownership-census.test.ts` imports the same
+// module and would be a second candidate if it also pinned an inventory digest,
+// and this would fail rather than silently pick one.
 function delegateCensusSuitePath() {
   const candidates = agentTestFiles(AGENT_SOURCE_ROOT).filter((file) => {
     const contents = readFileSync(path.join(repositoryRoot, file), "utf8");
-    return contents.includes("inventoryDigest") && contents.includes("Prisma.dmmf");
+    return contents.includes("inventoryDigest") && contents.includes("prisma-delegate-census");
   });
   assert.equal(
     candidates.length,

--- a/scripts/mutations-win268-p2.json
+++ b/scripts/mutations-win268-p2.json
@@ -1,0 +1,247 @@
+{
+  "$schema-note": "Not a schema-validated artifact. A committed record of mutations that were APPLIED to the working tree, RUN, and REVERTED, so a reviewer can re-run any row rather than take a green suite as proof.",
+  "issue": "WIN-268",
+  "tranche": "P2 - take the MCP platform authorization surfaces off the ORM",
+  "branch": "tejas/win-268-p2-mcp-platform-deprisma",
+  "base": "3b3f1ebb (v1, M4.1 #153)",
+  "purpose": [
+    "The tranche's central claim is that a FORGED tenant triple is now refused rather than answered.",
+    "A green suite is not evidence of that: the refusal path is new, so every case that exercises it",
+    "was written by the same hand that wrote the code, and a case that cannot be made to fail is a",
+    "case that proves the code compiles. Each row below removes exactly one guard and names the cases",
+    "that went from pass to fail.",
+    "",
+    "TWO ROWS SURVIVED AND BOTH ARE RECORDED WITH THEIR MEASURED REASON. Neither was omitted and",
+    "neither is counted as a kill."
+  ],
+  "procedure": [
+    "PROVE GREEN FIRST. The unmutated tree at d8d8ed75 ran green before and after every entry:",
+    "unit 27/27, integration 12/12, census 4/4, arch-boundaries 28/28 (1 skipped).",
+    "",
+    "EVERY ENTRY BELOW WAS APPLIED, RUN, AND REVERTED by scripts run on the mini against real",
+    "PostgreSQL 16 in a testcontainer. `kills` quotes what the runner actually printed, trimmed.",
+    "`killCount` is the number of CASES that went from pass to fail.",
+    "",
+    "M07 IS THE ROW THIS LEDGER EXISTS FOR. It survived the first pass: replacing the audit binary's",
+    "ratchet filter with a literal `violations: []` left every assertion green, because the standing",
+    "case asserted the pass was EMPTY on a clean tree and a pass that is empty on EVERY tree satisfies",
+    "that exactly. A case was added that drives the pass over a fixture carrying a real violation, and",
+    "over a mixed fixture carrying a violation of a rule the pass does not own. M07 was re-run against",
+    "the repaired suite and now kills 3."
+  ],
+  "commands": {
+    "unit": "pnpm --filter platos-agent exec vitest run src/mcp-platform/mcp-tool-acl.service.test.ts src/mcp-platform/permission-gateway.service.test.ts src/mcp-platform/identity-resolver.service.test.ts",
+    "integration": "pnpm --filter platos-agent exec vitest run src/mcp-platform/mcp-scope.integration.test.ts",
+    "census": "pnpm --filter platos-agent exec vitest run src/mcp-platform/orm-ownership-census.test.ts",
+    "arch-test": "node --test scripts/arch/arch-boundaries.test.mjs"
+  },
+  "build-state": [
+    "mini, macOS, Colima. DOCKER_HOST=unix:///Users/tejassuds/.colima/default/docker.sock and",
+    "TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock. CI=true throughout.",
+    "pnpm install --frozen-lockfile --ignore-scripts, then `pnpm --filter @platos/tenancy-database build`",
+    "and `pnpm --filter @internal/workload-identity build` -- the state ci.yml's agent job reaches",
+    "before its Vitest steps. The census suites are type-checker driven and under-count without that",
+    "build; the integration suite starts its own PostgreSQL 16 container and applies the repository's",
+    "own migrations with `prisma migrate deploy`."
+  ],
+  "mutations": [
+    {
+      "name": "M01 the forged-ancestry clause is deleted from the scope resolver",
+      "guards": "apps/agent/src/mcp-platform/mcp-scope.ts -- the whole tranche. Without this clause a claimed triple whose organization belongs to another tenant is admitted.",
+      "file": "apps/agent/src/mcp-platform/mcp-scope.ts",
+      "from": "if (resolved.projectId !== scope.projectId || resolved.organizationId !== scope.organizationId) return scopeRefused(MCP_SCOPE_FOREIGN);",
+      "to": "(removed)",
+      "command": "integration",
+      "exit": 1,
+      "killCount": 4,
+      "kills": [
+        "x FORGED: alpha's environment under beta's organization is REFUSED, not answered -> expected { ok: true, value: [ { ...(6) } ] } to deeply equal { ok: false, reason: 'out_of_scope' }",
+        "x refuses every WRITE on a forged scope, including the delete that used to answer false -> promise resolved \"[ { ...(6) } ]\" instead of rejecting",
+        "x FORGED: the exposure page is refused, and the refusal is not an empty page -> expected { ok: true, value: { ...(3) } } to deeply equal { ok: false, reason: 'out_of_scope' }",
+        "x FORGED: every scoped write is refused and leaves no row behind -> expected { ok: true, value: { ...(10) } } to deeply equal { ok: false, reason: 'out_of_scope' }"
+      ],
+      "note": "The COHERENT two-tenant cases stayed green under this mutation, which is the point of carrying the forged one: a two-tenant test is not automatically a tenancy test."
+    },
+    {
+      "name": "M02 an absent environment is admitted instead of refused",
+      "guards": "the SECOND refusal reason. `unknown_environment` and `out_of_scope` are distinct so an operator can tell a deleted environment from a forged ancestry without reading a message.",
+      "file": "apps/agent/src/mcp-platform/mcp-scope.ts",
+      "from": "if (resolved === undefined) return scopeRefused(MCP_SCOPE_UNKNOWN);",
+      "to": "if (resolved === undefined) return scopeAllowed({ projectId: scope.projectId, organizationId: scope.organizationId });",
+      "command": "integration",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "x distinguishes a forged ancestry from an environment that does not exist -> expected { ok: true, value: [ { ...(6) } ] } to deeply equal { ok: false, ...(1) }"
+      ]
+    },
+    {
+      "name": "M03 the gateway swallows a tier-2 scope refusal and abstains",
+      "guards": "permission-gateway.service.ts. This mutation RE-CREATES THE PRE-P2 DEFECT EXACTLY: a refusal becomes null, null is 'this tier has no objection', and the caller escapes the deny.",
+      "file": "apps/agent/src/mcp-platform/permission-gateway.service.ts",
+      "from": "if (isScopeRefusal(tier2)) { ...; return { state: \"block\", tier: 2, reason: `scope ${tier2.refused}` }; } const t2 = tier2;",
+      "to": "const t2 = isScopeRefusal(tier2) ? null : tier2;",
+      "command": "unit",
+      "exit": 1,
+      "killCount": 3,
+      "kills": [
+        "x blocks at tier 2 when the claimed scope is out_of_scope, with no agent in play",
+        "x blocks at tier 2 when the claimed scope is unknown_environment, with no agent in play -> expected { state: 'auto_allow', tier: 1, ...(1) } to deeply equal { state: 'block', tier: 2, ...(1) }",
+        "x MUTATION GUARD: the pre-P2 behaviour - abstain on a forged scope - is now RED -> expected 'auto_allow' not to be 'auto_allow'"
+      ],
+      "note": "The third kill is the case written FOR this mutation, and its message is the defect in one line: the pre-P2 tree answered `auto_allow` to a caller standing in a tenant that denies the tool."
+    },
+    {
+      "name": "M05 the LOCAL door is dropped from the ratchet rule",
+      "guards": "AGENT_ORM_DOORS in scripts/arch/boundary-rules.mjs. All three converted services took the client through `apps/agent/src/shared/database.provider`, not through the vendor package, so a rule naming only the vendor scope would have caught none of them.",
+      "file": "scripts/arch/boundary-rules.mjs",
+      "from": "`^(${TENANCY_DATABASE_SOURCE}|apps/agent/src/shared/database\\.provider)`",
+      "to": "`^(${TENANCY_DATABASE_SOURCE})`",
+      "command": "arch-test",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "not ok - fires on BOTH doors to the ORM (AssertionError: a converted service importing the DI provider that carries the client must fire)"
+      ]
+    },
+    {
+      "name": "M06 the converted-service list names a file that does not exist",
+      "guards": "the NON-VACUITY JOIN. A `from` list naming absent files passes every scan forever: rename a service and its rule silently stops applying, with nothing red.",
+      "file": "scripts/arch/boundary-rules.mjs",
+      "from": "\"apps/agent/src/mcp-platform/permission-gateway.service.ts\"",
+      "to": "\"apps/agent/src/mcp-platform/permission-gateway.service.ts.RENAMED\"",
+      "command": "arch-test",
+      "exit": 1,
+      "killCount": 2,
+      "kills": [
+        "not ok - fires on BOTH doors to the ORM",
+        "not ok - the converted-service list is joined to the real tree, not to itself"
+      ]
+    },
+    {
+      "name": "M07 the audit binary's ratchet pass reports nothing",
+      "guards": "ratchetPass in scripts/arch/arch-boundaries.mjs -- the WIRING, not the rule. THE ROW THIS LEDGER EXISTS FOR: it SURVIVED the first pass.",
+      "file": "scripts/arch/arch-boundaries.mjs",
+      "from": "violations: result.violations.filter((violation) => RATCHET_RULE_IDS.has(violation.rule)),",
+      "to": "violations: [],",
+      "command": "arch-test",
+      "exit": 1,
+      "killCount": 3,
+      "kills": [
+        "not ok - MUTATION: the ratchet pass can REPORT, not merely stay silent (the fixture pass reported no violation it was handed)",
+        "not ok - WIN-268 P2 - the mcp-platform strangler ratchet"
+      ],
+      "firstPass": {
+        "exit": 0,
+        "killCount": 0,
+        "reason": "The standing case asserted `deepEqual(pass.violations, [])` on the COMMITTED tree, and a pass that returns [] for every tree satisfies that exactly. An assertion that a gate is currently silent is not an assertion that it can speak.",
+        "repair": "A case was added that drives ratchetPass over a fixture containing a real violation and asserts the exact rule:path it reports, plus a mixed fixture carrying a violation of a rule the pass does NOT own, asserting that one is filtered out. Both halves are needed: the first stops `violations: []`, the second stops `violations: result.violations`."
+      }
+    },
+    {
+      "name": "M08 the tool ACL reports a refusal as an empty page",
+      "guards": "ToolAclScopeRefusedError. `list` answers a page and `bulk` answers a count; both have legitimate empty answers, so a refusal reported through either is a denial and a legitimate 'nothing here' in one value.",
+      "file": "apps/agent/src/mcp-platform/mcp-tool-acl.service.ts",
+      "from": "if (!result.ok) throw new ToolAclScopeRefusedError(result.reason);",
+      "to": "if (!result.ok) return undefined as unknown as Value;",
+      "command": "unit",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "x propagates a scope refusal out of every scoped method, distinguishably -> expected error to be instance of ToolAclScopeRefusedError"
+      ]
+    },
+    {
+      "name": "M09 a converted service reaches for the ORM again",
+      "guards": "the ACCEPTANCE CRITERION, stated literally: `arch-boundaries` refuses a Prisma import from every service converted, and a mutation reintroducing one goes RED.",
+      "file": "apps/agent/src/mcp-platform/permission-gateway.service.ts",
+      "from": "(no ORM import)",
+      "to": "import { PRISMA_TOKEN } from \"../shared/database.provider\";",
+      "command": "arch-test",
+      "exit": 1,
+      "killCount": 2,
+      "kills": [
+        "not ok - the converted-service list is joined to the real tree, not to itself",
+        "not ok - the audit binary's ratchet pass is the one that runs, and it is not vacuous"
+      ],
+      "secondRun": {
+        "command": "census",
+        "exit": 0,
+        "killCount": 0,
+        "reason": "CORRECT, AND IT IS EVIDENCE RATHER THAN A GAP. The census counts delegate CALLS; this mutation adds an IMPORT and no call. `orm-ownership-census.test.ts`'s own header says the zero-call claim is made twice on purpose 'because the boundary rule sees IMPORTS and this sees CALLS'. M09 is the measurement behind that sentence: neither gate subsumes the other, and the import half is caught by the rule that is about imports."
+      }
+    },
+    {
+      "name": "M10 the entity-tool page drops its scope check",
+      "guards": "entity-tool-policy.store.ts. The extraction source keyed every statement on { entityId, environmentId } and never asked whether that environment belongs to the claimed project and organization.",
+      "file": "apps/agent/src/mcp-platform/entity-tool-policy.store.ts",
+      "from": "const resolved = await resolveClaimedScope(this.prisma, scope); if (!resolved.ok) return resolved;",
+      "to": "(removed from pageExposures)",
+      "command": "integration",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "x FORGED: the exposure page is refused, and the refusal is not an empty page -> expected { ok: true, value: { ...(3) } } to deeply equal { ok: false, reason: 'out_of_scope' }"
+      ]
+    },
+    {
+      "name": "M11 the identity resolver drops its entity-ancestry join",
+      "guards": "mcp-identity.store.ts. This guard is NOT new -- the extraction source already had it -- and the case exists to assert a hole is absent rather than to claim one was closed.",
+      "file": "apps/agent/src/mcp-platform/mcp-identity.store.ts",
+      "from": "project: { entities: { some: { id: entityId } } },",
+      "to": "(removed)",
+      "command": "integration",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "x an environment from the OTHER tenant is not resolvable for this entity -> expected 'de079ffa-...' to be null"
+      ]
+    },
+    {
+      "name": "M12 the extracted analyzer stops following transaction aliases",
+      "guards": "prisma-delegate-census.ts. The analyzer moved out of clean-prisma-delegates.test.ts; this asks whether the move kept its teeth.",
+      "file": "apps/agent/src/prisma-delegate-census.ts",
+      "from": "if (ts.isCallExpression(node) && staticMemberName(node.expression) === \"$transaction\") {",
+      "to": "if (false && ...) {",
+      "command": "census",
+      "exit": 1,
+      "killCount": 1,
+      "kills": [
+        "x reports the split, and the split is joined to the app-wide pin -> expected 747 to be 813"
+      ],
+      "note": "66 call sites vanish when the transaction-callback alias resolution is switched off, and the census notices because it reads the app-wide pin out of clean-prisma-delegates.test.ts rather than restating it. That join is what makes a silently weakened analyzer red in the census as well as in the gate it was extracted from."
+    }
+  ],
+  "declared": [
+    {
+      "name": "M04 the store reads the CLAIMED organization instead of the RESOLVED one",
+      "file": "apps/agent/src/mcp-platform/mcp-policy.store.ts",
+      "from": "where: { organizationId: resolved.value.organizationId }",
+      "to": "where: { organizationId: scope.organizationId }",
+      "command": "integration",
+      "exit": 0,
+      "killCount": 0,
+      "reason": [
+        "SURVIVES, AND IT CANNOT BE KILLED BY ANY TEST WRITTEN AGAINST THIS CODE. `resolveClaimedScope`",
+        "has already refused every scope where the claimed organization differs from the resolved one, so",
+        "on every path that reaches this line the two values are equal by construction. Reading the",
+        "resolved one is DEFENCE IN DEPTH, not behaviour: it is there so that a future widening of the",
+        "check cannot silently widen what the read returns.",
+        "",
+        "IT IS RECORDED RATHER THAN DELETED because the alternative -- writing a case that forces the two",
+        "apart -- would mean weakening the resolver to create the difference, which is a test asserting",
+        "that a guard it disabled does nothing.",
+        "",
+        "OBSERVED ONCE AS exit=1 IN A BATCH RE-RUN AND NOT REPRODUCED. Re-run in isolation twice against",
+        "a fresh container: exit=0 both times, no failing case. The integration suite starts a PostgreSQL",
+        "container and applies migrations per run, and that one-off is recorded here rather than dropped."
+      ]
+    }
+  ],
+  "totals": {
+    "applied": 12,
+    "killed": 11,
+    "declared": 1,
+    "survivedFirstPassThenRepaired": 1
+  }
+}

--- a/scripts/v1-ledger.test.mjs
+++ b/scripts/v1-ledger.test.mjs
@@ -1718,7 +1718,13 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // alone recorded; `root-infra.test.script-suites` takes W2's two suites only
     // and moves 32 -> 34 unchanged. W1 is NOT in this branch, so its +1 on this
     // key is not here either -- see the merge commit for the tree fact.
-    "root-infra": 64,
+    //
+    // WIN-268 (M4.2) P2 64 -> 65. ONE file: `scripts/mutations-win268-p2.json`,
+    // this tranche's mutation ledger, beside the seven `mutations-win267-*.json`
+    // that already sit on the `root-infra.doc.audit-artifacts` rule. NO LEDGER
+    // RULE CHANGED, and the file is a record rather than an input: nothing reads
+    // it at run time, which is why it is a doc and not a fixture.
+    "root-infra": 65,
   };
   // M2 INTEGRATION: 1495 + 42 + 27 + 15 = 1579, and 3469 + 1579 = 5048, which
   // is what the ledger fingerprint carried before M4.
@@ -1801,10 +1807,17 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
   // WIN-268 (M4.2) P2 1679 -> 1686. SEVEN files, ALL in `apps-agent`, itemised
   // on that area's delta above — so the two halves of this case are the same
   // arithmetic once more, and the eight-key re-derivation from the merged
-  // `expectedDeltas` is 11 + 0 + 75 + 4 + 10 + 1503 + 19 + 64 = 1686. No other
+  // `expectedDeltas` is 11 + 0 + 75 + 4 + 10 + 1503 + 19 + 65 = 1687. No other
   // key takes a contribution from this tranche, which is what makes an
   // auto-merge with a sibling's delta safe to CHECK rather than assume.
-  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1686);
+  //
+  // EIGHT FILES, NOT SEVEN, and the eighth arrived after the first re-pin: the
+  // mutation ledger `scripts/mutations-win268-p2.json` is itself a tracked file,
+  // and writing it moved every tree-hashing audit a second time. That is the
+  // fixpoint this repository's fourth lesson describes, and it is recorded here
+  // because a reader comparing 1686 in an earlier commit message with 1687 on
+  // disk should find the reason rather than a discrepancy.
+  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1687);
   assert.deepEqual(
     Object.fromEntries(
       Object.entries(summary.areaCounts).map(([area, count]) => [area, count - rulesDocument.baseline.areaCounts[area]])
@@ -1964,10 +1977,11 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // reading the total, so the two arithmetics can disagree and be caught.
     // 1671 + 7 + 1 = 1679.
     //
-    // WIN-268 (M4.2) P2 1679 -> 1686 -- the THIRTEENTH hand move of this second
-    // reconciliation, and the same seven files as the first: five sources and
-    // two suites under `apps/agent/src`, on rules that already existed.
-    rulesDocument.baseline.totalFiles + 1686
+    // WIN-268 (M4.2) P2 1679 -> 1687 -- the THIRTEENTH hand move of this second
+    // reconciliation, and the same eight files as the first: five sources and
+    // two suites under `apps/agent/src`, plus the tranche's mutation ledger in
+    // `scripts/`, all on rules that already existed.
+    rulesDocument.baseline.totalFiles + 1687
   );
 });
 

--- a/scripts/v1-ledger.test.mjs
+++ b/scripts/v1-ledger.test.mjs
@@ -533,7 +533,27 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // judged by. Both land on the existing `apps-agent.tooling.scripts` rule
     // (11 -> 13); `generate-control-plane.mjs` is edited in place and adds no
     // file.
-    "apps-agent": 4,
+    //
+    // WIN-268 (M4.2) P2 4 -> 11. SEVEN files, all in `apps/agent/src`, all on
+    // rules that already existed — `apps-agent.source.runtime` 277 -> 282 and
+    // `apps-agent.test.suites` 206 -> 208. NO LEDGER RULE CHANGED.
+    //
+    // FIVE SOURCE. `prisma-delegate-census.ts` is the type-checker walk lifted
+    // out of `clean-prisma-delegates.test.ts` so a second gate can consume the
+    // same call sites; `mcp-platform/mcp-scope.ts` is the tenant-ancestry
+    // resolver; and `mcp-platform/mcp-policy.store.ts`,
+    // `mcp-platform/entity-tool-policy.store.ts` and
+    // `mcp-platform/mcp-identity.store.ts` are the three ORM seams the converted
+    // services reach data through.
+    //
+    // TWO TEST. `mcp-platform/orm-ownership-census.test.ts` splits the
+    // directory's remaining ORM surface by owning context and ratchets it;
+    // `mcp-platform/mcp-scope.integration.test.ts` is the two-tenant
+    // forged-triple proof against a real PostgreSQL.
+    //
+    // The three converted services are edited IN PLACE and add no file, which is
+    // why this delta is 7 and not 10.
+    "apps-agent": 11,
     "apps-webapp": 0,
     // 0 -> 19. WIN-297 makes apps/core-api a real process: 12 source files
     // (composition/{adapter-bindings,registry}, config/{schema,load},
@@ -1777,7 +1797,14 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
   // the eight-key re-derivation from the merged `expectedDeltas` above is
   // 4 + 0 + 75 + 4 + 10 + 1503 + 19 + 64 = 1679. Side-picking either branch's
   // own total (1678 or 1672) is red here AND at the second reconciliation below.
-  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1679);
+  //
+  // WIN-268 (M4.2) P2 1679 -> 1686. SEVEN files, ALL in `apps-agent`, itemised
+  // on that area's delta above — so the two halves of this case are the same
+  // arithmetic once more, and the eight-key re-derivation from the merged
+  // `expectedDeltas` is 11 + 0 + 75 + 4 + 10 + 1503 + 19 + 64 = 1686. No other
+  // key takes a contribution from this tranche, which is what makes an
+  // auto-merge with a sibling's delta safe to CHECK rather than assume.
+  assert.equal(summary.totalFiles, rulesDocument.baseline.totalFiles + 1686);
   assert.deepEqual(
     Object.fromEntries(
       Object.entries(summary.areaCounts).map(([area, count]) => [area, count - rulesDocument.baseline.areaCounts[area]])
@@ -1936,7 +1963,11 @@ test("area counts reconcile against the baseline plus exact WIN-254 and legal-pr
     // mutation manifest), reached here by summing the per-area counts instead of
     // reading the total, so the two arithmetics can disagree and be caught.
     // 1671 + 7 + 1 = 1679.
-    rulesDocument.baseline.totalFiles + 1679
+    //
+    // WIN-268 (M4.2) P2 1679 -> 1686 -- the THIRTEENTH hand move of this second
+    // reconciliation, and the same seven files as the first: five sources and
+    // two suites under `apps/agent/src`, on rules that already existed.
+    rulesDocument.baseline.totalFiles + 1686
   );
 });
 


### PR DESCRIPTION
Branch from `v1` @ 3b3f1ebb. **Nothing is merged, tagged, published or deployed.**

## What this is

The MCP platform's three **authorization surfaces** — the four-tier permission
gateway, the entity tool ACL and the inbound identity resolver — no longer hold
the ORM. They reach data through seams shaped like the `tools` /
`identity-access` contract calls that will replace them, and `arch-boundaries`
now refuses a Prisma import from all three through **both doors**.

## The defect this closes

`apps/agent/src/auth/scope.guard.ts` assembles `RequestScope` from three
unrelated request headers — `x-platos-organization-id`, `x-platos-project-id`,
`x-platos-environment-id` — and joins them only when `x-platos-agent-id` is also
present. Tier 3 of the gateway re-derived the whole chain; **tier 2 did not**:

```ts
prisma.organizationMcpPolicy.findMany({ where: { organizationId: scope.organizationId } })
```

Point that at an organization with no policy rows and it answers `[]`. `[]` means
"no pattern matched" means "this tier has no objection". So a caller standing in
a tenant that **denies** a tool could escape that denial by naming a second
tenant's organization id — a tier that can only tighten, made to abstain. And
tier 3 only runs when there IS an agent: an MCP client calls with `agentId ===
null`, and then tier 2 was the only tier that touched the database.

`mcp-scope.ts` is the join, in the shape `postgres-tenancy/src/tools-scope.ts`
already uses for the context that owns these rows — one statement, two distinct
refusals (`out_of_scope`, `unknown_environment`).

## Proved against a real database, with the case that separates

`mcp-scope.integration.test.ts` — 12/12 against real PostgreSQL 16, two tenants.
The coherent two-tenant cases pass **with or without** the ancestry check, and the
suite says so; the forged triple is the case that does the work. It runs the
extraction source's own statement against the fixture and shows the empty answer,
then shows the current code refusing.

## The gate runs, rather than existing

WIN-258 T6 wrote an equivalent rule and enforced it only from a test file. This
repository has already lost 1,064 commits of coverage to that shape. So the
ratchet gets its own **pass in the audit binary**, and both new suites are named
CI steps.

## Numbers, measured on both trees with the same analyzer

| | base 3b3f1ebb | this branch |
|---|---|---|
| app-wide ORM call sites | 815 | **813** |
| `mcp-platform/**` | 125 | **123** |
| owner `tools` | 35 | **33** |
| converted services | 24 | **0** |

24 out (8 + 11 + 5), 22 in (7 + 10 + 5). The two that vanished are duplicate
statements the extraction merged, both `tools`-owned — which is why `tools` moves
35 → 33 and the other nine owners do not.

## What this does NOT do

`apps/agent` imports no `@platos/context-*`, no `@platos/adapter-*` and no
`@platos/kernel`, and it cannot: rule (j) gives adapter imports to
`apps/core-api`, `composition-root.mjs` narrows that to one file, and `tools` is
uncomposed for want of `ToolDispatch` — WIN-269's scope. **No call site here was
routed to a published contract, and none could be.** Three services of six;
`mcp-bearer-token`, `token` and `events` still hold the client. The remaining
123 sites are enumerated per file and per owning context by
`orm-ownership-census.test.ts`, ratcheted one-way.

`identity-access` publishes **no** mint for `McpAnonymousSession` and says so
deliberately. That call site was stopped at, not worked around.

## Mutation ledger

`scripts/mutations-win268-p2.json` — 12 applied, 11 killed, 1 declared survivor
with its measured reason. **M07 survived the first pass**: a literal
`violations: []` in the ratchet pass left every assertion green, because the
standing case asserted the pass was empty on a clean tree. Repaired and re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzDWyb7YEERRegYTvNwzRp
